### PR TITLE
backend/DANG-124: GitHub Actions branch 이름 및 PR 제목 규칙 강제하도록 업데이트

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,8 @@
 frontend:
-  - head-branch: ["^frontend", "frontend"]
+  - head-branch: ["^frontend"]
 
 backend:
-  - head-branch: ["^backend", "backend"]
+  - head-branch: ["^backend"]
 
 infra:
-  - head-branch: ["^infra", "infra"]
+  - head-branch: ["^infra"]

--- a/.github/workflows/pr_labeler_validator.yaml
+++ b/.github/workflows/pr_labeler_validator.yaml
@@ -2,15 +2,14 @@ name: Labeler and Validator
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, edited]
 
 jobs:
   label_and_validate:
-    runs-on: ubuntu-latest
-    permissions: # for comment bot using default GITHUB_TOKEN
+    permissions:
       contents: read
-      issues: write
       pull-requests: write
+    runs-on: ubuntu-latest
     steps:
       - name: Add labels to PR
         id: labeler
@@ -19,30 +18,18 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check branch name format
-        if: steps.labeler.outputs.new-labels == ''
-        id: check_branch_name
         run: |
           branch_name=$(echo "${{ github.event.pull_request.head.ref }}")
           if [[ ! $branch_name =~ ^(frontend|backend|infra)\/DANG-[1-9][0-9]*$ ]]; then
-            echo "invalid_branch=true" >> "$GITHUB_OUTPUT"
-            echo "branch_name=$branch_name" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Check PR title format
-        id: check_pr_title
-        run: |
-          title_regex="^(frontend|backend|infra)\/DANG-[1-9][0-9]*: .+$"
-          pr_title="${{ github.event.pull_request.title }}"
-          if [[ ! $pr_title =~ $title_regex ]]; then
-            echo "invalid_title=true" >> "$GITHUB_OUTPUT"
-            echo "pr_title=$pr_title" >> "$GITHUB_OUTPUT"
+            echo "is_invalid_branch_name=true" >> "$GITHUB_ENV"
+            echo "branch_name=$branch_name" >> "$GITHUB_ENV"
           fi
 
       - name: Add comment for invalid branch name
-        if: steps.check_branch_name.outputs.invalid_branch == 'true'
+        if: env.is_invalid_branch_name == 'true'
         uses: actions/github-script@v7
         env:
-          BRANCH_NAME: ${{steps.check_branch_name.outputs.branch_name}}
+          BRANCH_NAME: ${{ env.branch_name }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -64,11 +51,23 @@ jobs:
               body: message
             });
 
+            core.setFailed("Branch Naming Convention 위반");
+
+      - name: Check PR title format
+        run: |
+          branch_name=$(echo "${{ github.event.pull_request.head.ref }}")
+          title_regex="^${branch_name}: .+$"
+          pr_title="${{ github.event.pull_request.title }}"
+          if [[ ! $pr_title =~ $title_regex ]]; then
+            echo "is_invalid_title=true" >> "$GITHUB_ENV"
+            echo "pr_title=$pr_title" >> "$GITHUB_ENV"
+          fi
+
       - name: Add comment for invalid PR title
-        if: steps.check_pr_title.outputs.invalid_title == 'true'
+        if: env.is_invalid_title == 'true'
         uses: actions/github-script@v7
         env:
-          PR_TITLE: ${{steps.check_pr_title.outputs.pr_title}}
+          PR_TITLE: ${{ env.pr_title }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -89,3 +88,5 @@ jobs:
               issue_number: context.payload.pull_request.number,
               body: message
             });
+
+            core.setFailed("PR Title Convention 위반");


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- **규칙을 따르지 않으면 GitHub Actions가 실패하도록 업데이트**
- trigger 조건 추가
- 불필요한 권한 삭제
- 변수를 GITHUB_OUTPUT이 아닌 GITHUB_ENV에 저장해 사용
- step의 순서를 바꿔 필요한 step만 실행되도록 refactoring

## 링크 (Links)
https://www.notion.so/do0ori/GitHub-Actions-branch-PR-0b6bb5f7f4114100b0e9892f2cbb4c46

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] CI 파이프라인이 통과가 되었나요?
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
