### PR TITLE
backend/DANG-226: oauth logut 추가

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -44,7 +44,9 @@ export class AuthController {
 
     @Post('logout')
     @UseGuards(AuthGuard)
-    async logout(@Res({ passthrough: true }) response: Response) {
+    async logout(@User() { userId, provider }: AccessTokenPayload, @Res({ passthrough: true }) response: Response) {
+        await this.authService.logout(userId, provider);
+
         response.clearCookie('refreshToken');
     }
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -40,6 +40,13 @@ export class AuthService {
         return { accessToken, refreshToken };
     }
 
+    async logout(userId: number, provider: OauthProvider): Promise<void> {
+        if (provider !== 'google') {
+            const { oauthAccessToken } = await this.usersService.findOne(userId);
+            await this[`${provider}Service`].requestLogout(oauthAccessToken);
+        }
+    }
+
     async deactivate(userId: number): Promise<void> {
         await this.usersService.remove(userId);
     }
@@ -54,7 +61,7 @@ export class AuthService {
     }
 
     async validateRefreshToken(token: string, oauthId: string): Promise<boolean> {
-        const { refreshToken } = await this.usersService.findOneWithOauthID(oauthId);
+        const { refreshToken } = await this.usersService.findOneWithOauthId(oauthId);
 
         return refreshToken === token;
     }
@@ -63,7 +70,7 @@ export class AuthService {
         oauthId: string,
         provider: OauthProvider
     ): Promise<{ accessToken: string; refreshToken: string }> {
-        const { id: userId } = await this.usersService.findOneWithOauthID(oauthId);
+        const { id: userId } = await this.usersService.findOneWithOauthId(oauthId);
 
         const accessToken = this.tokenService.signAccessToken(userId, provider);
         const refreshToken = this.tokenService.signRefreshToken(oauthId, provider);

--- a/backend/src/auth/oauth/kakao.service.ts
+++ b/backend/src/auth/oauth/kakao.service.ts
@@ -20,6 +20,10 @@ interface requestUserInfoResponse {
     app_id: number;
 }
 
+interface requestLogoutResponse {
+    id: number;
+}
+
 @Injectable()
 export class KakaoService implements OauthService {
     constructor(
@@ -62,5 +66,20 @@ export class KakaoService implements OauthService {
         );
 
         return data.id.toString();
+    }
+
+    async requestLogout(accessToken: string) {
+        await firstValueFrom(
+            this.httpService.post<requestLogoutResponse>(
+                'https://kapi.kakao.com/v1/user/logout',
+                {},
+                {
+                    headers: {
+                        Authorization: `Bearer ${accessToken}`,
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                }
+            )
+        );
     }
 }

--- a/backend/src/auth/oauth/naver.service.ts
+++ b/backend/src/auth/oauth/naver.service.ts
@@ -20,6 +20,11 @@ interface requestUserInfoResponse {
     };
 }
 
+interface requestLogoutResponse {
+    access_token: string;
+    result: string;
+}
+
 @Injectable()
 export class NaverService implements OauthService {
     constructor(
@@ -50,5 +55,13 @@ export class NaverService implements OauthService {
         );
 
         return data.response.id;
+    }
+
+    async requestLogout(accessToken: string) {
+        await firstValueFrom(
+            this.httpService.post<requestLogoutResponse>(
+                `https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id=${this.CLIENT_ID}&client_secret=${this.CLIENT_SECRET}&access_token=${accessToken}&service_provider=NAVER`
+            )
+        );
     }
 }

--- a/backend/src/auth/oauth/oauth.service.interface.ts
+++ b/backend/src/auth/oauth/oauth.service.interface.ts
@@ -9,4 +9,6 @@ export interface OauthService {
     }>;
 
     requestUserId(accessToken: string): Promise<string>;
+
+    requestLogout?(accessToken: string): Promise<void>;
 }

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -58,7 +58,7 @@ export class UsersService {
         return this.userRepo.remove(user);
     }
 
-    async findOneWithOauthID(oauthId: string) {
+    async findOneWithOauthId(oauthId: string) {
         const user = await this.userRepo.findOne({ where: { oauthId } });
         if (!user) throw new NotFoundException('User not found');
         return user;


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- oauth service에서도 따로 logout을 해주어야 한다.
  - 계정의 세션을 만료시키는 것은 아니다.
  - "카카오계정과 함께 로그아웃"으로 계정의 세션까지 만료시킬 수 있으나 Logout Redirect URI도 따로 등록해야 한다.
  - 그런데 카카오 계정은 보통 사람마다 하나이고 본인 계정을 사용할 것이기 때문에 카카오계정 세션까지 만료시킬 필요는 없다고 판단해서 단순히 token을 만료시키는 logout api를 사용했다.
- kakao, naver는 token을 만료시키는 방법을 사용한다.
- google은 따로 logout api가 없는 것 같다. (생각해보면 자동으로 로그인되지 않고 매 로그인마다 계정을 선택해서 로그인해야 하기 때문에 굳이 필요가 없다.)
- google을 제외한 provider에서 logout 요청 발생 시 oauth api를 통해 oauth token을 만료시켜 로그아웃 처리를 한다.
- 로그아웃 후 바로 로그인 페이지나 홈 페이지로 이동하므로 db에 저장해둔 oauth access/refresh token은 굳이 삭제할 필요는 없을 것 같다.
- 자연스럽게 다음 로그인 때 oauth access/refresh token이 갱신된다.

## 링크 (Links)
https://www.notion.so/do0ori/oauth-logut-3d761d19cad24a8baf0759a6bbdb6951

## 기타 사항 (Etc)
postmane을 활용해 테스트 완료

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
