### PR TITLE
infra/DANG-323: 백엔드 배포 워크플로우 서버 포트 동일하게 하게 하기

### DIFF
--- a/.github/workflows/backend_deploy.yaml
+++ b/.github/workflows/backend_deploy.yaml
@@ -1,4 +1,4 @@
-name: ECR Prod Backend Deploy
+name: Backend Deploy
 
 on:
   push:
@@ -64,17 +64,13 @@ jobs:
     needs: build
     runs-on: [ self-hosted, label-api ]
     steps:
-      - name: Create .env.file
-        run : |
-          echo "${{ secrets.ENV_TEST_FILE1 }}" >> .env.prod1
-          echo "${{ secrets.ENV_TEST_FILE2 }}" >> .env.prod2
       - name: Deploy to Amazon EC2
         run : | 
           aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{ env.REPO }}
           docker ps -q --filter "name=${{ env.CONTAINER_NAME1 }}" | grep -q . && docker stop ${{ env.CONTAINER_NAME1 }} && docker rm ${{ env.CONTAINER_NAME1 }}
           docker pull ${{ env.REPO }}/${{ env.IMAGE }}:${{ env.TAG }}
-          docker run -d --name ${{ env.CONTAINER_NAME1 }} --restart always -p 3031:3031 --env-file .env.prod1 ${{ env.REPO }}/${{ env.IMAGE }}:${{ env.TAG }}
+          docker run -d --name ${{ env.CONTAINER_NAME1 }} --restart always -p 3031:3031 --env-file .env.prod ${{ env.REPO }}/${{ env.IMAGE }}:${{ env.TAG }}
           docker ps -q --filter "name=${{ env.CONTAINER_NAME2 }}" | grep -q . && docker stop ${{ env.CONTAINER_NAME2 }} && docker rm ${{ env.CONTAINER_NAME2 }}
           docker pull ${{ env.REPO }}/${{ env.IMAGE }}:${{ env.TAG }}
-          docker run -d --name ${{ env.CONTAINER_NAME2 }} --restart always -p 3032:3032 --env-file .env.prod2 ${{ env.REPO }}/${{ env.IMAGE }}:${{ env.TAG }} 
+          docker run -d --name ${{ env.CONTAINER_NAME2 }} --restart always -p 3032:3031 --env-file .env.prod ${{ env.REPO }}/${{ env.IMAGE }}:${{ env.TAG }} 
           docker image prune -af


### PR DESCRIPTION
## 작업 내용 (Content)
컨테이너 포트 수정 이전에는 두 번째 백엔드 컨테이너의 포트가 3032였으나, 3031로 수정되었습니다.
두 컨테이너는 동일한 서비스를 제공하므로 동일한 포트를 사용해야 합니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
