### PR TITLE
backend/DANG-268: 전역에서 Auth 모듈 사용을 제거하기

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,7 +9,6 @@ import { APP_INTERCEPTOR } from '@nestjs/core';
 import { PrometheusInterceptor } from './common/interceptor/prometheus.interceptor';
 import { PrometheusModule } from '@willsoto/nestjs-prometheus';
 import { WinstonLoggerModule } from './common/logger/winstonLogger.module';
-import { AuthModule } from './auth/auth.module';
 import { FakeModule } from './fake/fake.module';
 import { DogsModule } from './dogs/dogs.module';
 import { WalkModule } from './walk/walk.module';
@@ -59,7 +58,6 @@ import { WalkLogPhotosModule } from './walk-log-photos/walk-log-photos.module';
         }),
         UsersModule,
         ConfigModule,
-        AuthModule,
         DogsModule,
         WalkModule,
         BreedModule,


### PR DESCRIPTION
## 작업 내용 (Content)
모든 요청의 UnauthorizedException 에러 발생으로 Auth 모듈을 제거했습니다.

## 링크 (Links)
- https://www.notion.so/do0ori/Auth-22597e846bda4c9aac64d68541342059?pvs=4
## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
