### PR TITLE
backend/DANG-246: health check api에 SkipAuthGuard 추가

### DIFF
--- a/backend/src/common/health/health.controller.ts
+++ b/backend/src/common/health/health.controller.ts
@@ -1,6 +1,8 @@
 import { Controller, Get } from '@nestjs/common';
+import { SkipAuthGuard } from 'src/auth/decorators/public.decorator';
 
 @Controller('health')
+@SkipAuthGuard()
 export class HealthController {
     @Get()
     check() {


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
AuthGuard를 global로 사용하면서 health check에도 적용이 되었다.
health check는 guard가 필요없기 때문에 decorator로 skip해주었다.

## 링크 (Links)
https://www.notion.so/do0ori/health-check-guard-skip-36863d67215d4f41972d2eb9a5d84e49

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
