### PR TITLE
backend/DANG-224: login 로직에 redirect uri 추가

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -25,9 +25,10 @@ export class AuthController {
     async login(
         @Body('authorizeCode') authorizeCode: string,
         @Body('provider') provider: OauthProvider,
+        @Body('redirectURI') redirectURI: string,
         @Res({ passthrough: true }) response: Response
     ): Promise<loginResponse> {
-        const { accessToken, refreshToken } = await this.authService.login(authorizeCode, provider);
+        const { accessToken, refreshToken } = await this.authService.login(authorizeCode, provider, redirectURI);
 
         response.cookie('refreshToken', refreshToken, {
             httpOnly: true,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -18,10 +18,12 @@ export class AuthService {
 
     async login(
         authorizeCode: string,
-        provider: OauthProvider
+        provider: OauthProvider,
+        redirectURI: string
     ): Promise<{ accessToken: string; refreshToken: string }> {
-        const { access_token: oauthAccessToken, refresh_token: oauthRefreshToken } =
-            await this[`${provider}Service`].requestToken(authorizeCode);
+        const { access_token: oauthAccessToken, refresh_token: oauthRefreshToken } = await this[
+            `${provider}Service`
+        ].requestToken(authorizeCode, redirectURI);
         const oauthId = await this[`${provider}Service`].requestUserId(oauthAccessToken);
 
         const refreshToken = this.tokenService.signRefreshToken(oauthId, provider);

--- a/backend/src/auth/oauth/google.service.ts
+++ b/backend/src/auth/oauth/google.service.ts
@@ -33,13 +33,14 @@ export class GoogleService implements OauthService {
     private readonly CLIENT_ID = this.configService.get<string>('GOOGLE_CLIENT_ID');
     private readonly CLIENT_SECRET = this.configService.get<string>('GOOGLE_CLIENT_SECRET');
 
-    async requestToken(authorizeCode: string) {
+    async requestToken(authorizeCode: string, redirectURI: string) {
         const { data } = await firstValueFrom(
             this.httpService.post<requestTokenResponse>(`https://oauth2.googleapis.com/token`, {
                 client_id: this.CLIENT_ID,
                 client_secret: this.CLIENT_SECRET,
                 code: authorizeCode,
                 grant_type: 'authorization_code',
+                redirect_uri: redirectURI,
             })
         );
 

--- a/backend/src/auth/oauth/kakao.service.ts
+++ b/backend/src/auth/oauth/kakao.service.ts
@@ -30,7 +30,7 @@ export class KakaoService implements OauthService {
     private readonly CLIENT_ID = this.configService.get<string>('KAKAO_CLIENT_ID');
     private readonly CLIENT_SECRET = this.configService.get<string>('KAKAO_CLIENT_SECRET');
 
-    async requestToken(authorizeCode: string) {
+    async requestToken(authorizeCode: string, redirectURI: string) {
         const { data } = await firstValueFrom(
             this.httpService.post<requestTokenResponse>(
                 'https://kauth.kakao.com/oauth/token',
@@ -39,6 +39,7 @@ export class KakaoService implements OauthService {
                     grant_type: 'authorization_code',
                     client_id: this.CLIENT_ID,
                     client_secret: this.CLIENT_SECRET,
+                    redirect_uri: redirectURI,
                 },
                 {
                     headers: {

--- a/backend/src/auth/oauth/oauth.service.interface.ts
+++ b/backend/src/auth/oauth/oauth.service.interface.ts
@@ -1,5 +1,8 @@
 export interface OauthService {
-    requestToken(authorizeCode: string): Promise<{
+    requestToken(
+        authorizeCode: string,
+        redirectURI?: string
+    ): Promise<{
         access_token: string;
         refresh_token: string;
         [key: string]: any;


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- request body에 redirectURI field가 추가되었다.
- oauth server로 요청 시 전달받은 redirectURI를 사용하도록 추가했다.

## 링크 (Links)
https://www.notion.so/do0ori/login-redirect-uri-755f488aab7e4fe9b2fc551251cc6da4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
