### PR TITLE
frontend/DANG-322: LoginBottomSheet 관련 로직 수정

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,11 +3,11 @@ import Navbar from './components/Navbar';
 import React, { useEffect, useRef } from 'react';
 import queryClient from './api/queryClient';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { useModalStateStore } from './store/modalStateStore';
+import { useLoginModalStateStore } from './store/modalStateStore';
 import LoginModal from '@/components/LoginModal';
 var console;
 function App() {
-    const { isModalOpen, isJoinning, setModalState } = useModalStateStore();
+    const { isLoginModalOpen: isModalOpen, isJoinning, setLoginModalState: setModalState } = useLoginModalStateStore();
     const outletRef = useRef<HTMLDivElement>(null);
     //TODO: 일시적인 배포시 console.log 제거 추가로 환경설정으로 빼줘야함ㄴ
     if (process.env.NODE_ENV === 'production') {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,7 +7,7 @@ import { useLoginModalStateStore } from './store/modalStateStore';
 import LoginModal from '@/components/LoginModal';
 var console;
 function App() {
-    const { isLoginModalOpen: isModalOpen, isJoinning, setLoginModalState: setModalState } = useLoginModalStateStore();
+    const { isLoginModalOpen, isJoinning, setLoginModalState } = useLoginModalStateStore();
     const outletRef = useRef<HTMLDivElement>(null);
     //TODO: 일시적인 배포시 console.log 제거 추가로 환경설정으로 빼줘야함ㄴ
     if (process.env.NODE_ENV === 'production') {
@@ -18,15 +18,15 @@ function App() {
     }
     useEffect(() => {
         if (outletRef.current) {
-            outletRef.current.addEventListener('click', () => setModalState(false));
+            outletRef.current.addEventListener('click', () => setLoginModalState(false));
         }
 
         return () => {
             if (outletRef.current) {
-                outletRef.current.removeEventListener('click', () => setModalState(false));
+                outletRef.current.removeEventListener('click', () => setLoginModalState(false));
             }
         };
-    }, [setModalState]);
+    }, [setLoginModalState]);
     return (
         <QueryClientProvider client={queryClient}>
             <div className="flex flex-col">
@@ -40,7 +40,7 @@ function App() {
                 )}
                 {!isJoinning && (
                     <div
-                        className={`fixed z-20 w-full duration-300 ${isModalOpen ? ' translate-y-72' : 'translate-y-full'}`}
+                        className={`fixed z-20 w-full duration-300 ${isLoginModalOpen ? ' translate-y-72' : 'translate-y-full'}`}
                     >
                         <LoginModal />
                     </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,11 +3,11 @@ import Navbar from './components/Navbar';
 import React, { useEffect, useRef } from 'react';
 import queryClient from './api/queryClient';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { useLoginModalStateStore } from './store/modalStateStore';
-import LoginModal from '@/components/LoginModal';
+import { useLoginBottomSheetStateStore } from './store/modalStateStore';
+import LoginBottomSheet from '@/components/LoginBottomSheet';
 var console;
 function App() {
-    const { isLoginModalOpen, isJoinning, setLoginModalState } = useLoginModalStateStore();
+    const { isLoginBottomSheetOpen, isJoinning, setLoginBottomSheetState } = useLoginBottomSheetStateStore();
     const outletRef = useRef<HTMLDivElement>(null);
     //TODO: 일시적인 배포시 console.log 제거 추가로 환경설정으로 빼줘야함ㄴ
     if (process.env.NODE_ENV === 'production') {
@@ -18,15 +18,15 @@ function App() {
     }
     useEffect(() => {
         if (outletRef.current) {
-            outletRef.current.addEventListener('click', () => setLoginModalState(false));
+            outletRef.current.addEventListener('click', () => setLoginBottomSheetState(false));
         }
 
         return () => {
             if (outletRef.current) {
-                outletRef.current.removeEventListener('click', () => setLoginModalState(false));
+                outletRef.current.removeEventListener('click', () => setLoginBottomSheetState(false));
             }
         };
-    }, [setLoginModalState]);
+    }, [setLoginBottomSheetState]);
     return (
         <QueryClientProvider client={queryClient}>
             <div className="flex flex-col">
@@ -40,9 +40,9 @@ function App() {
                 )}
                 {!isJoinning && (
                     <div
-                        className={`fixed z-20 w-full duration-300 ${isLoginModalOpen ? ' translate-y-72' : 'translate-y-full'}`}
+                        className={`fixed z-20 w-full duration-300 ${isLoginBottomSheetOpen ? ' translate-y-72' : 'translate-y-full'}`}
                     >
-                        <LoginModal />
+                        <LoginBottomSheet />
                     </div>
                 )}
             </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,14 @@
 import { Outlet } from 'react-router-dom';
 import Navbar from './components/Navbar';
-import { useState } from 'react';
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import queryClient from './api/queryClient';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useModalStateStore } from './store/modalStateStore';
 import LoginModal from '@/components/LoginModal';
 var console;
 function App() {
-    const [isLoginModalOpen] = useState(true);
-    const { isModalOpen } = useModalStateStore();
+    const { isModalOpen, isJoinning, setModalState } = useModalStateStore();
+    const outletRef = useRef<HTMLDivElement>(null);
     //TODO: 일시적인 배포시 console.log 제거 추가로 환경설정으로 빼줘야함ㄴ
     if (process.env.NODE_ENV === 'production') {
         console = window.console || {};
@@ -17,19 +16,35 @@ function App() {
         console.warn = function no_console() {};
         console.error = function () {};
     }
+    useEffect(() => {
+        if (outletRef.current) {
+            outletRef.current.addEventListener('click', () => setModalState(false));
+        }
+
+        return () => {
+            if (outletRef.current) {
+                outletRef.current.removeEventListener('click', () => setModalState(false));
+            }
+        };
+    }, [setModalState]);
     return (
         <QueryClientProvider client={queryClient}>
             <div className="flex flex-col">
-                <Outlet />
-                <div className={`fixed z-10`}>
-                    <Navbar isLoginModalOpen={isLoginModalOpen} />
+                <div ref={outletRef}>
+                    <Outlet />
                 </div>
-
-                <div
-                    className={`fixed z-20 w-full duration-300 ${isModalOpen ? 'translate-y-72' : 'translate-y-full'}`}
-                >
-                    <LoginModal />
-                </div>
+                {!isJoinning && (
+                    <div className={`fixed z-10`}>
+                        <Navbar />
+                    </div>
+                )}
+                {!isJoinning && (
+                    <div
+                        className={`fixed z-20 w-full duration-300 ${isModalOpen ? ' translate-y-72' : 'translate-y-full'}`}
+                    >
+                        <LoginModal />
+                    </div>
+                )}
             </div>
         </QueryClientProvider>
     );

--- a/frontend/src/components/LoginAlertModal.tsx
+++ b/frontend/src/components/LoginAlertModal.tsx
@@ -3,10 +3,10 @@ import LoginButton from '@/assets/icons/btn-login.svg';
 import { useLoginModalStateStore } from '@/store/modalStateStore';
 
 export default function LoginAlertModal() {
-    const { isLoginModalOpen: isModalOpen, setLoginModalState: setModalState } = useLoginModalStateStore();
+    const { isLoginModalOpen, setLoginModalState: setModalState } = useLoginModalStateStore();
     return (
-        <div className={`flex flex-col w-full h-dvh fixed ${isModalOpen && 'bg-neutral-800/40'}`}>
-            {!isModalOpen && (
+        <div className={`flex flex-col w-full h-dvh fixed ${isLoginModalOpen && 'bg-neutral-800/40'}`}>
+            {!isLoginModalOpen && (
                 <section
                     className={`top-0 left-0 w-full flex flex-col items-center justify-center h-full mb-[3.75rem]`}
                 >

--- a/frontend/src/components/LoginAlertModal.tsx
+++ b/frontend/src/components/LoginAlertModal.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import LoginButton from '@/assets/icons/btn-login.svg';
-import { useLoginModalStateStore } from '@/store/modalStateStore';
+import { useLoginBottomSheetStateStore } from '@/store/modalStateStore';
 
 export default function LoginAlertModal() {
-    const { isLoginModalOpen, setLoginModalState } = useLoginModalStateStore();
+    const { isLoginBottomSheetOpen: isLoginModalOpen, setLoginBottomSheetState } = useLoginBottomSheetStateStore();
     return (
         <div className={`flex flex-col w-full h-dvh fixed ${isLoginModalOpen && 'bg-neutral-800/40'}`}>
             {!isLoginModalOpen && (
@@ -14,7 +14,7 @@ export default function LoginAlertModal() {
                     <p className="text-stone-500 font-['NanumGothic'] text-xs font-semibold mb-3">
                         댕댕워크 산책기능은 회원에게만 제공됩니다
                     </p>
-                    <button onClick={() => setLoginModalState(true)}>
+                    <button onClick={() => setLoginBottomSheetState(true)}>
                         <img src={LoginButton} alt="Login" />
                     </button>
                 </section>

--- a/frontend/src/components/LoginAlertModal.tsx
+++ b/frontend/src/components/LoginAlertModal.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import LoginButton from '@/assets/icons/btn-login.svg';
-import { useModalStateStore } from '@/store/modalStateStore';
+import { useLoginModalStateStore } from '@/store/modalStateStore';
 
 export default function LoginAlertModal() {
-    const { isModalOpen, setModalState } = useModalStateStore();
+    const { isLoginModalOpen: isModalOpen, setLoginModalState: setModalState } = useLoginModalStateStore();
     return (
         <div className={`flex flex-col w-full h-dvh fixed ${isModalOpen && 'bg-neutral-800/40'}`}>
             {!isModalOpen && (

--- a/frontend/src/components/LoginAlertModal.tsx
+++ b/frontend/src/components/LoginAlertModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import LoginButton from '@/assets/icons/btn-login.svg';
 import { useModalStateStore } from '@/store/modalStateStore';
 

--- a/frontend/src/components/LoginAlertModal.tsx
+++ b/frontend/src/components/LoginAlertModal.tsx
@@ -3,10 +3,10 @@ import LoginButton from '@/assets/icons/btn-login.svg';
 import { useLoginBottomSheetStateStore } from '@/store/modalStateStore';
 
 export default function LoginAlertModal() {
-    const { isLoginBottomSheetOpen: isLoginModalOpen, setLoginBottomSheetState } = useLoginBottomSheetStateStore();
+    const { isLoginBottomSheetOpen, setLoginBottomSheetState } = useLoginBottomSheetStateStore();
     return (
-        <div className={`flex flex-col w-full h-dvh fixed ${isLoginModalOpen && 'bg-neutral-800/40'}`}>
-            {!isLoginModalOpen && (
+        <div className={`flex flex-col w-full h-dvh fixed ${isLoginBottomSheetOpen && 'bg-neutral-800/40'}`}>
+            {!isLoginBottomSheetOpen && (
                 <section
                     className={`top-0 left-0 w-full flex flex-col items-center justify-center h-full mb-[3.75rem]`}
                 >

--- a/frontend/src/components/LoginAlertModal.tsx
+++ b/frontend/src/components/LoginAlertModal.tsx
@@ -3,7 +3,7 @@ import LoginButton from '@/assets/icons/btn-login.svg';
 import { useLoginModalStateStore } from '@/store/modalStateStore';
 
 export default function LoginAlertModal() {
-    const { isLoginModalOpen, setLoginModalState: setModalState } = useLoginModalStateStore();
+    const { isLoginModalOpen, setLoginModalState } = useLoginModalStateStore();
     return (
         <div className={`flex flex-col w-full h-dvh fixed ${isLoginModalOpen && 'bg-neutral-800/40'}`}>
             {!isLoginModalOpen && (
@@ -14,7 +14,7 @@ export default function LoginAlertModal() {
                     <p className="text-stone-500 font-['NanumGothic'] text-xs font-semibold mb-3">
                         댕댕워크 산책기능은 회원에게만 제공됩니다
                     </p>
-                    <button onClick={() => setModalState(true)}>
+                    <button onClick={() => setLoginModalState(true)}>
                         <img src={LoginButton} alt="Login" />
                     </button>
                 </section>

--- a/frontend/src/components/LoginBottomSheet.tsx
+++ b/frontend/src/components/LoginBottomSheet.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import OAuthButton from '@/components/OAuthButton';
 import { OAUTH } from '@/constants';
 import signupIn3secs from '@/assets/icons/ic-signup-asap.svg';
-import { useLoginModalStateStore } from '@/store/modalStateStore';
+import { useLoginBottomSheetStateStore } from '@/store/modalStateStore';
 
-const LoginModal = () => {
-    const { setLoginModalState: setModalState } = useLoginModalStateStore();
+const LoginBottomSheet = () => {
+    const { setLoginBottomSheetState: setModalState } = useLoginBottomSheetStateStore();
     return (
         <div className="flex flex-col h-dvh bg-white rounded-t-xl px-[1.875rem]">
             <div className="flex flex-col gap-2 justify-center mt-10">
@@ -32,4 +32,4 @@ const LoginModal = () => {
     );
 };
 
-export default LoginModal;
+export default LoginBottomSheet;

--- a/frontend/src/components/LoginModal.tsx
+++ b/frontend/src/components/LoginModal.tsx
@@ -2,10 +2,10 @@ import React from 'react';
 import OAuthButton from '@/components/OAuthButton';
 import { OAUTH } from '@/constants';
 import signupIn3secs from '@/assets/icons/ic-signup-asap.svg';
-import { useModalStateStore } from '@/store/modalStateStore';
+import { useLoginModalStateStore } from '@/store/modalStateStore';
 
 const LoginModal = () => {
-    const { setModalState } = useModalStateStore();
+    const { setLoginModalState: setModalState } = useLoginModalStateStore();
     return (
         <div className="flex flex-col h-dvh bg-white rounded-t-xl px-[1.875rem]">
             <div className="flex flex-col gap-2 justify-center mt-10">

--- a/frontend/src/components/LoginModal.tsx
+++ b/frontend/src/components/LoginModal.tsx
@@ -1,20 +1,13 @@
 import React from 'react';
 import OAuthButton from '@/components/OAuthButton';
 import { OAUTH } from '@/constants';
-import { useLocation, useNavigate } from 'react-router-dom';
 import signupIn3secs from '@/assets/icons/ic-signup-asap.svg';
-import cancel from '@/assets/icons/ic-top-cancel.svg';
-import { Dispatch, SetStateAction } from 'react';
 import { useModalStateStore } from '@/store/modalStateStore';
 
 const LoginModal = () => {
-    const location = useLocation();
-    const navigate = useNavigate();
-    // const prevURL = location.state.redirectURI;
-    const prevURL = '/';
     const { setModalState } = useModalStateStore();
     return (
-        <div className="flex flex-col h-dvh bg-slate-300 rounded-t-xl px-[1.875rem]">
+        <div className="flex flex-col h-dvh bg-white rounded-t-xl px-[1.875rem]">
             <div className="flex flex-col gap-2 justify-center mt-10">
                 <div className="flex relative justify-center items-center mx-[4.375rem]">
                     <img className="" src={signupIn3secs} alt="빠른가입 안내" />
@@ -25,7 +18,7 @@ const LoginModal = () => {
 
                 <div className="flex flex-col items-center gap-3">
                     {OAUTH.map((oauth, index) => (
-                        <OAuthButton key={index} provider={oauth.PROVIDER} name={oauth.NAME} prevURL={prevURL} />
+                        <OAuthButton key={index} provider={oauth.PROVIDER} name={oauth.NAME} />
                     ))}
                 </div>
                 <button

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -5,10 +5,7 @@ import myPageOn from '@/assets/icons/btn-mypage-on.svg';
 import WalkOff from '@/assets/icons/btn-walk-off.svg';
 import WalkOn from '@/assets/icons/btn-walk-on.svg';
 
-interface Props {
-    isLoginModalOpen: boolean;
-}
-function Navbar({ isLoginModalOpen }: Props) {
+function Navbar() {
     const location = useLocation();
     const currentPath = window.location.pathname;
     if (currentPath === '/login') return null;

--- a/frontend/src/components/OAuthButton.tsx
+++ b/frontend/src/components/OAuthButton.tsx
@@ -4,14 +4,14 @@ import icGoogle from '@/assets/icons/ic-google.svg';
 import icKakao from '@/assets/icons/ic-kakao.svg';
 import icNaver from '@/assets/icons/ic-naver.svg';
 import { useNavigate } from 'react-router-dom';
-import { useModalStateStore } from '@/store/modalStateStore';
+import { useLoginModalStateStore } from '@/store/modalStateStore';
 
 type Props = {
     provider: string;
     name: string;
 };
 const OAuthButton = ({ provider, name }: Props) => {
-    const { setModalState, setJoinningState } = useModalStateStore();
+    const { setLoginModalState: setModalState, setJoinningState } = useLoginModalStateStore();
     const currentUrl = window.location.pathname;
     const navigate = useNavigate();
     const btnLogin = (provider: string) => {

--- a/frontend/src/components/OAuthButton.tsx
+++ b/frontend/src/components/OAuthButton.tsx
@@ -11,7 +11,7 @@ type Props = {
     name: string;
 };
 const OAuthButton = ({ provider, name }: Props) => {
-    const { setLoginModalState: setModalState, setJoinningState } = useLoginModalStateStore();
+    const { setLoginModalState, setJoinningState } = useLoginModalStateStore();
     const currentUrl = window.location.pathname;
     const navigate = useNavigate();
     const btnLogin = (provider: string) => {
@@ -62,7 +62,7 @@ const OAuthButton = ({ provider, name }: Props) => {
             className={`rounded-lg flex justify-center items-center relative w-full h-[3.25rem] ${bgColor(provider)} ${provider === 'google' && 'border border-neutral-200 '}`}
             onClick={() => {
                 handleCallOAuth(provider);
-                setModalState(false);
+                setLoginModalState(false);
                 setJoinningState(true);
             }}
         >

--- a/frontend/src/components/OAuthButton.tsx
+++ b/frontend/src/components/OAuthButton.tsx
@@ -3,13 +3,17 @@ import React from 'react';
 import icGoogle from '@/assets/icons/ic-google.svg';
 import icKakao from '@/assets/icons/ic-kakao.svg';
 import icNaver from '@/assets/icons/ic-naver.svg';
+import { useNavigate } from 'react-router-dom';
+import { useModalStateStore } from '@/store/modalStateStore';
 
 type Props = {
     provider: string;
     name: string;
-    prevURL: string;
 };
-const OAuthButton = ({ provider, name, prevURL }: Props) => {
+const OAuthButton = ({ provider, name }: Props) => {
+    const { setModalState, setJoinningState } = useModalStateStore();
+    const currentUrl = window.location.pathname;
+    const navigate = useNavigate();
     const btnLogin = (provider: string) => {
         switch (provider) {
             case 'google':
@@ -39,21 +43,28 @@ const OAuthButton = ({ provider, name, prevURL }: Props) => {
         let url = '';
         switch (provider) {
             case 'google':
-                url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.REACT_APP_GOOGLE_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_BASE_URL}${prevURL}&response_type=code&access_type=offline&scope=https://www.googleapis.com/auth/userinfo.email&prompt=select_account`;
+                url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.REACT_APP_GOOGLE_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_BASE_URL}${currentUrl}&response_type=code&access_type=offline&scope=https://www.googleapis.com/auth/userinfo.email&prompt=select_account`;
                 break;
             case 'kakao':
-                url = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${process.env.REACT_APP_KAKAO_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_BASE_URL}${prevURL}`;
+                url = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${process.env.REACT_APP_KAKAO_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_BASE_URL}${currentUrl}`;
                 break;
             case 'naver':
-                url = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${process.env.REACT_APP_NAVER_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_BASE_URL}${prevURL}&state=naverLoginState`;
+                url = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${process.env.REACT_APP_NAVER_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_BASE_URL}${currentUrl}&state=naverLoginState`;
                 break;
         }
-        window.location.href = url;
+        //1. oauthUrl set
+        //2. currentUrl set
+        //3. 동의 페이지로 이동
+        navigate('/join', { state: { oauthUrl: url } });
     };
     return (
         <button
             className={`rounded-lg flex justify-center items-center relative w-full h-[3.25rem] ${bgColor(provider)} ${provider === 'google' && 'border border-neutral-200 '}`}
-            onClick={() => handleCallOAuth(provider)}
+            onClick={() => {
+                handleCallOAuth(provider);
+                setModalState(false);
+                setJoinningState(true);
+            }}
         >
             <img className="absolute left-0 ml-5" src={btnLogin(provider)} alt={`${provider}`} />
             <div

--- a/frontend/src/components/OAuthButton.tsx
+++ b/frontend/src/components/OAuthButton.tsx
@@ -4,14 +4,14 @@ import icGoogle from '@/assets/icons/ic-google.svg';
 import icKakao from '@/assets/icons/ic-kakao.svg';
 import icNaver from '@/assets/icons/ic-naver.svg';
 import { useNavigate } from 'react-router-dom';
-import { useLoginModalStateStore } from '@/store/modalStateStore';
+import { useLoginBottomSheetStateStore } from '@/store/modalStateStore';
 
 type Props = {
     provider: string;
     name: string;
 };
 const OAuthButton = ({ provider, name }: Props) => {
-    const { setLoginModalState, setJoinningState } = useLoginModalStateStore();
+    const { setLoginBottomSheetState, setJoinningState } = useLoginBottomSheetStateStore();
     const currentUrl = window.location.pathname;
     const navigate = useNavigate();
     const btnLogin = (provider: string) => {
@@ -62,7 +62,7 @@ const OAuthButton = ({ provider, name }: Props) => {
             className={`rounded-lg flex justify-center items-center relative w-full h-[3.25rem] ${bgColor(provider)} ${provider === 'google' && 'border border-neutral-200 '}`}
             onClick={() => {
                 handleCallOAuth(provider);
-                setLoginModalState(false);
+                setLoginBottomSheetState(false);
                 setJoinningState(true);
             }}
         >

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -8,6 +8,7 @@ import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
+import Join from '@/pages/Join';
 const router = createBrowserRouter([
     {
         path: '/',
@@ -29,6 +30,10 @@ const router = createBrowserRouter([
             {
                 path: '/health',
                 element: <Health />,
+            },
+            {
+                path: '/join',
+                element: <Join />,
             },
         ],
     },

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,12 +1,18 @@
+import LoginAlertModal from '@/components/LoginAlertModal';
 import DogCardList from '@/components/home/DogCardList';
 import WeatherInfo from '@/components/home/WeatherInfo';
+import { useAuth } from '@/hooks/useAuth';
 import React from 'react';
 
 function Home() {
+    const { isLoggedIn } = useAuth();
     return (
-        <main className=" px-5 bg-neutral-50">
-            <WeatherInfo />
-            <DogCardList />
+        <main className="flex flex-col px-5 bg-neutral-50">
+            <div className={`${isLoggedIn ? '' : 'blur-sm'}`}>
+                <WeatherInfo />
+                <DogCardList />
+            </div>
+            {!isLoggedIn && <LoginAlertModal />}
         </main>
     );
 }

--- a/frontend/src/pages/Join.tsx
+++ b/frontend/src/pages/Join.tsx
@@ -1,8 +1,8 @@
-import { useLoginModalStateStore } from '@/store/modalStateStore';
+import { useLoginBottomSheetStateStore } from '@/store/modalStateStore';
 import React, { useEffect } from 'react';
 
 export default function Join() {
-    const { setJoinningState } = useLoginModalStateStore();
+    const { setJoinningState } = useLoginBottomSheetStateStore();
 
     useEffect(() => {
         window.addEventListener('popstate', () => setJoinningState(false));

--- a/frontend/src/pages/Join.tsx
+++ b/frontend/src/pages/Join.tsx
@@ -1,0 +1,64 @@
+import { useModalStateStore } from '@/store/modalStateStore';
+import React, { useEffect } from 'react';
+
+export default function Join() {
+    const { setJoinningState } = useModalStateStore();
+
+    useEffect(() => {
+        window.addEventListener('popstate', () => setJoinningState(false));
+    }, []);
+    return (
+        <div className="flex w-dvw">
+            <div id="agreement" className="bg-slate-200 w-dvw">
+                <div>
+                    <button>뒤로가기버튼</button>
+                </div>
+
+                <div>
+                    댕댕워크 사용을 위한
+                    <br />
+                    <span>약관내용에 동의</span>해주세요
+                </div>
+
+                <div>
+                    <input type="checkbox" />
+                    <span>모두 동의합니다</span>
+                </div>
+
+                <div>
+                    <div>
+                        <p>필수 동의</p>
+                        <div>
+                            <input type="checkbox" />
+                            <span>서비스 이용약관</span>
+                        </div>
+                        <div>
+                            <input type="checkbox" />
+                            <span>위치기반 서비스 이용약관</span>
+                        </div>
+                        <div>
+                            <input type="checkbox" />
+                            <span>개인정보 수집과 이용</span>
+                        </div>
+                    </div>
+
+                    <div>
+                        <p>선택 동의</p>
+                        <div>
+                            <input type="checkbox" />
+                            <span>마케팅 정보 수신</span>
+                            <p>앱 알림, 문자 메시지, 이메일로 광고성 정보를 전송합니다.</p>
+                        </div>
+                    </div>
+                </div>
+                <button>다음 단계로</button>
+            </div>
+
+            <div className="bg-slate-500 ">
+                <div>반려견여부 페이지</div>
+                <div>반려견 기본정보를 알려주세요</div>
+                <div>강아지 세부정보를 알려주세요</div>
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/pages/Join.tsx
+++ b/frontend/src/pages/Join.tsx
@@ -1,8 +1,8 @@
-import { useModalStateStore } from '@/store/modalStateStore';
+import { useLoginModalStateStore } from '@/store/modalStateStore';
 import React, { useEffect } from 'react';
 
 export default function Join() {
-    const { setJoinningState } = useModalStateStore();
+    const { setJoinningState } = useLoginModalStateStore();
 
     useEffect(() => {
         window.addEventListener('popstate', () => setJoinningState(false));

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -3,10 +3,9 @@ import LoginAlertModal from '@/components/LoginAlertModal';
 import { useAuth } from '@/hooks/useAuth';
 import { getStorage, setStorage } from '@/utils/storage';
 import { useEffect } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 
 function Profile() {
-    const navigate = useNavigate();
     const { search } = useLocation();
     const params = new URLSearchParams(search);
     const authorizeCode = params.get('code');

--- a/frontend/src/store/modalStateStore.ts
+++ b/frontend/src/store/modalStateStore.ts
@@ -1,17 +1,17 @@
 import { create } from 'zustand';
 
 interface ModalState {
-    isLoginModalOpen: boolean;
+    isLoginBottomSheetOpen: boolean;
     isJoinning: boolean;
-    setLoginModalState: (state: boolean) => void;
+    setLoginBottomSheetState: (state: boolean) => void;
     setJoinningState: (state: boolean) => void;
 }
 
-export const useLoginModalStateStore = create<ModalState>((set) => ({
-    isLoginModalOpen: false,
+export const useLoginBottomSheetStateStore = create<ModalState>((set) => ({
+    isLoginBottomSheetOpen: false,
     isJoinning: false,
-    setLoginModalState: (state: boolean) => {
-        set({ isLoginModalOpen: state });
+    setLoginBottomSheetState: (state: boolean) => {
+        set({ isLoginBottomSheetOpen: state });
     },
     setJoinningState: (state: boolean) => {
         set({ isJoinning: state });

--- a/frontend/src/store/modalStateStore.ts
+++ b/frontend/src/store/modalStateStore.ts
@@ -2,12 +2,18 @@ import { create } from 'zustand';
 
 interface ModalState {
     isModalOpen: boolean;
+    isJoinning: boolean;
     setModalState: (state: boolean) => void;
+    setJoinningState: (state: boolean) => void;
 }
 
 export const useModalStateStore = create<ModalState>((set) => ({
     isModalOpen: false,
+    isJoinning: false,
     setModalState: (state: boolean) => {
         set({ isModalOpen: state });
+    },
+    setJoinningState: (state: boolean) => {
+        set({ isJoinning: state });
     },
 }));

--- a/frontend/src/store/modalStateStore.ts
+++ b/frontend/src/store/modalStateStore.ts
@@ -1,17 +1,17 @@
 import { create } from 'zustand';
 
 interface ModalState {
-    isModalOpen: boolean;
+    isLoginModalOpen: boolean;
     isJoinning: boolean;
-    setModalState: (state: boolean) => void;
+    setLoginModalState: (state: boolean) => void;
     setJoinningState: (state: boolean) => void;
 }
 
-export const useModalStateStore = create<ModalState>((set) => ({
-    isModalOpen: false,
+export const useLoginModalStateStore = create<ModalState>((set) => ({
+    isLoginModalOpen: false,
     isJoinning: false,
-    setModalState: (state: boolean) => {
-        set({ isModalOpen: state });
+    setLoginModalState: (state: boolean) => {
+        set({ isLoginModalOpen: state });
     },
     setJoinningState: (state: boolean) => {
         set({ isJoinning: state });


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
`LoginAlertModal`이 띄어 졌는지 , 회원가입중인지 상태를 알기 위해 zustands로 store 생성

1. `LoginAlertModal`의 회원가입/로그인 버튼 클릭시에 `setLoginBottomSheetState(true)`가 되어 `setLoginBottomSheetState`은 true가 되고,

`setLoginBottomSheetState == true?  `
1)`LoginBottomSheetState`가 화면 아래에서 위로 올라옴
2) `LoginAlertModal` 배경 어둡게, `LoginAlertModal` 페이지 section 없어짐
3) 뒷배경을 클릭하면 `isLoginBottomSheet` === false, 다시 LoginBottomSheet 내려감

2. oauth로그인 버튼 클릭후 '`/join`'페이지로 이동시 `navbar`와 `LoginBottomSheet`가 같이 보이는 일이 발생했기때문에
회원가입중인 상태(`isJoinning`)에 따라 navbar와 LoginBottomSheet 없앰

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
