### PR TITLE
backend/DANG-245: test skip되는 문제 해결

### DIFF
--- a/.github/workflows/pr_labeler_validator.yaml
+++ b/.github/workflows/pr_labeler_validator.yaml
@@ -10,6 +10,8 @@ jobs:
       contents: read
       pull-requests: write
     runs-on: ubuntu-latest
+    env:
+      IS_VALID_TRIGGER: ${{ github.event.action == 'opened' || github.event.changes.title.from }}
     steps:
       - name: Add labels to PR
         id: labeler
@@ -18,12 +20,11 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check branch name format
-        if: github.event.action == 'opened' || github.event.changes.title.from
         run: |
           branch_name=$(echo "${{ github.event.pull_request.head.ref }}")
+          echo "branch_name=$branch_name" >> "$GITHUB_ENV"
           if [[ ! $branch_name =~ ^(frontend|backend|infra)\/DANG-[1-9][0-9]*$ ]]; then
             echo "is_invalid_branch_name=true" >> "$GITHUB_ENV"
-            echo "branch_name=$branch_name" >> "$GITHUB_ENV"
           fi
 
       - name: Add comment for invalid branch name
@@ -45,24 +46,27 @@ jobs:
                             "    backend/DANG-2\n" +
                             "    infra/DANG-3\n" +
                             "```";
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: message
-            });
+            const isValidTrigger = process.env.IS_VALID_TRIGGER;
+            if (isValidTrigger) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: message
+              });
+            }
 
             core.setFailed("Branch Naming Convention 위반");
 
       - name: Check PR title format
-        if: github.event.action == 'opened' || github.event.changes.title.from
+        env:
+          BRANCH_NAME: ${{ env.branch_name }}
         run: |
-          branch_name=$(echo "${{ github.event.pull_request.head.ref }}")
-          title_regex="^${branch_name}: .+$"
+          title_regex="^${BRANCH_NAME}: .+$"
           pr_title="${{ github.event.pull_request.title }}"
+          echo "pr_title=$pr_title" >> "$GITHUB_ENV"
           if [[ ! $pr_title =~ $title_regex ]]; then
             echo "is_invalid_title=true" >> "$GITHUB_ENV"
-            echo "pr_title=$pr_title" >> "$GITHUB_ENV"
           fi
 
       - name: Add comment for invalid PR title
@@ -84,11 +88,14 @@ jobs:
                             "    backend/DANG-2: PR에서 수행한 작업 간략히 설명\n" +
                             "    infra/DANG-3: PR에서 수행한 작업 간략히 설명\n" +
                             "```";
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-              body: message
-            });
+            const isValidTrigger = process.env.IS_VALID_TRIGGER;
+            if (isValidTrigger) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: message
+              });
+            }
 
             core.setFailed("PR Title Convention 위반");


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
현재는 branch 이름 검사와 PR title 형식 검사가 PR이 열렸을 때 그리고 title이 수정되었을 때에만 trigger된다.
PR 본문을 수정했을 때 불필요한 검사가 실행되는 것을 방지할 수는 있지만 형식을 지키지 않았을 때에도 skip되는 문제가 있다.
이를 방지하기 위해 message를 보낼 때에만 조건을 넣어서 해결했다.

## 링크 (Links)
https://www.notion.so/do0ori/GitHub-Actions-labeler-and-validator-020875f9da2044bab42658612a885613

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
