### PR TITLE
backend/DANG-196: auth guard에 사용자 존재 여부 확인 로직 추가 & 회원 탈퇴 api 추가

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -38,6 +38,10 @@ export class AuthService {
         return { accessToken, refreshToken };
     }
 
+    async deactivate(userId: number): Promise<void> {
+        await this.usersService.remove(userId);
+    }
+
     async validateAccessToken(userId: number): Promise<boolean> {
         try {
             await this.usersService.findOne(userId);

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -38,6 +38,15 @@ export class AuthService {
         return { accessToken, refreshToken };
     }
 
+    async validateAccessToken(userId: number): Promise<boolean> {
+        try {
+            await this.usersService.findOne(userId);
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
     async validateRefreshToken(token: string, oauthId: string): Promise<boolean> {
         const { refreshToken } = await this.usersService.findOneWithOauthID(oauthId);
 

--- a/backend/src/auth/guards/refreshToken.guard.ts
+++ b/backend/src/auth/guards/refreshToken.guard.ts
@@ -17,7 +17,7 @@ export class RefreshTokenGuard implements CanActivate {
 
         try {
             const payload = this.tokenService.verify(token) as RefreshTokenPayload;
-            const isValid = this.authService.validateRefreshToken(token, payload.oauthId);
+            const isValid = await this.authService.validateRefreshToken(token, payload.oauthId);
 
             request.user = payload;
 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- access token에 들어 있는 userId에 해당하는 사용자가 실제로 존재하는지 검증하는 로직을 추가했다.
- 대응하는 method를 auth service에 구현했다.
- refresh token guard에 빠진 await을 추가했다.
- 회원 탈퇴 api는 일단은 간단히 사용자를 직접 삭제하고 cookie를 clear하도록 했다. oauth 탈퇴 처리는 나중에.

## 링크 (Links)
https://www.notion.so/do0ori/api-b2132bd43d3642f8ab39a790569a958c

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
