### PR TITLE
backend/DANG-257: Users entity에서 oauthId field에 누락된 unique 조건 추가

### DIFF
--- a/backend/src/users/users.entity.ts
+++ b/backend/src/users/users.entity.ts
@@ -24,7 +24,7 @@ export class Users {
     @Column({ name: 'main_dog_id', nullable: true })
     mainDogId: number;
 
-    @Column({ name: 'oauth_id' })
+    @Column({ name: 'oauth_id', unique: true })
     oauthId: string;
 
     @Column({ name: 'oauth_access_token' })


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
로그인 요청이 2번 왔을 때 row가 2개 와서 문제 원인 파악을 하다가 발견했다.
근본적인 원인은 react의 `index.ts` 파일에서 [`<StrictMode>`](https://ko.react.dev/reference/react/StrictMode)를 사용으로 인해 요청이 2번 보내지는 것이었다.
로그인 테스트 때에는 해당 부분을 주석 처리하고 진행했다.


## 링크 (Links)
https://www.notion.so/do0ori/users-entity-oauthId-field-unique-4aca90171a3d45be963f8d0f592fdfd4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
