### PR TITLE
infra/DANG-292: 컨테이너 정리 명령 수정 및 ECR 빌드/배포 스테이지 명칭 변경

### DIFF
--- a/.github/workflows/backend_deploy.yaml
+++ b/.github/workflows/backend_deploy.yaml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    name: build
+    name: ECR Build
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -62,13 +62,10 @@ jobs:
     needs: build
     runs-on: [ self-hosted, label-api ]
     steps:
-      - name: Create .env.prod
-        run: |      
-          echo "${{ secrets.ENV_PROD_FILE }}" >> .env.prod
       - name: Deploy to Amazon EC2
         run : |
-          docker ps -q --filter "name=${{ env.IMAGE }}" | grep -q . && docker stop ${{ env.IMAGE }} && docker container prune -f
+          docker ps -q --filter "name=${{ env.IMAGE }}" | grep -q . && docker stop ${{ env.IMAGE }} && && docker rm -fv ${{ env.IMAGE }}
           aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{ env.REPO }}
           docker pull ${{ env.REPO }}/${{ env.IMAGE }}:${{ env.TAG }}
           docker run -d --name ${{ env.IMAGE }} --restart always -p 3031:3031 --env-file .env.prod ${{ env.REPO }}/${{ env.IMAGE }}:${{ env.TAG }} 
-          docker image prune -a --filter "until=1h" -f
+          docker image prune -af

--- a/.github/workflows/frontend_deploy.yaml
+++ b/.github/workflows/frontend_deploy.yaml
@@ -58,13 +58,14 @@ jobs:
           docker tag ${{ env.IMAGE }} ${{ env.REPO }}/${{ env.IMAGE }}:${{ env.TAG }}
           docker push ${{ env.REPO }}/${{ env.IMAGE}}:${{ env.TAG }}
   deploy:
+    name: ECR Deploy
     needs: build
     runs-on: [ self-hosted, label-front ]
     steps:
       - name: Deploy to Amazon EC2
         run : |
-          docker ps -q --filter "name=${{ env.IMAGE }}" | grep -q . && docker stop ${{ env.IMAGE }} && docker container prune -f
+          docker ps -q --filter "name=${{ env.IMAGE }}" | grep -q . && docker stop ${{ env.IMAGE }} && && docker rm -fv ${{ env.IMAGE }}
           aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{ env.REPO }}
           docker pull ${{ env.REPO }}/${{ env.IMAGE }}:${{ env.TAG }}
           docker run -d --name ${{ env.IMAGE }} --restart always -p 3000:3000 ${{ env.REPO }}/${{ env.IMAGE }}:${{ env.TAG }}
-          docker image prune -a --filter "until=1h" -f
+          docker image prune -af


### PR DESCRIPTION
## 작업 내용 (Content)
컨테이너 정리 명령 수정
- 이전에는 docker container prune -f 명령을 사용하여 실행 중이지 않는 컨테이너를 제거했습니다.
- 이번 커밋에서는 명령을 docker rm -fv 로 변경하여 정지된 컨테이너뿐만 아니라 볼륨 정보까지 제거하도록 했습니다. ECR 빌드/배포 스테이지 명칭 변경
- 이전 스테이지 명칭은 단순히 build 또는 deploy였습니다.
- 이번 커밋에서는 명확성을 위해 각 스테이지 이름을 ECR Build와 ECR Deploy로 변경했습니다.

## 링크 (Links)
- https://www.notion.so/do0ori/GitAction-Docker-Build-name-4454514143ad43158168920155d5e1ab?pvs=4
## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] CI 파이프라인이 통과가 되었나요?
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
