### PR TITLE
infra/DANG-326: PR merge 시 Status를 Done으로 업데이트하도록 하는 GitHub Actions 추가

### DIFF
--- a/.github/workflows/change_ticket_status_done.yaml
+++ b/.github/workflows/change_ticket_status_done.yaml
@@ -1,0 +1,84 @@
+name: Change Ticket Status to Done
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  change_ticket_status_to_done_if_merged:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Change the status of corresponding Notion Ticket to Done
+        env:
+          DATABASE_ID: 35e838520c274894b2206eb34a198575
+          NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+        run: |
+          check_error() {
+            echo $1 | jq .
+            if [[ $1 == *"error"* ]]; then
+              exit 1
+            fi
+          }
+
+          branch_name="${{ github.event.pull_request.head.ref }}"
+
+          if [[ $branch_name =~ DANG-([0-9]+)$ ]]; then
+            TASK_ID="${BASH_REMATCH[1]}"
+            echo "Task ID number: $TASK_ID"
+          else
+            echo "Branch 이름에서 Task ID number 정보를 찾을 수 없습니다."
+            exit 1
+          fi
+
+          JSON_DATA=$(cat <<EOF
+          {
+            "filter": {
+              "property": "Task ID",
+              "unique_id": {
+                "equals": $TASK_ID
+              }
+            }
+          }
+          EOF
+          )
+
+          response=$(
+            curl -X POST "https://api.notion.com/v1/databases/${DATABASE_ID}/query" \
+            -H "Authorization: Bearer ${NOTION_API_KEY}" \
+            -H "Notion-Version: 2022-06-28" \
+            -H "Content-Type: application/json" \
+            --data "$JSON_DATA"
+          )
+
+          check_error "$response"
+
+          PAGE_ID=$(echo $response | jq -r ".results[0].id")
+
+          if [ "$PAGE_ID" == "null" ]; then
+            echo "$PAGE_ID Ticket이 존재하지 않습니다."
+            exit 1
+          fi
+
+          JSON_DATA=$(cat <<EOF
+          {
+            "properties": {
+              "Status": {
+                "status": {
+                  "name": "Done"
+                }
+              }
+            }
+          }
+          EOF
+          )
+
+          response=$(
+            curl -X PATCH "https://api.notion.com/v1/pages/${PAGE_ID}" \
+            -H "Authorization: Bearer ${NOTION_API_KEY}" \
+            -H "Notion-Version: 2022-06-28" \
+            -H "Content-Type: application/json" \
+            --data "$JSON_DATA"
+          )
+
+          check_error "$response"


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
PR merge 시 notion ticket의 status를 Done으로 업데이트한다.

## 링크 (Links)
https://www.notion.so/do0ori/PR-Notion-Status-Done-53fb296815d44f048d7634a028452381

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
