### PR TITLE
backend/DANG-201: Users에 사용자의 강아지 목록 리턴하는 함수 임시로 하드코딩

### DIFF
--- a/backend/src/users/userDogs.entity.ts
+++ b/backend/src/users/userDogs.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { Users } from './users.entity';
+import { Dogs } from '../dog/dogs.entity';
+
+@Entity('users_dogs')
+export class UsersDogs {
+    @PrimaryColumn({ name: 'user_id' })
+    @ManyToOne(() => Users, (users) => users.id)
+    @JoinColumn({ name: 'user_id' })
+    userId: number;
+
+    @PrimaryColumn({ name: 'dog_id' })
+    @ManyToOne(() => Dogs, (dog) => dog.id)
+    @JoinColumn({ name: 'dog_id' })
+    dogId: number;
+}

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -4,11 +4,12 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { UsersController } from './users.controller';
 import { WinstonLoggerModule } from '../common/logger/winstonLogger.module';
 import { UsersService } from './users.service';
+import { UsersDogs } from 'src/users/userDogs.entity';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Users]), WinstonLoggerModule],
+    imports: [TypeOrmModule.forFeature([Users, UsersDogs]), WinstonLoggerModule],
     controllers: [UsersController],
     providers: [UsersService],
-    exports: [UsersService],
+    exports: [TypeOrmModule, UsersService],
 })
 export class UsersModule {}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,15 +1,16 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { InjectRepository, InjectEntityManager } from '@nestjs/typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
 import { Users } from './users.entity';
-import { Repository, EntityManager } from 'typeorm';
+import { Repository } from 'typeorm';
 import { Role } from './user-roles.enum';
 import { generateUuid } from '../utils/hash.utils';
+import { UsersDogs } from 'src/users/userDogs.entity';
 
 @Injectable()
 export class UsersService {
     constructor(
         @InjectRepository(Users) private userRepo: Repository<Users>,
-        @InjectEntityManager() private entityManager: EntityManager
+        @InjectRepository(UsersDogs) private usersDogsRepo: Repository<UsersDogs>
     ) {}
 
     async create(
@@ -97,5 +98,11 @@ export class UsersService {
         }
 
         return nickname;
+    }
+
+    async getDogsList(userId: number): Promise<number[]> {
+        const foundDogs = await this.usersDogsRepo.find({ where: { userId: 1 } });
+
+        return [1, 2, 3];
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- 실제 DB에서는 SELECT가 되는데 코드상으로 빈배열이 리턴되는 에러때문에 임시로 하드코딩해둠
- 재경님이 Users를 써야해서 임시로 해둔것
- usersDogs 엔티티 파일 users 하위로 이동

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] CI 파이프라인이 통과가 되었나요?
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
