### PR TITLE
backend/DANG-243: 상대 경로인 redirectURI를 full path로 가공하는 코드 추가

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -29,6 +29,7 @@ export class AuthController {
         @Body('redirectURI') redirectURI: string,
         @Res({ passthrough: true }) response: Response
     ): Promise<loginResponse> {
+        redirectURI = `${this.configService.get<string>('CORS_ORIGIN')}${redirectURI}`;
         const { accessToken, refreshToken } = await this.authService.login(authorizeCode, provider, redirectURI);
 
         response.cookie('refreshToken', refreshToken, {


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
redirectURI가 full path인 줄 알고 그대로 넘겼는데 상대경로로 전달되는 관계로 redirectURI를 request body에서 꺼내서 앞에 cors origin을 붙여주는 코드를 추가했다.

## 링크 (Links)
https://www.notion.so/do0ori/redirect-uri-2c3f6f069b6b48a1bdb6bd7e25c628ba

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
