### PR TITLE
backend/DANG-239: google에 대한 oauth logout 추가

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -41,10 +41,9 @@ export class AuthService {
     }
 
     async logout(userId: number, provider: OauthProvider): Promise<void> {
-        if (provider !== 'google') {
-            const { oauthAccessToken } = await this.usersService.findOne(userId);
-            await this[`${provider}Service`].requestLogout(oauthAccessToken);
-        }
+        const { oauthAccessToken } = await this.usersService.findOne(userId);
+
+        await this[`${provider}Service`].requestTokenExpiration(oauthAccessToken);
     }
 
     async deactivate(userId: number): Promise<void> {

--- a/backend/src/auth/oauth/google.service.ts
+++ b/backend/src/auth/oauth/google.service.ts
@@ -56,4 +56,18 @@ export class GoogleService implements OauthService {
 
         return data.sub;
     }
+
+    async requestTokenExpiration(accessToken: string) {
+        await firstValueFrom(
+            this.httpService.post(
+                `https://oauth2.googleapis.com/revoke?token=${accessToken}`,
+                {},
+                {
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                }
+            )
+        );
+    }
 }

--- a/backend/src/auth/oauth/kakao.service.ts
+++ b/backend/src/auth/oauth/kakao.service.ts
@@ -68,7 +68,7 @@ export class KakaoService implements OauthService {
         return data.id.toString();
     }
 
-    async requestLogout(accessToken: string) {
+    async requestTokenExpiration(accessToken: string) {
         await firstValueFrom(
             this.httpService.post<requestLogoutResponse>(
                 'https://kapi.kakao.com/v1/user/logout',

--- a/backend/src/auth/oauth/naver.service.ts
+++ b/backend/src/auth/oauth/naver.service.ts
@@ -57,7 +57,7 @@ export class NaverService implements OauthService {
         return data.response.id;
     }
 
-    async requestLogout(accessToken: string) {
+    async requestTokenExpiration(accessToken: string) {
         await firstValueFrom(
             this.httpService.post<requestLogoutResponse>(
                 `https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id=${this.CLIENT_ID}&client_secret=${this.CLIENT_SECRET}&access_token=${accessToken}&service_provider=NAVER`

--- a/backend/src/auth/oauth/oauth.service.interface.ts
+++ b/backend/src/auth/oauth/oauth.service.interface.ts
@@ -10,5 +10,5 @@ export interface OauthService {
 
     requestUserId(accessToken: string): Promise<string>;
 
-    requestLogout?(accessToken: string): Promise<void>;
+    requestTokenExpiration(accessToken: string): Promise<void>;
 }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
없는 줄 알았는데 token 삭제하는 api가 있어서 추가했다.
또 해당 service의 이름을 더 명확하게 변경했다. (requestLogout -> requestTokenExpiration)

## 링크 (Links)
https://www.notion.so/do0ori/oauth-logout-google-3cee27423fa54bd28f2088d20fcdc1e7

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
