### PR TITLE
feat: edit trigger 제거

### DIFF
--- a/.github/workflows/pr_labeler_validator.yaml
+++ b/.github/workflows/pr_labeler_validator.yaml
@@ -2,7 +2,7 @@ name: Labeler and Validator
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened]
 
 jobs:
   label_and_validate:


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
PR 본문의 check box를 누르는 것도 다 edit event를 trigger 시키는 관계로 그냥 edit trigger를 제거하고 실패 시 manual하게 다시 돌리는 것으로 변경

## 링크 (Links)
https://www.notion.so/do0ori/GitHub-Actions-pr_labeler_validator-edit-trigger-e252d47af50748ffa1b7330aa25814f3

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] CI 파이프라인이 통과가 되었나요?
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
