### PR TITLE
backend/DANG-208: Users 엔티티에 create 메서드 추가 및 테스트 코드 작성

### DIFF
--- a/backend/src/fixture/users.fixture.ts
+++ b/backend/src/fixture/users.fixture.ts
@@ -1,0 +1,21 @@
+import { Users } from '../users/users.entity';
+import { Role } from '../users/user-roles.enum';
+
+const ACCESS_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTY2ODc1NzUzNCwiZXhwIjoxNjY4ODQzOTM0fQ.fwjmKJZ7enTKt7tPfNx-ZG_rczvhkz2ktMV5pDNbxkw';
+const REFRESH_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM';
+const OAUTH_REFRESH_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM';
+
+export const mockUser = Users.create(
+    1,
+    '오징어1234',
+    Role.User,
+    1,
+    '1',
+    ACCESS_TOKEN,
+    OAUTH_REFRESH_TOKEN,
+    REFRESH_TOKEN,
+    new Date('2019-01-01')
+);

--- a/backend/src/users/users.entity.ts
+++ b/backend/src/users/users.entity.ts
@@ -34,5 +34,31 @@ export class Users {
     refreshToken: string;
 
     @CreateDateColumn()
-    created_at: Date;
+    createdAt: Date;
+
+    constructor() {}
+
+    static create(
+        id: number,
+        nickname: string,
+        role: Role,
+        mainDogId: number,
+        oauthId: string,
+        oauthAccessToken: string,
+        oauthRefreshToken: string,
+        refreshToken: string,
+        createAt: Date
+    ) {
+        const user = new Users();
+        user.id = id;
+        user.nickname = nickname;
+        user.role = role;
+        user.mainDogId = mainDogId;
+        user.oauthId = oauthId;
+        user.oauthAccessToken = oauthAccessToken;
+        user.oauthRefreshToken = oauthRefreshToken;
+        user.refreshToken = refreshToken;
+        user.createdAt = createAt;
+        return user;
+    }
 }

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -1,0 +1,60 @@
+import { UsersService } from './users.service';
+import { Repository } from 'typeorm';
+import { Users } from './users.entity';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { UsersDogs } from './userDogs.entity';
+import { mockUser } from '../fixture/users.fixture';
+import { NotFoundException } from '@nestjs/common';
+
+const context = describe;
+
+describe('UsersService', () => {
+    let service: UsersService;
+    let userRepository: Repository<Users>;
+    let usersDogsRepository: Repository<UsersDogs>;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                UsersService,
+                {
+                    provide: getRepositoryToken(Users),
+                    useClass: Repository,
+                },
+                {
+                    provide: getRepositoryToken(UsersDogs),
+                    useClass: Repository,
+                },
+            ],
+        }).compile();
+
+        service = module.get<UsersService>(UsersService);
+        userRepository = module.get<Repository<Users>>(getRepositoryToken(Users));
+        usersDogsRepository = module.get<Repository<UsersDogs>>(getRepositoryToken(UsersDogs));
+    });
+
+    describe('findOne', () => {
+        context('사용자가 존재 할 때', () => {
+            beforeEach(() => {
+                jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser);
+            });
+
+            it('사용자 정보를 리턴해야 한다.', async () => {
+                const res = await service.findOne(mockUser.id);
+
+                expect(res).toEqual(mockUser);
+            });
+        });
+
+        context('사용자가 존재하지 않을 때', () => {
+            beforeEach(() => {
+                jest.spyOn(userRepository, 'findOne').mockResolvedValue(null);
+            });
+
+            it('NotFoundException 예외를 던져야 한다.', async () => {
+                await expect(service.findOne(1)).rejects.toThrow(NotFoundException);
+            });
+        });
+    });
+});

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -57,4 +57,28 @@ describe('UsersService', () => {
             });
         });
     });
+
+    describe('loginOrCreateUser', () => {
+        context('사용자 토큰 정보가 주어지고 사용자가 존재하지 않으면', () => {
+            beforeEach(() => {
+                jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser);
+                jest.spyOn(userRepository, 'save').mockResolvedValue(mockUser);
+                jest.spyOn(service, 'generateUniqueNickname').mockResolvedValue('unique-nickname');
+                jest.spyOn(service, 'create').mockResolvedValue({ id: 1 } as Users);
+            });
+
+            it('사용자 정보를 저장하고 사용자 id를 리턴해야 한다.', async () => {
+                const res = await service.loginOrCreateUser(
+                    mockUser.oauthId,
+                    mockUser.oauthAccessToken,
+                    mockUser.oauthRefreshToken,
+                    mockUser.refreshToken
+                );
+
+                expect(res).toBe(1);
+                expect(userRepository.save).toHaveBeenCalledWith({ ...mockUser });
+                expect(userRepository.findOne).toHaveBeenCalledWith({ where: { oauthId: mockUser.oauthId } });
+            });
+        });
+    });
 });

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -87,7 +87,7 @@ export class UsersService {
         return user.id;
     }
 
-    private async generateUniqueNickname(): Promise<string> {
+    async generateUniqueNickname(): Promise<string> {
         let nickname = generateUuid();
         let user = await this.userRepo.findOne({ where: { nickname } });
 

--- a/backend/src/users/users.spec.ts
+++ b/backend/src/users/users.spec.ts
@@ -1,31 +1,12 @@
 import { Users } from './users.entity';
-import { Role } from './user-roles.enum';
+import { mockUser } from '../fixture/users.fixture';
 
 describe('User', () => {
-    const ACCESS_TOKEN =
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTY2ODc1NzUzNCwiZXhwIjoxNjY4ODQzOTM0fQ.fwjmKJZ7enTKt7tPfNx-ZG_rczvhkz2ktMV5pDNbxkw';
-    const REFRESH_TOKEN =
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM';
-    const OAUTH_REFRESH_TOKEN =
-        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM';
-
     it('user 정보가 주어지면 user 정보를 리턴해야 한다.', () => {
-        const user = Users.create(
-            1,
-            '오징어1234',
-            Role.User,
-            1,
-            '1',
-            ACCESS_TOKEN,
-            OAUTH_REFRESH_TOKEN,
-            REFRESH_TOKEN,
-            new Date('2019-01-01')
-        );
-
-        expect(user).toEqual({
+        expect(mockUser).toEqual({
             id: 1,
             mainDogId: 1,
-            nickname: '도루마',
+            nickname: '오징어1234',
             oauthId: '1',
             oauthAccessToken:
                 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTY2ODc1NzUzNCwiZXhwIjoxNjY4ODQzOTM0fQ.fwjmKJZ7enTKt7tPfNx-ZG_rczvhkz2ktMV5pDNbxkw',

--- a/backend/src/users/users.spec.ts
+++ b/backend/src/users/users.spec.ts
@@ -1,0 +1,46 @@
+import { Users } from './users.entity';
+import { Role } from './user-roles.enum';
+
+describe('User', () => {
+    const ACCESS_TOKEN =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTY2ODc1NzUzNCwiZXhwIjoxNjY4ODQzOTM0fQ.fwjmKJZ7enTKt7tPfNx-ZG_rczvhkz2ktMV5pDNbxkw';
+    const REFRESH_TOKEN =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM';
+    const OAUTH_REFRESH_TOKEN =
+        'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM';
+
+    it('user 정보가 주어지면 user 정보를 리턴해야 한다.', () => {
+        const user = Users.create(
+            1,
+            '오징어1234',
+            Role.User,
+            1,
+            '1',
+            ACCESS_TOKEN,
+            OAUTH_REFRESH_TOKEN,
+            REFRESH_TOKEN,
+            new Date('2019-01-01')
+        );
+
+        expect(user).toEqual({
+            id: 1,
+            mainDogId: 1,
+            nickname: '도루마',
+            oauthId: '1',
+            oauthAccessToken:
+                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTY2ODc1NzUzNCwiZXhwIjoxNjY4ODQzOTM0fQ.fwjmKJZ7enTKt7tPfNx-ZG_rczvhkz2ktMV5pDNbxkw',
+            oauthRefreshToken:
+                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM',
+            refreshToken:
+                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM',
+            role: 'USER',
+            createdAt: expect.any(Date),
+        });
+    });
+
+    it('user 정보가 없으면 빈 객체를 리턴해야 한다.', () => {
+        const user = new Users();
+
+        expect(user).toEqual({});
+    });
+});


### PR DESCRIPTION
## 작업 내용 (Content)
주요 변경 사항
- Users 엔티티에 새로운 create 메서드를 추가했습니다.
- 이 메서드는 사용자 정보를 입력받아 새로운 Users 인스턴스를 생성합니다.
- Users 엔티티에 대한 유닛 테스트 코드를 추가했습니다.
- 테스트 코드는 create 메서드가 올바르게 작동하는지 확인합니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
