### PR TITLE
backend/DANG-231: oauth deactivate 추가

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -51,8 +51,8 @@ export class AuthController {
     }
 
     @Delete('deactivate')
-    async deactivate(@User() { userId }: AccessTokenPayload, @Res({ passthrough: true }) response: Response) {
-        await this.authService.deactivate(userId);
+    async deactivate(@User() { userId, provider }: AccessTokenPayload, @Res({ passthrough: true }) response: Response) {
+        await this.authService.deactivate(userId, provider);
 
         response.clearCookie('refreshToken');
     }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -46,7 +46,15 @@ export class AuthService {
         await this[`${provider}Service`].requestTokenExpiration(oauthAccessToken);
     }
 
-    async deactivate(userId: number): Promise<void> {
+    async deactivate(userId: number, provider: OauthProvider): Promise<void> {
+        const { oauthAccessToken } = await this.usersService.findOne(userId);
+
+        if (provider === 'kakao') {
+            await this[`${provider}Service`].requestUnlink(oauthAccessToken);
+        } else {
+            await this[`${provider}Service`].requestTokenExpiration(oauthAccessToken);
+        }
+
         await this.usersService.remove(userId);
     }
 

--- a/backend/src/auth/oauth/kakao.service.ts
+++ b/backend/src/auth/oauth/kakao.service.ts
@@ -20,10 +20,6 @@ interface requestUserInfoResponse {
     app_id: number;
 }
 
-interface requestLogoutResponse {
-    id: number;
-}
-
 @Injectable()
 export class KakaoService implements OauthService {
     constructor(
@@ -70,8 +66,23 @@ export class KakaoService implements OauthService {
 
     async requestTokenExpiration(accessToken: string) {
         await firstValueFrom(
-            this.httpService.post<requestLogoutResponse>(
+            this.httpService.post<{ id: number }>(
                 'https://kapi.kakao.com/v1/user/logout',
+                {},
+                {
+                    headers: {
+                        Authorization: `Bearer ${accessToken}`,
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                }
+            )
+        );
+    }
+
+    async requestUnlink(accessToken: string) {
+        await firstValueFrom(
+            this.httpService.post<{ id: number }>(
+                'https://kapi.kakao.com/v1/user/unlink',
                 {},
                 {
                     headers: {

--- a/backend/src/auth/oauth/naver.service.ts
+++ b/backend/src/auth/oauth/naver.service.ts
@@ -20,11 +20,6 @@ interface requestUserInfoResponse {
     };
 }
 
-interface requestLogoutResponse {
-    access_token: string;
-    result: string;
-}
-
 @Injectable()
 export class NaverService implements OauthService {
     constructor(
@@ -59,7 +54,7 @@ export class NaverService implements OauthService {
 
     async requestTokenExpiration(accessToken: string) {
         await firstValueFrom(
-            this.httpService.post<requestLogoutResponse>(
+            this.httpService.post<{ access_token: string; result: string }>(
                 `https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id=${this.CLIENT_ID}&client_secret=${this.CLIENT_SECRET}&access_token=${accessToken}&service_provider=NAVER`
             )
         );


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
네이버와 구글은 로그아웃 로직 동일하게, 카카오는 연결 끊기 api를 활용해 oauth 탈퇴를 구현했다.
일단은 여전히 사용자를 table에서 실제로 삭제한다.

## 링크 (Links)
https://www.notion.so/do0ori/oauth-deactivate-d478a4c2e99c4fc4be61fec9269885f4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
