### PR TITLE
backend/DANG-289: access token 수명을 12h에서 1h로 변경

### DIFF
--- a/backend/src/auth/token/token.service.ts
+++ b/backend/src/auth/token/token.service.ts
@@ -21,7 +21,7 @@ type TokenExpiryMap = {
 };
 
 export const TOKEN_LIFETIME_MAP: TokenExpiryMap = {
-    access: { expiresIn: '12h', maxAge: 12 * 60 * 60 * 1000 },
+    access: { expiresIn: '1h', maxAge: 1 * 60 * 60 * 1000 },
     refresh: { expiresIn: '14d', maxAge: 14 * 24 * 60 * 60 * 1000 },
 };
 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- OAuth에서 발급해주는 access token의 수명을 조사해 본 결과 다음과 같다.
  - Google: 1시간
  - Kakao: 6시간
  - Naver: 1시간
- OAuth access token도 만료되기 전에 갱신을 해주는 것이 좋기 때문에 우리 token을 갱신할 때 OAuth token도 갱신할 수 있도록 수명을 OAuth token의 최소 수명에 맞추기로 한다.

## 링크 (Links)
https://www.notion.so/do0ori/access-token-1-495b8ff4ab324b23bd96ec33800b8d86

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
