### PR TITLE
backend/DANG-337: WinstonLoggerService에서 환경 변수 가져올때 production→prod로 변경

### DIFF
--- a/backend/src/common/interceptor/logging.interceptor.ts
+++ b/backend/src/common/interceptor/logging.interceptor.ts
@@ -1,4 +1,4 @@
-import { CallHandler, ExecutionContext, Injectable, Logger, NestInterceptor } from '@nestjs/common';
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
 import { Observable, tap } from 'rxjs';
 import { generateUuid } from 'src/utils/hash.utils';
 import { WinstonLoggerService } from '../logger/winstonLogger.service';
@@ -6,7 +6,7 @@ import { WinstonLoggerService } from '../logger/winstonLogger.service';
 @Injectable()
 export class LoggingInterceptor implements NestInterceptor {
     constructor(private readonly logger: WinstonLoggerService) {
-        logger = new WinstonLoggerService(new Logger());
+        logger = new WinstonLoggerService();
     }
 
     intercept(context: ExecutionContext, next: CallHandler<any>): Observable<any> {

--- a/backend/src/common/logger/winstonLogger.service.ts
+++ b/backend/src/common/logger/winstonLogger.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger, LoggerService } from '@nestjs/common';
+import { Injectable, LoggerService } from '@nestjs/common';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as winston from 'winston';
@@ -8,15 +8,12 @@ import * as winstonDaily from 'winston-daily-rotate-file';
 export class WinstonLoggerService implements LoggerService {
     private readonly logger: winston.Logger;
 
-    constructor(private readonly nestLogger: Logger) {
-        const isDevelopment = process.env.NODE_ENV != 'production';
+    constructor() {
+        const isDevelopment = process.env.NODE_ENV != 'prod';
         const logDir = path.join(process.cwd(), 'log');
         if (!fs.existsSync(logDir)) {
             fs.mkdirSync(logDir, { recursive: true });
         }
-
-        nestLogger.debug(`logDir :  ${logDir}`);
-        nestLogger.debug(`isDevelopment:  ${isDevelopment}`);
 
         const logFormat = winston.format.printf(({ timestamp, level, message }) => {
             const seoulTimestamp = new Date(timestamp).toLocaleString('ko-KR');

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -20,9 +20,10 @@ async function bootstrap() {
 
     app.use(cookieParser());
 
+    const logger = app.get(Logger);
     await (async () => {
         await app.listen(PORT, () => {
-            console.log(`Server running at http://${process.env.MYSQL_HOST}:${PORT}`);
+            logger.log(`Server running at http://${process.env.MYSQL_HOST}:${PORT}`);
         });
     })();
 }

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -9,7 +9,7 @@ import { PORT } from './config/settings';
 async function bootstrap() {
     const app = await NestFactory.create(AppModule);
 
-    app.useLogger(new WinstonLoggerService(new Logger()));
+    app.useLogger(new WinstonLoggerService());
 
     app.enableCors({
         origin: process.env.CORS_ORIGIN,


### PR DESCRIPTION
## 작업 내용 (Content)
- WinstonLoggerService에서 NODE_ENV를 productio으로 잘못 가져오고 있어 prod로 변경
- main.ts에서 콘솔 로그 찍던 거 winston 로거로 변경
- WinstonLoggerService 내부에서 찍던 로그는 제거해버림, 매번 내장 로거를 의존성으로 주입받는게 너무 불편함

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
