### PR TITLE
backend/DANG-244: oauth token 갱신 추가

### DIFF
--- a/backend/src/auth/oauth/google.service.ts
+++ b/backend/src/auth/oauth/google.service.ts
@@ -23,6 +23,13 @@ interface requestUserInfoResponse {
     email_verified: string;
 }
 
+interface requestTokenRefreshResponse {
+    access_token: string;
+    expires_in: number;
+    scope: string;
+    token_type: string;
+}
+
 @Injectable()
 export class GoogleService implements OauthService {
     constructor(
@@ -69,5 +76,22 @@ export class GoogleService implements OauthService {
                 }
             )
         );
+    }
+
+    async requestTokenRefresh(refreshToken: string): Promise<{
+        access_token: string;
+        refresh_token?: string;
+        [key: string]: any;
+    }> {
+        const { data } = await firstValueFrom(
+            this.httpService.post<requestTokenRefreshResponse>(`https://oauth2.googleapis.com/token`, {
+                client_id: this.CLIENT_ID,
+                client_secret: this.CLIENT_SECRET,
+                grant_type: 'refresh_token',
+                refresh_token: refreshToken,
+            })
+        );
+
+        return data;
     }
 }

--- a/backend/src/auth/oauth/kakao.service.ts
+++ b/backend/src/auth/oauth/kakao.service.ts
@@ -20,6 +20,14 @@ interface requestUserInfoResponse {
     app_id: number;
 }
 
+interface requestTokenRefreshResponse {
+    token_type: string;
+    access_token: string;
+    expires_in: number;
+    refresh_token?: string;
+    refresh_token_expires_in?: number;
+}
+
 @Injectable()
 export class KakaoService implements OauthService {
     constructor(
@@ -92,5 +100,26 @@ export class KakaoService implements OauthService {
                 }
             )
         );
+    }
+
+    async requestTokenRefresh(refreshToken: string) {
+        const { data } = await firstValueFrom(
+            this.httpService.post<requestTokenRefreshResponse>(
+                'https://kauth.kakao.com/oauth/token',
+                {
+                    grant_type: 'refresh_token',
+                    client_id: this.CLIENT_ID,
+                    client_secret: this.CLIENT_SECRET,
+                    refresh_token: refreshToken,
+                },
+                {
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+                    },
+                }
+            )
+        );
+
+        return data;
     }
 }

--- a/backend/src/auth/oauth/naver.service.ts
+++ b/backend/src/auth/oauth/naver.service.ts
@@ -20,6 +20,12 @@ interface requestUserInfoResponse {
     };
 }
 
+interface requestTokenRefreshResponse {
+    access_token: string;
+    token_type: string;
+    expires_in: number;
+}
+
 @Injectable()
 export class NaverService implements OauthService {
     constructor(
@@ -32,7 +38,7 @@ export class NaverService implements OauthService {
 
     async requestToken(authorizeCode: string) {
         const { data } = await firstValueFrom(
-            this.httpService.post<requestTokenResponse>(
+            this.httpService.get<requestTokenResponse>(
                 `https://nid.naver.com/oauth2.0/token?grant_type=authorization_code&client_id=${this.CLIENT_ID}&client_secret=${this.CLIENT_SECRET}&code=${authorizeCode}&state=naverLoginState`
             )
         );
@@ -54,9 +60,23 @@ export class NaverService implements OauthService {
 
     async requestTokenExpiration(accessToken: string) {
         await firstValueFrom(
-            this.httpService.post<{ access_token: string; result: string }>(
+            this.httpService.get<{ access_token: string; result: string }>(
                 `https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id=${this.CLIENT_ID}&client_secret=${this.CLIENT_SECRET}&access_token=${accessToken}&service_provider=NAVER`
             )
         );
+    }
+
+    async requestTokenRefresh(refreshToken: string): Promise<{
+        access_token: string;
+        refresh_token?: string;
+        [key: string]: any;
+    }> {
+        const { data } = await firstValueFrom(
+            this.httpService.get<requestTokenRefreshResponse>(
+                `https://nid.naver.com/oauth2.0/token?grant_type=refresh_token&client_id=${this.CLIENT_ID}&client_secret=${this.CLIENT_SECRET}&refresh_token=${refreshToken}`
+            )
+        );
+
+        return data;
     }
 }

--- a/backend/src/auth/oauth/oauth.service.interface.ts
+++ b/backend/src/auth/oauth/oauth.service.interface.ts
@@ -11,4 +11,12 @@ export interface OauthService {
     requestUserId(accessToken: string): Promise<string>;
 
     requestTokenExpiration(accessToken: string): Promise<void>;
+
+    requestUnlink?(accessToken: string): Promise<void>;
+
+    requestTokenRefresh(refreshToken: string): Promise<{
+        access_token: string;
+        refresh_token?: string;
+        [key: string]: any;
+    }>;
 }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 각 oauth service에 토큰 재발급 요청을 보내 새로운 access/refresh token을 받는 `requestTokenRefresh`라는 method를 추가했다.
- 모두 기본적으로 새로운 access token을 발급해준다.
- refresh token은 provider마다 다르다.
  - kakao의 경우 refresh token의 만료 기간이 1개월 이내 일 경우에만 새로운 refresh token이 발급된다고 한다.
  - naver의 경우는 refresh token의 만료 기간을 늘려줄 뿐 새로운 refresh token을 발급해주지는 않는다. 처음에 발급받은 refresh token을 그대로 사용하면 된다.
  - google은 사용자가 access를 취소할 때까지 처음에 발급 받은 refresh token을 계속 사용할 수 있기 때문에 마찬가지로 따로 refresh token을 새로 발급해주지 않는다.

## 링크 (Links)
https://www.notion.so/do0ori/oauth-token-d1d639d2eb5040c1b638d5649ccb5cb6

## 기타 사항 (Etc)
전반적으로 refactoring을 할 예정

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
