### PR TITLE
infra/DANG-143: edit trigger 시 title 수정 때에만 job이 실행되도록  조건 추가

### DIFF
--- a/.github/workflows/pr_labeler_validator.yaml
+++ b/.github/workflows/pr_labeler_validator.yaml
@@ -10,6 +10,7 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    if: github.event.action == 'opened' || github.event.changes.title.from
     steps:
       - name: Add labels to PR
         id: labeler


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
기존에는 모든 edit event 발생 시 job이 실행되기 때문에 PR body만 수정된 경우에도 job이 실행되어 comment가 여러 번 생성되는 상황이 발생했었다.
이를 방지하기 위해 edit event가 trigger되더라도 PR title이 수정되었을 때에만 job이 실행되도록 조건을 추가했다.

## 링크 (Links)
https://www.notion.so/do0ori/GitHub-Actions-pr_labeler_validator-edit-trigger-e252d47af50748ffa1b7330aa25814f3

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
