### PR TITLE
backend/DANG-301: token 수명 하드 코딩 제거

### DIFF
--- a/backend/src/auth/token/token.service.ts
+++ b/backend/src/auth/token/token.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { OauthProvider } from '../auth.controller';
+import { parse } from 'src/utils/ms.utils';
 
 export interface AccessTokenPayload {
     userId: number;
@@ -20,9 +21,12 @@ type TokenExpiryMap = {
     };
 };
 
+const ACCESS_TOKEN_LIFETIME = process.env.ACCESS_TOKEN_LIFETIME || '1h';
+const REFRESH_TOKEN_LIFETIME = process.env.REFRESH_TOKEN_LIFETIME || '14d';
+
 export const TOKEN_LIFETIME_MAP: TokenExpiryMap = {
-    access: { expiresIn: '1h', maxAge: 1 * 60 * 60 * 1000 },
-    refresh: { expiresIn: '14d', maxAge: 14 * 24 * 60 * 60 * 1000 },
+    access: { expiresIn: ACCESS_TOKEN_LIFETIME, maxAge: parse(ACCESS_TOKEN_LIFETIME) },
+    refresh: { expiresIn: REFRESH_TOKEN_LIFETIME, maxAge: parse(REFRESH_TOKEN_LIFETIME) },
 };
 
 @Injectable()

--- a/backend/src/utils/ms.utils.spec.ts
+++ b/backend/src/utils/ms.utils.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * Modified from https://github.com/vercel/ms/blob/main/src/parse.test.ts
+ */
+
+import { parse } from './ms.utils';
+
+describe('parse(string)', () => {
+    it('should not throw an error', () => {
+        expect(() => {
+            parse('1m');
+        }).not.toThrow();
+    });
+
+    it('should preserve ms', () => {
+        expect(parse('100')).toBe(100);
+    });
+
+    it('should convert from m to ms', () => {
+        expect(parse('1m')).toBe(60000);
+    });
+
+    it('should convert from h to ms', () => {
+        expect(parse('1h')).toBe(3600000);
+    });
+
+    it('should convert d to ms', () => {
+        expect(parse('2d')).toBe(172800000);
+    });
+
+    it('should convert w to ms', () => {
+        expect(parse('3w')).toBe(1814400000);
+    });
+
+    it('should convert s to ms', () => {
+        expect(parse('1s')).toBe(1000);
+    });
+
+    it('should convert ms to ms', () => {
+        expect(parse('100ms')).toBe(100);
+    });
+
+    it('should convert y to ms', () => {
+        expect(parse('1y')).toBe(31557600000);
+    });
+
+    it('should work with ms', () => {
+        expect(parse('1.5h')).toBe(5400000);
+    });
+
+    it('should work with multiple spaces', () => {
+        expect(parse('1   s')).toBe(1000);
+    });
+
+    it('should return NaN if invalid', () => {
+        expect(isNaN(parse('☃'))).toBe(true);
+        expect(isNaN(parse('10-.5'))).toBe(true);
+        expect(isNaN(parse('foo'))).toBe(true);
+    });
+
+    it('should be case-insensitive', () => {
+        expect(parse('1.5H')).toBe(5400000);
+    });
+
+    it('should work with numbers starting with .', () => {
+        expect(parse('.5ms')).toBe(0.5);
+    });
+
+    it('should work with negative integers', () => {
+        expect(parse('-100ms')).toBe(-100);
+    });
+
+    it('should work with negative decimals', () => {
+        expect(parse('-1.5h')).toBe(-5400000);
+        expect(parse('-10.5h')).toBe(-37800000);
+    });
+
+    it('should work with negative decimals starting with "."', () => {
+        expect(parse('-.5h')).toBe(-1800000);
+    });
+});
+
+// long strings
+
+describe('parse(long string)', () => {
+    it('should not throw an error', () => {
+        expect(() => {
+            parse('53 milliseconds');
+        }).not.toThrow();
+    });
+
+    it('should convert milliseconds to ms', () => {
+        expect(parse('53 milliseconds')).toBe(53);
+    });
+
+    it('should convert msecs to ms', () => {
+        expect(parse('17 msecs')).toBe(17);
+    });
+
+    it('should convert sec to ms', () => {
+        expect(parse('1 sec')).toBe(1000);
+    });
+
+    it('should convert from min to ms', () => {
+        expect(parse('1 min')).toBe(60000);
+    });
+
+    it('should convert from hr to ms', () => {
+        expect(parse('1 hr')).toBe(3600000);
+    });
+
+    it('should convert days to ms', () => {
+        expect(parse('2 days')).toBe(172800000);
+    });
+
+    it('should convert weeks to ms', () => {
+        expect(parse('1 week')).toBe(604800000);
+    });
+
+    it('should convert years to ms', () => {
+        expect(parse('1 year')).toBe(31557600000);
+    });
+
+    it('should work with decimals', () => {
+        expect(parse('1.5 hours')).toBe(5400000);
+    });
+
+    it('should work with negative integers', () => {
+        expect(parse('-100 milliseconds')).toBe(-100);
+    });
+
+    it('should work with negative decimals', () => {
+        expect(parse('-1.5 hours')).toBe(-5400000);
+    });
+
+    it('should work with negative decimals starting with "."', () => {
+        expect(parse('-.5 hr')).toBe(-1800000);
+    });
+});
+
+// invalid inputs
+
+describe('parse(invalid inputs)', () => {
+    it('should throw an error, when parse("")', () => {
+        expect(() => {
+            parse('');
+        }).toThrow();
+    });
+
+    it('should throw an error, when parse(undefined)', () => {
+        expect(() => {
+            // @ts-expect-error - We expect this to throw.
+            parse(undefined);
+        }).toThrow();
+    });
+
+    it('should throw an error, when parse(null)', () => {
+        expect(() => {
+            // @ts-expect-error - We expect this to throw.
+            parse(null);
+        }).toThrow();
+    });
+
+    it('should throw an error, when parse([])', () => {
+        expect(() => {
+            // @ts-expect-error - We expect this to throw.
+            parse([]);
+        }).toThrow();
+    });
+
+    it('should throw an error, when parse({})', () => {
+        expect(() => {
+            // @ts-expect-error - We expect this to throw.
+            parse({});
+        }).toThrow();
+    });
+
+    it('should throw an error, when parse(NaN)', () => {
+        expect(() => {
+            // @ts-expect-error - We expect this to throw.
+            parse(NaN);
+        }).toThrow();
+    });
+
+    it('should throw an error, when parse(Infinity)', () => {
+        expect(() => {
+            // @ts-expect-error - We expect this to throw.
+            parse(Infinity);
+        }).toThrow();
+    });
+
+    it('should throw an error, when parse(-Infinity)', () => {
+        expect(() => {
+            // @ts-expect-error - We expect this to throw.
+            parse(-Infinity);
+        }).toThrow();
+    });
+});

--- a/backend/src/utils/ms.utils.ts
+++ b/backend/src/utils/ms.utils.ts
@@ -1,0 +1,146 @@
+/**
+ * Modified from https://github.com/vercel/ms/blob/main/src/index.ts
+ */
+
+// Helpers.
+const s = 1000;
+const m = s * 60;
+const h = m * 60;
+const d = h * 24;
+const w = d * 7;
+const y = d * 365.25;
+
+type Unit =
+    | 'Years'
+    | 'Year'
+    | 'Yrs'
+    | 'Yr'
+    | 'Y'
+    | 'Weeks'
+    | 'Week'
+    | 'W'
+    | 'Days'
+    | 'Day'
+    | 'D'
+    | 'Hours'
+    | 'Hour'
+    | 'Hrs'
+    | 'Hr'
+    | 'H'
+    | 'Minutes'
+    | 'Minute'
+    | 'Mins'
+    | 'Min'
+    | 'M'
+    | 'Seconds'
+    | 'Second'
+    | 'Secs'
+    | 'Sec'
+    | 's'
+    | 'Milliseconds'
+    | 'Millisecond'
+    | 'Msecs'
+    | 'Msec'
+    | 'Ms';
+
+type UnitAnyCase = Unit | Uppercase<Unit> | Lowercase<Unit>;
+
+export type StringValue = `${number}` | `${number}${UnitAnyCase}` | `${number} ${UnitAnyCase}`;
+
+/**
+ * Parse or format the given value.
+ *
+ * @param value - The string or number to convert
+ * @throws Error if `value` is not a non-empty string or a number
+ */
+function msFn(value: StringValue): number {
+    try {
+        if (typeof value === 'string') return parse(value);
+        throw new Error('Value provided to ms() must be a string or number.');
+    } catch (error) {
+        const message = isError(error)
+            ? `${error.message}. value=${JSON.stringify(value)}`
+            : 'An unknown error has occurred.';
+        throw new Error(message);
+    }
+}
+
+/**
+ * Parse the given string and return milliseconds.
+ *
+ * @param str - A string to parse to milliseconds
+ * @returns The parsed value in milliseconds, or `NaN` if the string can't be
+ * parsed
+ */
+export function parse(str: string): number {
+    if (typeof str !== 'string' || str.length === 0 || str.length > 100) {
+        throw new Error('Value provided to ms.parse() must be a string with length between 1 and 99.');
+    }
+    const match =
+        /^(?<value>-?(?:\d+)?\.?\d+) *(?<type>milliseconds?|msecs?|ms|seconds?|secs?|s|minutes?|mins?|m|hours?|hrs?|h|days?|d|weeks?|w|years?|yrs?|y)?$/i.exec(
+            str
+        );
+    // Named capture groups need to be manually typed today.
+    // https://github.com/microsoft/TypeScript/issues/32098
+    const groups = match?.groups as { value: string; type?: string } | undefined;
+    if (!groups) {
+        return NaN;
+    }
+    const n = parseFloat(groups.value);
+    const type = (groups.type || 'ms').toLowerCase() as Lowercase<Unit>;
+    switch (type) {
+        case 'years':
+        case 'year':
+        case 'yrs':
+        case 'yr':
+        case 'y':
+            return n * y;
+        case 'weeks':
+        case 'week':
+        case 'w':
+            return n * w;
+        case 'days':
+        case 'day':
+        case 'd':
+            return n * d;
+        case 'hours':
+        case 'hour':
+        case 'hrs':
+        case 'hr':
+        case 'h':
+            return n * h;
+        case 'minutes':
+        case 'minute':
+        case 'mins':
+        case 'min':
+        case 'm':
+            return n * m;
+        case 'seconds':
+        case 'second':
+        case 'secs':
+        case 'sec':
+        case 's':
+            return n * s;
+        case 'milliseconds':
+        case 'millisecond':
+        case 'msecs':
+        case 'msec':
+        case 'ms':
+            return n;
+        default:
+            // This should never occur.
+            throw new Error(`The unit ${type as string} was matched, but no matching case exists.`);
+    }
+}
+
+export default msFn;
+
+/**
+ * A type guard for errors.
+ *
+ * @param value - The value to test
+ * @returns A boolean `true` if the provided value is an Error-like object
+ */
+function isError(value: unknown): value is Error {
+    return typeof value === 'object' && value !== null && 'message' in value;
+}


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
token 수명을 환경변수에 추가했다.
수명을 miliseconds로 변환하기 위해 utils에 vercel/ms 오픈소스에서 필요한 parse 함수만 가져와 수정해 추가했다.

## 링크 (Links)
https://www.notion.so/do0ori/token-944841d12a5c42ecbffd983d33ddbf25

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
