### PR TITLE
backend/DANG-249: oauth service refactoring

### DIFF
--- a/backend/src/auth/oauth/google.service.ts
+++ b/backend/src/auth/oauth/google.service.ts
@@ -56,9 +56,11 @@ export class GoogleService implements OauthService {
 
     async requestUserId(accessToken: string) {
         const { data } = await firstValueFrom(
-            this.httpService.get<requestUserInfoResponse>(
-                `https://oauth2.googleapis.com/tokeninfo?access_token=${accessToken}`
-            )
+            this.httpService.get<requestUserInfoResponse>('https://oauth2.googleapis.com/tokeninfo', {
+                params: {
+                    access_token: accessToken,
+                },
+            })
         );
 
         return data.sub;
@@ -67,11 +69,14 @@ export class GoogleService implements OauthService {
     async requestTokenExpiration(accessToken: string) {
         await firstValueFrom(
             this.httpService.post(
-                `https://oauth2.googleapis.com/revoke?token=${accessToken}`,
+                'https://oauth2.googleapis.com/revoke',
                 {},
                 {
                     headers: {
                         'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                    params: {
+                        token: accessToken,
                     },
                 }
             )

--- a/backend/src/auth/oauth/naver.service.ts
+++ b/backend/src/auth/oauth/naver.service.ts
@@ -38,9 +38,15 @@ export class NaverService implements OauthService {
 
     async requestToken(authorizeCode: string) {
         const { data } = await firstValueFrom(
-            this.httpService.get<requestTokenResponse>(
-                `https://nid.naver.com/oauth2.0/token?grant_type=authorization_code&client_id=${this.CLIENT_ID}&client_secret=${this.CLIENT_SECRET}&code=${authorizeCode}&state=naverLoginState`
-            )
+            this.httpService.get<requestTokenResponse>('https://nid.naver.com/oauth2.0/token', {
+                params: {
+                    grant_type: 'authorization_code',
+                    client_id: this.CLIENT_ID,
+                    client_secret: this.CLIENT_SECRET,
+                    code: authorizeCode,
+                    state: 'naverLoginState',
+                },
+            })
         );
 
         return data;
@@ -60,9 +66,15 @@ export class NaverService implements OauthService {
 
     async requestTokenExpiration(accessToken: string) {
         await firstValueFrom(
-            this.httpService.get<{ access_token: string; result: string }>(
-                `https://nid.naver.com/oauth2.0/token?grant_type=delete&client_id=${this.CLIENT_ID}&client_secret=${this.CLIENT_SECRET}&access_token=${accessToken}&service_provider=NAVER`
-            )
+            this.httpService.get<{ access_token: string; result: string }>(`https://nid.naver.com/oauth2.0/token`, {
+                params: {
+                    grant_type: 'delete',
+                    client_id: this.CLIENT_ID,
+                    client_secret: this.CLIENT_SECRET,
+                    access_token: accessToken,
+                    service_provider: 'NAVER',
+                },
+            })
         );
     }
 
@@ -72,9 +84,14 @@ export class NaverService implements OauthService {
         [key: string]: any;
     }> {
         const { data } = await firstValueFrom(
-            this.httpService.get<requestTokenRefreshResponse>(
-                `https://nid.naver.com/oauth2.0/token?grant_type=refresh_token&client_id=${this.CLIENT_ID}&client_secret=${this.CLIENT_SECRET}&refresh_token=${refreshToken}`
-            )
+            this.httpService.get<requestTokenRefreshResponse>(`https://nid.naver.com/oauth2.0/token`, {
+                params: {
+                    grant_type: 'refresh_token',
+                    client_id: this.CLIENT_ID,
+                    client_secret: this.CLIENT_SECRET,
+                    refresh_token: refreshToken,
+                },
+            })
         );
 
         return data;

--- a/backend/src/auth/oauth/oauth.service.interface.ts
+++ b/backend/src/auth/oauth/oauth.service.interface.ts
@@ -1,12 +1,15 @@
+interface RequestToken {
+    access_token: string;
+    refresh_token: string;
+    [key: string]: any;
+}
+
+export interface RequestTokenRefreshResponse extends Omit<RequestToken, 'refresh_token'> {
+    refresh_token?: string;
+}
+
 export interface OauthService {
-    requestToken(
-        authorizeCode: string,
-        redirectURI?: string
-    ): Promise<{
-        access_token: string;
-        refresh_token: string;
-        [key: string]: any;
-    }>;
+    requestToken(authorizeCode: string, redirectURI?: string): Promise<RequestToken>;
 
     requestUserId(accessToken: string): Promise<string>;
 
@@ -14,9 +17,5 @@ export interface OauthService {
 
     requestUnlink?(accessToken: string): Promise<void>;
 
-    requestTokenRefresh(refreshToken: string): Promise<{
-        access_token: string;
-        refresh_token?: string;
-        [key: string]: any;
-    }>;
+    requestTokenRefresh(refreshToken: string): Promise<RequestTokenRefreshResponse>;
 }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- url query string을 axios config의 params property를 이용해 가독성을 높였다.
  - naver의 경우 모든 값들을 url query로 넣어서 요청을 보내야 한다.😒
  - google의 경우 일부 api만 url query를 사용한다.
  - kakao는 깔끔하게 url query를 사용하지 않는다.
- hard coding되어 있던 oauth api url을 환경변수에서 관리하도록 변경했다.
- 타입 정의를 해둔 interface 파일도 수정했다.

## 링크 (Links)
https://www.notion.so/do0ori/oauth-service-refactoring-5274d41cd73d4771bbc687854dfb55e6

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
