### PR TITLE
backend/DANG-142: 로그인까지 구현 (DB X)

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,7 @@ import { APP_INTERCEPTOR } from '@nestjs/core';
 import { PrometheusInterceptor } from './common/interceptor/prometheus.interceptor';
 import { PrometheusModule } from '@willsoto/nestjs-prometheus';
 import { WinstonLoggerModule } from './common/logger/winstonLogger.module';
+import { AuthModule } from './auth/auth.module';
 
 @Module({
     imports: [
@@ -49,6 +50,7 @@ import { WinstonLoggerModule } from './common/logger/winstonLogger.module';
         }),
         UsersModule,
         ConfigModule,
+        AuthModule,
     ],
     controllers: [AppController, HealthController],
     providers: [

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,0 +1,6 @@
+import { Response } from 'express';
+
+export interface OAuthController {
+    authorize(response: Response): void;
+    callback(code: string, response: Response, error: string, error_description?: string): Promise<void>;
+}

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,6 +1,43 @@
+import { ConfigService } from '@nestjs/config';
 import { Response } from 'express';
+import { OAuthService, TOKEN_LIFETIME_MAP } from './auth.service';
+import { BadRequestException, Get, Query, Res } from '@nestjs/common';
 
-export interface OAuthController {
-    authorize(response: Response): void;
-    callback(code: string, response: Response, error: string, error_description?: string): Promise<void>;
+export abstract class OAuthController {
+    constructor(
+        protected readonly configService: ConfigService,
+        private oauthService: OAuthService
+    ) {}
+
+    protected abstract AUTHORIZE_CODE_REQUEST_URL: string;
+    private readonly CLIENT_REDIRECT_URL = this.configService.get<string>('CORS_ORIGIN', 'http://localhost:3000');
+
+    @Get()
+    async authorize(@Res({ passthrough: true }) response: Response) {
+        response.redirect(this.AUTHORIZE_CODE_REQUEST_URL);
+    }
+
+    @Get('callback')
+    async callback(
+        @Query('code') autherizeCode: string,
+        @Res({ passthrough: true }) response: Response,
+        @Query('error') error: string,
+        @Query('error_description') errorDescription: string
+    ) {
+        if (error) throw new BadRequestException(errorDescription ?? error);
+
+        const { accessToken, refreshToken } = await this.oauthService.login(autherizeCode);
+
+        response.cookie('accessToken', accessToken, {
+            httpOnly: true,
+            secure: Boolean(this.configService.get<string>('NODE_ENV', 'test') === 'production'),
+            maxAge: TOKEN_LIFETIME_MAP.access.maxAge,
+        });
+        response.cookie('refreshToken', refreshToken, {
+            httpOnly: true,
+            secure: Boolean(this.configService.get<string>('NODE_ENV', 'test') === 'production'),
+            maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
+        });
+        response.redirect(this.CLIENT_REDIRECT_URL);
+    }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -8,6 +8,8 @@ import { UsersModule } from 'src/users/users.module';
 import { HttpModule } from '@nestjs/axios';
 import { KakaoController } from './kakao/kakao.controller';
 import { KakaoService } from './kakao/kakao.service';
+import { NaverService } from './naver/naver.service';
+import { NaverController } from './naver/naver.controller';
 
 @Module({
     imports: [
@@ -24,7 +26,7 @@ import { KakaoService } from './kakao/kakao.service';
             inject: [ConfigService],
         }),
     ],
-    controllers: [KakaoController],
-    providers: [AuthService, KakaoService],
+    controllers: [KakaoController, NaverController],
+    providers: [AuthService, KakaoService, NaverService],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -10,6 +10,8 @@ import { KakaoController } from './kakao/kakao.controller';
 import { KakaoService } from './kakao/kakao.service';
 import { NaverService } from './naver/naver.service';
 import { NaverController } from './naver/naver.controller';
+import { GoogleController } from './google/google.controller';
+import { GoogleService } from './google/google.service';
 
 @Module({
     imports: [
@@ -26,7 +28,7 @@ import { NaverController } from './naver/naver.controller';
             inject: [ConfigService],
         }),
     ],
-    controllers: [KakaoController, NaverController],
-    providers: [AuthService, KakaoService, NaverService],
+    controllers: [KakaoController, NaverController, GoogleController],
+    providers: [AuthService, KakaoService, NaverService, GoogleService],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,28 @@
+// auth.module.ts
+
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { AuthService } from './auth.service';
+import { UsersModule } from 'src/users/users.module';
+import { HttpModule } from '@nestjs/axios';
+
+@Module({
+    imports: [
+        UsersModule,
+        HttpModule.register({
+            timeout: 5000,
+            maxRedirects: 5,
+        }),
+        JwtModule.registerAsync({
+            imports: [ConfigModule],
+            useFactory: async (config: ConfigService) => ({
+                secret: config.get('JWT_SECRET'),
+            }),
+            inject: [ConfigService],
+        }),
+    ],
+    controllers: [],
+    providers: [AuthService],
+})
+export class AuthModule {}

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -6,6 +6,8 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { AuthService } from './auth.service';
 import { UsersModule } from 'src/users/users.module';
 import { HttpModule } from '@nestjs/axios';
+import { KakaoController } from './kakao/kakao.controller';
+import { KakaoService } from './kakao/kakao.service';
 
 @Module({
     imports: [
@@ -22,7 +24,7 @@ import { HttpModule } from '@nestjs/axios';
             inject: [ConfigService],
         }),
     ],
-    controllers: [],
-    providers: [AuthService],
+    controllers: [KakaoController],
+    providers: [AuthService, KakaoService],
 })
 export class AuthModule {}

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -9,7 +9,15 @@ interface JwtPayload {
 type Provider = 'kakao' | 'naver' | 'google';
 type TokenType = 'access' | 'refresh';
 type TokenExpiryMap = {
-    [key in TokenType]: string;
+    [key in TokenType]: {
+        expiresIn: string;
+        maxAge: number;
+    };
+};
+
+export const TOKEN_LIFETIME_MAP: TokenExpiryMap = {
+    access: { expiresIn: '12h', maxAge: 12 * 60 * 60 * 1000 },
+    refresh: { expiresIn: '14d', maxAge: 14 * 24 * 60 * 60 * 1000 },
 };
 
 @Injectable()
@@ -19,18 +27,13 @@ export class AuthService {
     private readonly logger = new Logger(AuthService.name);
 
     signToken(userId: number, tokenType: TokenType, provider: Provider) {
-        const tokenExpiryMap: TokenExpiryMap = {
-            access: '12h',
-            refresh: '14d',
-        };
-
         const payload: JwtPayload = {
             userId,
             provider,
         };
 
         const newToken = this.jwtService.sign(payload, {
-            expiresIn: tokenExpiryMap[tokenType],
+            expiresIn: TOKEN_LIFETIME_MAP[tokenType].expiresIn,
         });
 
         return newToken;
@@ -46,5 +49,5 @@ export class AuthService {
 export interface OAuthService {
     requestToken(autherizeCode: string): Promise<any>;
     requestUserInfo(accessToken: string): Promise<any>;
-    login(autherizeCode: string): Promise<{ accessToken: string }>;
+    login(autherizeCode: string): Promise<{ accessToken: string; refreshToken: string }>;
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -48,6 +48,6 @@ export class AuthService {
 
 export interface OAuthService {
     requestToken(autherizeCode: string): Promise<any>;
-    requestUserInfo(accessToken: string): Promise<any>;
+    requestUserId(accessToken: string): Promise<any>;
     login(autherizeCode: string): Promise<{ accessToken: string; refreshToken: string }>;
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+
+interface JwtPayload {
+    userId: number;
+    provider: Provider;
+}
+
+type Provider = 'kakao' | 'naver' | 'google';
+type TokenType = 'access' | 'refresh';
+type TokenExpiryMap = {
+    [key in TokenType]: string;
+};
+
+@Injectable()
+export class AuthService {
+    constructor(private jwtService: JwtService) {}
+
+    private readonly logger = new Logger(AuthService.name);
+
+    signToken(userId: number, tokenType: TokenType, provider: Provider) {
+        const tokenExpiryMap: TokenExpiryMap = {
+            access: '12h',
+            refresh: '14d',
+        };
+
+        const payload: JwtPayload = {
+            userId,
+            provider,
+        };
+
+        const newToken = this.jwtService.sign(payload, {
+            expiresIn: tokenExpiryMap[tokenType],
+        });
+
+        return newToken;
+    }
+
+    decodeToken(token: string) {
+        const data = this.jwtService.verify<JwtPayload>(token);
+
+        return data;
+    }
+}
+
+export interface OAuthService {
+    requestToken(autherizeCode: string): Promise<any>;
+    requestUserInfo(accessToken: string): Promise<any>;
+    login(autherizeCode: string): Promise<{ accessToken: string }>;
+}

--- a/backend/src/auth/google/google.controller.ts
+++ b/backend/src/auth/google/google.controller.ts
@@ -1,47 +1,13 @@
-import { BadRequestException, Controller, Get, Logger, Query, Res } from '@nestjs/common';
-import { Response } from 'express';
+import { Controller } from '@nestjs/common';
 import { OAuthController } from '../auth.controller';
 import { ConfigService } from '@nestjs/config';
 import { GoogleService } from './google.service';
-import { TOKEN_LIFETIME_MAP } from '../auth.service';
 
 @Controller('auth/google')
-export class GoogleController implements OAuthController {
-    constructor(
-        private readonly configService: ConfigService,
-        private readonly googleService: GoogleService
-    ) {}
-
-    private readonly logger = new Logger(GoogleController.name);
-    private readonly AUTHORIZE_CODE_REQUEST_URL = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${this.configService.get<string>('GOOGLE_CLIENT_ID')}&redirect_uri=${this.configService.get<string>('GOOGLE_REDIRECT_URI')}&response_type=code&scope=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile`;
-    private readonly CLIENT_REDIRECT_URL = this.configService.get<string>('CORS_ORIGIN', 'http://localhost:3000');
-
-    @Get()
-    async authorize(@Res({ passthrough: true }) response: Response) {
-        response.redirect(this.AUTHORIZE_CODE_REQUEST_URL);
+export class GoogleController extends OAuthController {
+    constructor(configService: ConfigService, googleService: GoogleService) {
+        super(configService, googleService);
     }
 
-    @Get('callback')
-    async callback(
-        @Query('code') autherizeCode: string,
-        @Res({ passthrough: true }) response: Response,
-        @Query('error') error: string,
-        @Query('error_description') errorDescription: string
-    ) {
-        if (error) throw new BadRequestException(errorDescription ?? error);
-
-        const { accessToken, refreshToken } = await this.googleService.login(autherizeCode);
-
-        response.cookie('accessToken', accessToken, {
-            httpOnly: true,
-            secure: Boolean(this.configService.get<string>('NODE_ENV', 'test') === 'production'),
-            maxAge: TOKEN_LIFETIME_MAP.access.maxAge,
-        });
-        response.cookie('refreshToken', refreshToken, {
-            httpOnly: true,
-            secure: Boolean(this.configService.get<string>('NODE_ENV', 'test') === 'production'),
-            maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
-        });
-        response.redirect(this.CLIENT_REDIRECT_URL);
-    }
+    protected readonly AUTHORIZE_CODE_REQUEST_URL = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${this.configService.get<string>('GOOGLE_CLIENT_ID')}&redirect_uri=${this.configService.get<string>('GOOGLE_REDIRECT_URI')}&response_type=code&scope=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile`;
 }

--- a/backend/src/auth/google/google.controller.ts
+++ b/backend/src/auth/google/google.controller.ts
@@ -1,0 +1,47 @@
+import { BadRequestException, Controller, Get, Logger, Query, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { OAuthController } from '../auth.controller';
+import { ConfigService } from '@nestjs/config';
+import { GoogleService } from './google.service';
+import { TOKEN_LIFETIME_MAP } from '../auth.service';
+
+@Controller('auth/google')
+export class GoogleController implements OAuthController {
+    constructor(
+        private readonly configService: ConfigService,
+        private readonly googleService: GoogleService
+    ) {}
+
+    private readonly logger = new Logger(GoogleController.name);
+    private readonly AUTHORIZE_CODE_REQUEST_URL = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${this.configService.get<string>('GOOGLE_CLIENT_ID')}&redirect_uri=${this.configService.get<string>('GOOGLE_REDIRECT_URI')}&response_type=code&scope=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile`;
+    private readonly CLIENT_REDIRECT_URL = this.configService.get<string>('CORS_ORIGIN', 'http://localhost:3000');
+
+    @Get()
+    async authorize(@Res({ passthrough: true }) response: Response) {
+        response.redirect(this.AUTHORIZE_CODE_REQUEST_URL);
+    }
+
+    @Get('callback')
+    async callback(
+        @Query('code') autherizeCode: string,
+        @Res({ passthrough: true }) response: Response,
+        @Query('error') error: string,
+        @Query('error_description') errorDescription: string
+    ) {
+        if (error) throw new BadRequestException(errorDescription ?? error);
+
+        const { accessToken, refreshToken } = await this.googleService.login(autherizeCode);
+
+        response.cookie('accessToken', accessToken, {
+            httpOnly: true,
+            secure: Boolean(this.configService.get<string>('NODE_ENV', 'test') === 'production'),
+            maxAge: TOKEN_LIFETIME_MAP.access.maxAge,
+        });
+        response.cookie('refreshToken', refreshToken, {
+            httpOnly: true,
+            secure: Boolean(this.configService.get<string>('NODE_ENV', 'test') === 'production'),
+            maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
+        });
+        response.redirect(this.CLIENT_REDIRECT_URL);
+    }
+}

--- a/backend/src/auth/google/google.service.ts
+++ b/backend/src/auth/google/google.service.ts
@@ -15,13 +15,14 @@ interface requestTokenResponse {
 }
 
 interface requestUserInfoResponse {
-    id: number;
-    has_signed_up?: boolean;
-    connected_at?: Date;
-    synched_at?: Date;
-    properties?: JSON;
-    kakao_account?: { [key: string]: any };
-    for_partner?: { uuid?: string };
+    azp: string;
+    aud: string;
+    sub: string;
+    scope: string;
+    exp: string;
+    expires_in: string;
+    email: string;
+    email_verified: string;
 }
 
 @Injectable()
@@ -52,21 +53,19 @@ export class GoogleService implements OAuthService {
         return data;
     }
 
-    async requestUserInfo(accessToken: string) {
+    async requestUserId(accessToken: string) {
         const { data } = await firstValueFrom(
-            this.httpService.get<requestUserInfoResponse>('https://www.googleapis.com/oauth2/v2/userinfo', {
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                },
-            })
+            this.httpService.get<requestUserInfoResponse>(
+                `https://oauth2.googleapis.com/tokeninfo?access_token=${accessToken}`
+            )
         );
 
-        return data;
+        return data.sub;
     }
 
     async login(autherizeCode: string) {
         const { access_token: oauthAccessToken } = await this.requestToken(autherizeCode);
-        const { id: oauthId } = await this.requestUserInfo(oauthAccessToken);
+        const oauthId = await this.requestUserId(oauthAccessToken);
 
         // oauthId가 users table에 존재하는지 확인해서 로그인 or 회원가입 처리하고 userId 가져오기
         const userId = 1;

--- a/backend/src/auth/google/google.service.ts
+++ b/backend/src/auth/google/google.service.ts
@@ -26,18 +26,15 @@ interface requestUserInfoResponse {
 }
 
 @Injectable()
-export class GoogleService implements OAuthService {
-    constructor(
-        private readonly configService: ConfigService,
-        private readonly httpService: HttpService,
-        private readonly authService: AuthService
-    ) {}
+export class GoogleService extends OAuthService {
+    constructor(configService: ConfigService, httpService: HttpService, authService: AuthService) {
+        super(configService, httpService, authService, 'google');
+    }
 
     private readonly logger = new Logger(GoogleService.name);
     private readonly CLIENT_ID = this.configService.get<string>('GOOGLE_CLIENT_ID');
     private readonly CLIENT_SECRET = this.configService.get<string>('GOOGLE_CLIENT_SECRET');
     private readonly REDIRECT_URI = this.configService.get<string>('GOOGLE_REDIRECT_URI');
-    private readonly PROVIDER = 'google';
 
     async requestToken(autherizeCode: string) {
         const { data } = await firstValueFrom(
@@ -61,18 +58,5 @@ export class GoogleService implements OAuthService {
         );
 
         return data.sub;
-    }
-
-    async login(autherizeCode: string) {
-        const { access_token: oauthAccessToken } = await this.requestToken(autherizeCode);
-        const oauthId = await this.requestUserId(oauthAccessToken);
-
-        // oauthId가 users table에 존재하는지 확인해서 로그인 or 회원가입 처리하고 userId 가져오기
-        const userId = 1;
-        const accessToken = this.authService.signToken(userId, 'access', this.PROVIDER);
-        const refreshToken = this.authService.signToken(userId, 'refresh', this.PROVIDER);
-        // users table에 refreshToken 저장
-
-        return { accessToken, refreshToken };
     }
 }

--- a/backend/src/auth/google/google.service.ts
+++ b/backend/src/auth/google/google.service.ts
@@ -1,0 +1,79 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { firstValueFrom } from 'rxjs';
+import { AuthService, OAuthService } from '../auth.service';
+
+interface requestTokenResponse {
+    token_type: string;
+    access_token: string;
+    id_token?: string;
+    expires_in: number;
+    refresh_token: string;
+    refresh_token_expires_in: number;
+    scope?: string;
+}
+
+interface requestUserInfoResponse {
+    id: number;
+    has_signed_up?: boolean;
+    connected_at?: Date;
+    synched_at?: Date;
+    properties?: JSON;
+    kakao_account?: { [key: string]: any };
+    for_partner?: { uuid?: string };
+}
+
+@Injectable()
+export class GoogleService implements OAuthService {
+    constructor(
+        private readonly configService: ConfigService,
+        private readonly httpService: HttpService,
+        private readonly authService: AuthService
+    ) {}
+
+    private readonly logger = new Logger(GoogleService.name);
+    private readonly CLIENT_ID = this.configService.get<string>('GOOGLE_CLIENT_ID');
+    private readonly CLIENT_SECRET = this.configService.get<string>('GOOGLE_CLIENT_SECRET');
+    private readonly REDIRECT_URI = this.configService.get<string>('GOOGLE_REDIRECT_URI');
+    private readonly PROVIDER = 'google';
+
+    async requestToken(autherizeCode: string) {
+        const { data } = await firstValueFrom(
+            this.httpService.post<requestTokenResponse>(`https://oauth2.googleapis.com/token`, {
+                client_id: this.CLIENT_ID,
+                client_secret: this.CLIENT_SECRET,
+                code: autherizeCode,
+                grant_type: 'authorization_code',
+                redirect_uri: this.REDIRECT_URI,
+            })
+        );
+
+        return data;
+    }
+
+    async requestUserInfo(accessToken: string) {
+        const { data } = await firstValueFrom(
+            this.httpService.get<requestUserInfoResponse>('https://www.googleapis.com/oauth2/v2/userinfo', {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                },
+            })
+        );
+
+        return data;
+    }
+
+    async login(autherizeCode: string) {
+        const { access_token: oauthAccessToken } = await this.requestToken(autherizeCode);
+        const { id: oauthId } = await this.requestUserInfo(oauthAccessToken);
+
+        // oauthId가 users table에 존재하는지 확인해서 로그인 or 회원가입 처리하고 userId 가져오기
+        const userId = 1;
+        const accessToken = this.authService.signToken(userId, 'access', this.PROVIDER);
+        const refreshToken = this.authService.signToken(userId, 'refresh', this.PROVIDER);
+        // users table에 refreshToken 저장
+
+        return { accessToken, refreshToken };
+    }
+}

--- a/backend/src/auth/kakao/kakao.controller.ts
+++ b/backend/src/auth/kakao/kakao.controller.ts
@@ -1,0 +1,37 @@
+import { BadRequestException, Controller, Get, Logger, Query, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { OAuthController } from '../auth.controller';
+import { ConfigService } from '@nestjs/config';
+import { KakaoService } from './kakao.service';
+
+@Controller('auth/kakao')
+export class KakaoController implements OAuthController {
+    constructor(
+        private readonly configService: ConfigService,
+        private readonly kakaoService: KakaoService
+    ) {}
+
+    private readonly logger = new Logger(KakaoController.name);
+    private readonly AUTHORIZE_CODE_REQUEST_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${this.configService.get<string>('KAKAO_CLIENT_ID')}&redirect_uri=${this.configService.get<string>('KAKAO_REDIRECT_URI')}`;
+    private readonly CLIENT_REDIRECT_URL = this.configService.get<string>('CORS_ORIGIN', 'http://localhost:3000');
+
+    @Get()
+    async authorize(@Res({ passthrough: true }) response: Response) {
+        response.redirect(this.AUTHORIZE_CODE_REQUEST_URL);
+    }
+
+    @Get('callback')
+    async callback(
+        @Query('code') autherizeCode: string,
+        @Res({ passthrough: true }) response: Response,
+        @Query('error') error: string,
+        @Query('error_description') errorDescription: string
+    ) {
+        if (error) throw new BadRequestException(errorDescription);
+
+        const { accessToken } = await this.kakaoService.login(autherizeCode);
+
+        response.cookie('access-token', accessToken);
+        response.redirect(this.CLIENT_REDIRECT_URL);
+    }
+}

--- a/backend/src/auth/kakao/kakao.controller.ts
+++ b/backend/src/auth/kakao/kakao.controller.ts
@@ -1,47 +1,13 @@
-import { BadRequestException, Controller, Get, Logger, Query, Res } from '@nestjs/common';
-import { Response } from 'express';
+import { Controller } from '@nestjs/common';
 import { OAuthController } from '../auth.controller';
 import { ConfigService } from '@nestjs/config';
 import { KakaoService } from './kakao.service';
-import { TOKEN_LIFETIME_MAP } from '../auth.service';
 
 @Controller('auth/kakao')
-export class KakaoController implements OAuthController {
-    constructor(
-        private readonly configService: ConfigService,
-        private readonly kakaoService: KakaoService
-    ) {}
-
-    private readonly logger = new Logger(KakaoController.name);
-    private readonly AUTHORIZE_CODE_REQUEST_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${this.configService.get<string>('KAKAO_CLIENT_ID')}&redirect_uri=${this.configService.get<string>('KAKAO_REDIRECT_URI')}`;
-    private readonly CLIENT_REDIRECT_URL = this.configService.get<string>('CORS_ORIGIN', 'http://localhost:3000');
-
-    @Get()
-    async authorize(@Res({ passthrough: true }) response: Response) {
-        response.redirect(this.AUTHORIZE_CODE_REQUEST_URL);
+export class KakaoController extends OAuthController {
+    constructor(configService: ConfigService, kakaoService: KakaoService) {
+        super(configService, kakaoService);
     }
 
-    @Get('callback')
-    async callback(
-        @Query('code') autherizeCode: string,
-        @Res({ passthrough: true }) response: Response,
-        @Query('error') error: string,
-        @Query('error_description') errorDescription: string
-    ) {
-        if (error) throw new BadRequestException(errorDescription);
-
-        const { accessToken, refreshToken } = await this.kakaoService.login(autherizeCode);
-
-        response.cookie('accessToken', accessToken, {
-            httpOnly: true,
-            secure: Boolean(this.configService.get<string>('NODE_ENV', 'test') === 'production'),
-            maxAge: TOKEN_LIFETIME_MAP.access.maxAge,
-        });
-        response.cookie('refreshToken', refreshToken, {
-            httpOnly: true,
-            secure: Boolean(this.configService.get<string>('NODE_ENV', 'test') === 'production'),
-            maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
-        });
-        response.redirect(this.CLIENT_REDIRECT_URL);
-    }
+    protected readonly AUTHORIZE_CODE_REQUEST_URL = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${this.configService.get<string>('KAKAO_CLIENT_ID')}&redirect_uri=${this.configService.get<string>('KAKAO_REDIRECT_URI')}`;
 }

--- a/backend/src/auth/kakao/kakao.service.ts
+++ b/backend/src/auth/kakao/kakao.service.ts
@@ -83,6 +83,6 @@ export class KakaoService implements OAuthService {
         const refreshToken = this.authService.signToken(userId, 'refresh', this.PROVIDER);
         // users table에 refreshToken 저장
 
-        return { accessToken };
+        return { accessToken, refreshToken };
     }
 }

--- a/backend/src/auth/kakao/kakao.service.ts
+++ b/backend/src/auth/kakao/kakao.service.ts
@@ -21,18 +21,15 @@ interface requestUserInfoResponse {
 }
 
 @Injectable()
-export class KakaoService implements OAuthService {
-    constructor(
-        private readonly configService: ConfigService,
-        private readonly httpService: HttpService,
-        private readonly authService: AuthService
-    ) {}
+export class KakaoService extends OAuthService {
+    constructor(configService: ConfigService, httpService: HttpService, authService: AuthService) {
+        super(configService, httpService, authService, 'kakao');
+    }
 
     private readonly logger = new Logger(KakaoService.name);
     private readonly CLIENT_ID = this.configService.get<string>('KAKAO_CLIENT_ID');
     private readonly CLIENT_SECRET = this.configService.get<string>('KAKAO_CLIENT_SECRET');
     private readonly REDIRECT_URI = this.configService.get<string>('KAKAO_REDIRECT_URI');
-    private readonly PROVIDER = 'kakao';
 
     async requestToken(autherizeCode: string) {
         const { data } = await firstValueFrom(
@@ -66,18 +63,5 @@ export class KakaoService implements OAuthService {
         );
 
         return data.id;
-    }
-
-    async login(autherizeCode: string) {
-        const { access_token: oauthAccessToken } = await this.requestToken(autherizeCode);
-        const oauthId = await this.requestUserId(oauthAccessToken);
-
-        // oauthId가 users table에 존재하는지 확인해서 로그인 or 회원가입 처리하고 userId 가져오기
-        const userId = 1;
-        const accessToken = this.authService.signToken(userId, 'access', this.PROVIDER);
-        const refreshToken = this.authService.signToken(userId, 'refresh', this.PROVIDER);
-        // users table에 refreshToken 저장
-
-        return { accessToken, refreshToken };
     }
 }

--- a/backend/src/auth/kakao/kakao.service.ts
+++ b/backend/src/auth/kakao/kakao.service.ts
@@ -1,0 +1,88 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { firstValueFrom } from 'rxjs';
+import { AuthService, OAuthService } from '../auth.service';
+
+interface requestTokenResponse {
+    token_type: string;
+    access_token: string;
+    id_token?: string;
+    expires_in: number;
+    refresh_token: string;
+    refresh_token_expires_in: number;
+    scope?: string;
+}
+
+interface requestUserInfoResponse {
+    id: number;
+    has_signed_up?: boolean;
+    connected_at?: Date;
+    synched_at?: Date;
+    properties?: JSON;
+    kakao_account?: { [key: string]: any };
+    for_partner?: { uuid?: string };
+}
+
+@Injectable()
+export class KakaoService implements OAuthService {
+    constructor(
+        private readonly configService: ConfigService,
+        private readonly httpService: HttpService,
+        private readonly authService: AuthService
+    ) {}
+
+    private readonly logger = new Logger(KakaoService.name);
+    private readonly CLIENT_ID = this.configService.get<string>('KAKAO_CLIENT_ID');
+    private readonly REDIRECT_URI = this.configService.get<string>('KAKAO_REDIRECT_URI');
+    private readonly CLIENT_SECRET = this.configService.get<string>('KAKAO_CLIENT_SECRET');
+    private readonly PROVIDER = 'kakao';
+
+    async requestToken(autherizeCode: string): Promise<requestTokenResponse> {
+        const { data } = await firstValueFrom(
+            this.httpService.post<requestTokenResponse>(
+                'https://kauth.kakao.com/oauth/token',
+                {
+                    code: autherizeCode,
+                    grant_type: 'authorization_code',
+                    client_id: this.CLIENT_ID,
+                    redirect_uri: this.REDIRECT_URI,
+                    client_secret: this.CLIENT_SECRET,
+                },
+                {
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+                    },
+                }
+            )
+        );
+
+        return data;
+    }
+
+    async requestUserInfo(accessToken: string): Promise<requestUserInfoResponse> {
+        const { data } = await firstValueFrom(
+            this.httpService.get<requestUserInfoResponse>('https://kapi.kakao.com/v2/user/me', {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                    'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+                },
+            })
+        );
+
+        return data;
+    }
+
+    async login(autherizeCode: string) {
+        const { access_token: oauthAccessToken } = await this.requestToken(autherizeCode);
+        const { id: oauthId } = await this.requestUserInfo(oauthAccessToken);
+
+        // oauthId가 users table에 존재하는지 확인해서 로그인 or 회원가입 처리하고 userId 가져오기
+        const userId = 1;
+        const accessToken = this.authService.signToken(userId, 'access', this.PROVIDER);
+        const refreshToken = this.authService.signToken(userId, 'refresh', this.PROVIDER);
+        // users table에 refreshToken 저장
+
+        return { accessToken };
+    }
+}

--- a/backend/src/auth/naver/naver.controller.ts
+++ b/backend/src/auth/naver/naver.controller.ts
@@ -1,47 +1,13 @@
-import { BadRequestException, Controller, Get, Logger, Query, Res } from '@nestjs/common';
-import { Response } from 'express';
+import { Controller } from '@nestjs/common';
 import { OAuthController } from '../auth.controller';
 import { ConfigService } from '@nestjs/config';
 import { NaverService } from './naver.service';
-import { TOKEN_LIFETIME_MAP } from '../auth.service';
 
 @Controller('auth/naver')
-export class NaverController implements OAuthController {
-    constructor(
-        private readonly configService: ConfigService,
-        private readonly naverService: NaverService
-    ) {}
-
-    private readonly logger = new Logger(NaverController.name);
-    private readonly AUTHORIZE_CODE_REQUEST_URL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${this.configService.get<string>('NAVER_CLIENT_ID')}&redirect_uri=${encodeURI(this.configService.get<string>('NAVER_REDIRECT_URI', 'http://localhost:3333/auth/naver/callback'))}&state=naverLoginState`;
-    private readonly CLIENT_REDIRECT_URL = this.configService.get<string>('CORS_ORIGIN', 'http://localhost:3000');
-
-    @Get()
-    async authorize(@Res({ passthrough: true }) response: Response) {
-        response.redirect(this.AUTHORIZE_CODE_REQUEST_URL);
+export class NaverController extends OAuthController {
+    constructor(configService: ConfigService, naverService: NaverService) {
+        super(configService, naverService);
     }
 
-    @Get('callback')
-    async callback(
-        @Query('code') autherizeCode: string,
-        @Res({ passthrough: true }) response: Response,
-        @Query('error') error: string,
-        @Query('error_description') errorDescription: string
-    ) {
-        if (error) throw new BadRequestException(errorDescription);
-
-        const { accessToken, refreshToken } = await this.naverService.login(autherizeCode);
-
-        response.cookie('accessToken', accessToken, {
-            httpOnly: true,
-            secure: Boolean(this.configService.get<string>('NODE_ENV', 'test') === 'production'),
-            maxAge: TOKEN_LIFETIME_MAP.access.maxAge,
-        });
-        response.cookie('refreshToken', refreshToken, {
-            httpOnly: true,
-            secure: Boolean(this.configService.get<string>('NODE_ENV', 'test') === 'production'),
-            maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
-        });
-        response.redirect(this.CLIENT_REDIRECT_URL);
-    }
+    protected readonly AUTHORIZE_CODE_REQUEST_URL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${this.configService.get<string>('NAVER_CLIENT_ID')}&redirect_uri=${encodeURI(this.configService.get<string>('NAVER_REDIRECT_URI', 'http://localhost:3333/auth/naver/callback'))}&state=naverLoginState`;
 }

--- a/backend/src/auth/naver/naver.controller.ts
+++ b/backend/src/auth/naver/naver.controller.ts
@@ -1,0 +1,47 @@
+import { BadRequestException, Controller, Get, Logger, Query, Res } from '@nestjs/common';
+import { Response } from 'express';
+import { OAuthController } from '../auth.controller';
+import { ConfigService } from '@nestjs/config';
+import { NaverService } from './naver.service';
+import { TOKEN_LIFETIME_MAP } from '../auth.service';
+
+@Controller('auth/naver')
+export class NaverController implements OAuthController {
+    constructor(
+        private readonly configService: ConfigService,
+        private readonly naverService: NaverService
+    ) {}
+
+    private readonly logger = new Logger(NaverController.name);
+    private readonly AUTHORIZE_CODE_REQUEST_URL = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${this.configService.get<string>('NAVER_CLIENT_ID')}&redirect_uri=${encodeURI(this.configService.get<string>('NAVER_REDIRECT_URI', 'http://localhost:3333/auth/naver/callback'))}&state=naverLoginState`;
+    private readonly CLIENT_REDIRECT_URL = this.configService.get<string>('CORS_ORIGIN', 'http://localhost:3000');
+
+    @Get()
+    async authorize(@Res({ passthrough: true }) response: Response) {
+        response.redirect(this.AUTHORIZE_CODE_REQUEST_URL);
+    }
+
+    @Get('callback')
+    async callback(
+        @Query('code') autherizeCode: string,
+        @Res({ passthrough: true }) response: Response,
+        @Query('error') error: string,
+        @Query('error_description') errorDescription: string
+    ) {
+        if (error) throw new BadRequestException(errorDescription);
+
+        const { accessToken, refreshToken } = await this.naverService.login(autherizeCode);
+
+        response.cookie('accessToken', accessToken, {
+            httpOnly: true,
+            secure: Boolean(this.configService.get<string>('NODE_ENV', 'test') === 'production'),
+            maxAge: TOKEN_LIFETIME_MAP.access.maxAge,
+        });
+        response.cookie('refreshToken', refreshToken, {
+            httpOnly: true,
+            secure: Boolean(this.configService.get<string>('NODE_ENV', 'test') === 'production'),
+            maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
+        });
+        response.redirect(this.CLIENT_REDIRECT_URL);
+    }
+}

--- a/backend/src/auth/naver/naver.service.ts
+++ b/backend/src/auth/naver/naver.service.ts
@@ -1,0 +1,70 @@
+import { HttpService } from '@nestjs/axios';
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { firstValueFrom } from 'rxjs';
+import { AuthService, OAuthService } from '../auth.service';
+
+interface requestTokenResponse {
+    access_token: string;
+    refresh_token: string;
+    token_type: string;
+    expires_in: number;
+}
+
+interface requestUserInfoResponse {
+    resultcode: string;
+    message: string;
+    response: {
+        id: string;
+        [key: string]: any;
+    };
+}
+
+@Injectable()
+export class NaverService implements OAuthService {
+    constructor(
+        private readonly configService: ConfigService,
+        private readonly httpService: HttpService,
+        private readonly authService: AuthService
+    ) {}
+
+    private readonly logger = new Logger(NaverService.name);
+    private readonly CLIENT_ID = this.configService.get<string>('NAVER_CLIENT_ID');
+    private readonly CLIENT_SECRET = this.configService.get<string>('NAVER_CLIENT_SECRET');
+    private readonly PROVIDER = 'naver';
+
+    async requestToken(autherizeCode: string) {
+        const { data } = await firstValueFrom(
+            this.httpService.post<requestTokenResponse>(
+                `https://nid.naver.com/oauth2.0/token?grant_type=authorization_code&client_id=${this.CLIENT_ID}&client_secret=${this.CLIENT_SECRET}&code=${autherizeCode}&state=naverLoginState`
+            )
+        );
+
+        return data;
+    }
+
+    async requestUserInfo(accessToken: string) {
+        const { data } = await firstValueFrom(
+            this.httpService.get<requestUserInfoResponse>('https://openapi.naver.com/v1/nid/me', {
+                headers: {
+                    Authorization: `Bearer ${accessToken}`,
+                },
+            })
+        );
+
+        return data.response;
+    }
+
+    async login(autherizeCode: string) {
+        const { access_token: oauthAccessToken } = await this.requestToken(autherizeCode);
+        const { id: oauthId } = await this.requestUserInfo(oauthAccessToken);
+
+        // oauthId가 users table에 존재하는지 확인해서 로그인 or 회원가입 처리하고 userId 가져오기
+        const userId = 1;
+        const accessToken = this.authService.signToken(userId, 'access', this.PROVIDER);
+        const refreshToken = this.authService.signToken(userId, 'refresh', this.PROVIDER);
+        // users table에 refreshToken 저장
+
+        return { accessToken, refreshToken };
+    }
+}

--- a/backend/src/auth/naver/naver.service.ts
+++ b/backend/src/auth/naver/naver.service.ts
@@ -21,17 +21,14 @@ interface requestUserInfoResponse {
 }
 
 @Injectable()
-export class NaverService implements OAuthService {
-    constructor(
-        private readonly configService: ConfigService,
-        private readonly httpService: HttpService,
-        private readonly authService: AuthService
-    ) {}
+export class NaverService extends OAuthService {
+    constructor(configService: ConfigService, httpService: HttpService, authService: AuthService) {
+        super(configService, httpService, authService, 'naver');
+    }
 
     private readonly logger = new Logger(NaverService.name);
     private readonly CLIENT_ID = this.configService.get<string>('NAVER_CLIENT_ID');
     private readonly CLIENT_SECRET = this.configService.get<string>('NAVER_CLIENT_SECRET');
-    private readonly PROVIDER = 'naver';
 
     async requestToken(autherizeCode: string) {
         const { data } = await firstValueFrom(
@@ -53,18 +50,5 @@ export class NaverService implements OAuthService {
         );
 
         return data.response.id;
-    }
-
-    async login(autherizeCode: string) {
-        const { access_token: oauthAccessToken } = await this.requestToken(autherizeCode);
-        const oauthId = await this.requestUserId(oauthAccessToken);
-
-        // oauthId가 users table에 존재하는지 확인해서 로그인 or 회원가입 처리하고 userId 가져오기
-        const userId = 1;
-        const accessToken = this.authService.signToken(userId, 'access', this.PROVIDER);
-        const refreshToken = this.authService.signToken(userId, 'refresh', this.PROVIDER);
-        // users table에 refreshToken 저장
-
-        return { accessToken, refreshToken };
     }
 }

--- a/backend/src/auth/naver/naver.service.ts
+++ b/backend/src/auth/naver/naver.service.ts
@@ -43,7 +43,7 @@ export class NaverService implements OAuthService {
         return data;
     }
 
-    async requestUserInfo(accessToken: string) {
+    async requestUserId(accessToken: string) {
         const { data } = await firstValueFrom(
             this.httpService.get<requestUserInfoResponse>('https://openapi.naver.com/v1/nid/me', {
                 headers: {
@@ -52,12 +52,12 @@ export class NaverService implements OAuthService {
             })
         );
 
-        return data.response;
+        return data.response.id;
     }
 
     async login(autherizeCode: string) {
         const { access_token: oauthAccessToken } = await this.requestToken(autherizeCode);
-        const { id: oauthId } = await this.requestUserInfo(oauthAccessToken);
+        const oauthId = await this.requestUserId(oauthAccessToken);
 
         // oauthId가 users table에 존재하는지 확인해서 로그인 or 회원가입 처리하고 userId 가져오기
         const userId = 1;


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- DB 없이 일단 기본 로그인 로직 구현했습니다.
  1. `auth/:provider`
      - [x]  authorize_code_request_url로 redirect
  2. `auth/:provider/callback`
      - [x]  authorize_code로 oauth login → oauth_access_token과 oauth_refresh_token
      - [x]  access_token으로 user 정보 요청 → oauth_id
      - oauth_id가 users table에 존재하는지 확인
          - 존재할 경우 (로그인): oauth_access_token과 oauth_refresh_token 저장..해야되나? 필요하지 않을 것 같기도..
          - 존재하지 않는 경우 (회원가입): 새로운 user 생성 (nickname은 hash로)
      - [x]  자체 access_token, refresh_token 발급
          - jwt payload
              - user_id
              - provider (kakao, naver, google)
              
              ```
              {
            	  user_id
            	  provider
              }
              ```
      - [x] cookie에 access token과 refresh token을 담아 client home으로 redirect
- controller와 service 모두 abstract class를 만들고 이를 extends하여 각 provider 별로 구현하는 식으로 작성했습니다.

## 링크 (Links)
https://www.notion.so/do0ori/DB-X-8b4d4d649d1b4601bd676e3fe8985ce7

## 기타 사항 (Etc)
- 현재 `auth.service.ts`에 jwt 발행 및 복호화하는 service를 작성했는데 token.service.ts로 따로 뺀다면 어느 위치에 만들면 좋을까요?
- 다음에 할 일
  - DB 로직 추가
  - `auth.guard.ts` 추가
  - `user.decorator.ts` 추가

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
