### PR TITLE
Infra/DANG 227: DockerFile health Check를 추가하기

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -49,7 +49,6 @@ services:
     build:
       context: frontend
       dockerfile: Dockerfile
-      target: dev
     volumes:
       - ./frontend:/app
       - /app/node_modules

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,8 +2,6 @@ FROM node:18-alpine AS base
 
 FROM base AS prod
 
-ENV NODE_ENV prod
-
 RUN apk add --no-cache libc6-compat && \
     apk update && \
     apk add --no-cache --update curl && \
@@ -20,6 +18,8 @@ RUN npm install -g serve
 
 COPY --chown=react:nodejs build ./build
 COPY --chown=react:nodejs docker-entrypoint.sh /usr/local/bin/
+
+HEALTHCHECK CMD curl --fail http://localhost:3000/health || exit 1
 
 RUN chmod u+x /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
## 작업 내용 (Content)
주요 변경사항
- 프론트엔드 상태 확인을 위해 HEALTHCHECK CMD를 추가합니다.
- 상태 확인은 http://localhost:3000/health 를 컬링하고 실패하면 1로 종료한다.
- 이전에는 target: dev로 인해 프론트엔드가 제대로 빌드되지 않는 문제가 있었습니다.
- frontend 서비스에서 target: dev를 제거했습니다.
## 링크 (Links)
- https://www.notion.so/do0ori/DockerFile-health-Check-b59b652cb3434c5795efb628fe171707?pvs=4
## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
