### PR TITLE
backend/DANG-270: 우리 서비스에 가입된 사용자인지 확인하는 api 추가 및 login logic 수정

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -17,14 +17,22 @@ export class AuthService {
         private readonly naverService: NaverService
     ) {}
 
+    async isMember(oauthAccessToken: string, provider: OauthProvider): Promise<boolean> {
+        const oauthId = await this[`${provider}Service`].requestUserId(oauthAccessToken);
+
+        try {
+            await this.usersService.findOneWithOauthId(oauthId);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
     async login(
-        authorizeCode: string,
-        provider: OauthProvider,
-        redirectURI: string
+        oauthAccessToken: string,
+        oauthRefreshToken: string,
+        provider: OauthProvider
     ): Promise<{ accessToken: string; refreshToken: string }> {
-        const { access_token: oauthAccessToken, refresh_token: oauthRefreshToken } = await this[
-            `${provider}Service`
-        ].requestToken(authorizeCode, redirectURI);
         const oauthId = await this[`${provider}Service`].requestUserId(oauthAccessToken);
 
         const refreshToken = this.tokenService.signRefreshToken(oauthId, provider);


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
우리 서비스에 가입된 사용자가 아니라면 동의화면을 보여줘야 하므로 이를 확인하는 api가 필요하다. 인가 코드는 일회용이기 때문에 사용자 인지 확인한 후 로그인 때 재사용할 수가 없으므로 frontend에서 oauth access/refresh token까지 발급받기로 logic를 수정했다.

[회원 API 문서 참고](https://www.notion.so/do0ori/ac3c2402d85c4ac6a8160a232e825071?v=7a0568c6172c446cb41ea419db93e3c3)

## 링크 (Links)
https://www.notion.so/do0ori/is-member-api-login-logic-0655a8398c5e4006936d5b0d0fca6f64

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
