### PR TITLE
backend/DANG-100: PR labeling과 branch 이름 및 PR 제목 validation을 위한 GitHub Actions 추가

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+frontend:
+  - head-branch: ["^frontend", "frontend"]
+
+backend:
+  - head-branch: ["^backend", "backend"]

--- a/.github/workflows/pr_labeler_validator.yaml
+++ b/.github/workflows/pr_labeler_validator.yaml
@@ -1,0 +1,89 @@
+name: Labeler and Validator
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  label_and_validate:
+    runs-on: ubuntu-latest
+    permissions: # for comment bot using default GITHUB_TOKEN
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Add labels to PR
+        id: labeler
+        uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check branch name format
+        if: steps.labeler.outputs.new-labels == ''
+        id: check_branch_name
+        run: |
+          branch_name=$(echo "${{ github.event.pull_request.head.ref }}")
+          if [[ ! $branch_name =~ ^(frontend|backend)\/DANG-[1-9][0-9]*$ ]]; then
+            echo "invalid_branch=true" >> "$GITHUB_OUTPUT"
+            echo "branch_name=$branch_name" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check PR title format
+        id: check_pr_title
+        run: |
+          title_regex="^(frontend|backend)\/DANG-[1-9][0-9]*: .+$"
+          pr_title="${{ github.event.pull_request.title }}"
+          if [[ ! $pr_title =~ $title_regex ]]; then
+            echo "invalid_title=true" >> "$GITHUB_OUTPUT"
+            echo "pr_title=$pr_title" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Add comment for invalid branch name
+        if: steps.check_branch_name.outputs.invalid_branch == 'true'
+        uses: actions/github-script@v7
+        env:
+          BRANCH_NAME: ${{steps.check_branch_name.outputs.branch_name}}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const branchName = process.env.BRANCH_NAME;
+            const message = "## :warning: Branch Naming Convention 위반\n" +
+                            "Branch 이름(\"" + branchName + "\")이 프로젝트의 Branch Naming Convention에 맞지 않습니다.\n" +
+                            "다음과 같은 형식으로 수정해 주세요.\n" +
+                            "```\n" +
+                            "[role]/[Task-ID]\n\n" +
+                            "ex.\n" +
+                            "    frontend/DANG-1\n" +
+                            "    backend/DANG-2\n" +
+                            "```";
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: message
+            });
+
+      - name: Add comment for invalid PR title
+        if: steps.check_pr_title.outputs.invalid_title == 'true'
+        uses: actions/github-script@v7
+        env:
+          PR_TITLE: ${{steps.check_pr_title.outputs.pr_title}}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prTitle = process.env.PR_TITLE;
+            const message = "## :warning: PR Title Convention 위반\n" +
+                            "작성하신 PR 제목(\"" + prTitle + "\")이 프로젝트의 PR Title Convention에 맞지 않습니다.\n" +
+                            "다음과 같은 형식으로 수정해 주세요.\n" +
+                            "```\n" +
+                            "[branch name]: [description]\n\n" +
+                            "ex.\n" +
+                            "    frontend/DANG-1: PR에서 수행한 작업 간략히 설명\n" +
+                            "    backend/DANG-2: PR에서 수행한 작업 간략히 설명\n" +
+                            "```";
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: message
+            });


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
새로운 PR이 열릴 때마다 다음 순서로 labeling 작업과 branch 이름 및 PR 제목 검사를 수행합니다.
- branch명의 prefix(frontend/backend)로 labeling
- labeling 실패 시 branch naming convention을 따르는지 검사
- PR title convention을 따르는지 검사
- branch naming convention을 따르지 않을 경우 convention을 따르도록 수정해달라는 comment 생성
- PR title convention을 따르지 않을 경우 convention을 따르도록 수정해달라는 comment 생성

오류를 해결하기 위해 default GITHUB_TOKEN을 사용하고 permission을 설정해주었습니다.

## 링크 (Links)
https://www.notion.so/do0ori/PR-Labeler-Validator-deaa00f1c076473ba466a894a860dac3

## 기타 사항 (Etc)
제 개인 repo에서 작성한 GitHub Actions가 잘 돌아가는지 미리 테스트를 진행했고 문제 없이 돌아가는 것을 확인했습니다.
![image](https://github.com/jihwooon/dangdang-walk/assets/71831926/8fe8660e-351c-4525-a7aa-4df143d828bd)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
