### PR TITLE
frontend/DANG-202: 로그인 후 로그인전 path로 redirect

### DIFF
--- a/frontend/src/components/OAuthButton.tsx
+++ b/frontend/src/components/OAuthButton.tsx
@@ -3,10 +3,11 @@ import React from 'react';
 type Props = {
     provider: string;
     name: string;
+    prevURL: string;
 };
-const OAuthButton = ({ provider, name }: Props) => {
+const OAuthButton = ({ provider, name, prevURL }: Props) => {
     const handleCallOAuth = () => {
-        window.location.href = `${process.env.REACT_APP_NEST_BASE_URL}/auth/${provider}`;
+        window.location.href = `${process.env.REACT_APP_NEST_BASE_URL}/auth/${provider}?redirect=${process.env.REACT_APP_BASE_URL}${prevURL}`;
     };
     return (
         <button className="bg-yellow-200" onClick={handleCallOAuth}>

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,12 +1,15 @@
 import OAuthButton from '@/components/OAuthButton';
 import { OAUTH } from '@/constants/oauthList';
+import { useLocation } from 'react-router-dom';
 const Login = () => {
+    const location = useLocation();
+    const prevURL = location.state.currentURL;
     return (
         <div>
             <p>로그인 페이지</p>
             <div className="flex gap-2">
                 {OAUTH.map((oauth, index) => (
-                    <OAuthButton key={index} provider={oauth.PROVIDER} name={oauth.NAME} />
+                    <OAuthButton key={index} provider={oauth.PROVIDER} name={oauth.NAME} prevURL={prevURL} />
                 ))}
             </div>
         </div>


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
로그인 후 로그인전 path로 redirect
## 링크 (Links)

## 기타 사항 (Etc)
산책(홈)페이지, 내정보페이지에 로그인버튼 만들때 아래의 코드 추가해야됨
```
const handleLogin = () => {
        const currentURL = window.location.pathname;
        navigate('/login', { state: { currentURL } });
    };
```

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] CI 파이프라인이 통과가 되었나요?
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
