### PR TITLE
backend/DANG-213: oauth service에서 redirect url 삭제

### DIFF
--- a/backend/src/auth/oauth/google.service.ts
+++ b/backend/src/auth/oauth/google.service.ts
@@ -32,7 +32,6 @@ export class GoogleService implements OauthService {
 
     private readonly CLIENT_ID = this.configService.get<string>('GOOGLE_CLIENT_ID');
     private readonly CLIENT_SECRET = this.configService.get<string>('GOOGLE_CLIENT_SECRET');
-    private readonly REDIRECT_URI = this.configService.get<string>('GOOGLE_REDIRECT_URI');
 
     async requestToken(authorizeCode: string) {
         const { data } = await firstValueFrom(
@@ -41,7 +40,6 @@ export class GoogleService implements OauthService {
                 client_secret: this.CLIENT_SECRET,
                 code: authorizeCode,
                 grant_type: 'authorization_code',
-                redirect_uri: this.REDIRECT_URI,
             })
         );
 

--- a/backend/src/auth/oauth/kakao.service.ts
+++ b/backend/src/auth/oauth/kakao.service.ts
@@ -29,7 +29,6 @@ export class KakaoService implements OauthService {
 
     private readonly CLIENT_ID = this.configService.get<string>('KAKAO_CLIENT_ID');
     private readonly CLIENT_SECRET = this.configService.get<string>('KAKAO_CLIENT_SECRET');
-    private readonly REDIRECT_URI = this.configService.get<string>('KAKAO_REDIRECT_URI');
 
     async requestToken(authorizeCode: string) {
         const { data } = await firstValueFrom(
@@ -39,7 +38,6 @@ export class KakaoService implements OauthService {
                     code: authorizeCode,
                     grant_type: 'authorization_code',
                     client_id: this.CLIENT_ID,
-                    redirect_uri: this.REDIRECT_URI,
                     client_secret: this.CLIENT_SECRET,
                 },
                 {


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
요청한 정보를 받을 redirect url을 지정했더니 oauth에서 client로 요청이 가서 cors 에러가 발생했다. authorize code는 이제 client에서 처리하므로 redirect url이 필요 없다. 따라서 oauth service에서 요청을 보낼 때 redirect url을 사용하지 않도록 수정했다.

## 링크 (Links)
https://www.notion.so/do0ori/redirect-url-6fa465a9c89448f2a2024fdb6f41e804

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
