### PR TITLE
frontend/DANG-333: 공통 컴포넌트에 구분선 추가

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
             "name": "frontend",
             "version": "0.1.0",
             "dependencies": {
+                "@radix-ui/react-separator": "^1.0.3",
                 "@radix-ui/react-slot": "^1.0.2",
                 "@tanstack/react-query": "^5.32.0",
                 "axios": "^1.6.8",
@@ -3794,6 +3795,52 @@
                 }
             }
         },
+        "node_modules/@radix-ui/react-primitive": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-1.0.3.tgz",
+            "integrity": "sha512-yi58uVyoAcK/Nq1inRY56ZSjKypBNKTa/1mcL8qdl6oJeEaDbOldlzrGn7P6Q3Id5d+SYNGc5AJgc4vGhjs5+g==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-slot": "1.0.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-separator": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-separator/-/react-separator-1.0.3.tgz",
+            "integrity": "sha512-itYmTy/kokS21aiV5+Z56MZB54KrhPgn6eHDKkFeOLR34HMN2s8PaN47qZZAGnvupcjxHaFZnW4pQEh0BvvVuw==",
+            "dependencies": {
+                "@babel/runtime": "^7.13.10",
+                "@radix-ui/react-primitive": "1.0.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0",
+                "react-dom": "^16.8 || ^17.0 || ^18.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@radix-ui/react-slot": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.0.2.tgz",
@@ -5140,7 +5187,7 @@
             "version": "18.3.0",
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.0.tgz",
             "integrity": "sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==",
-            "dev": true,
+            "devOptional": true,
             "dependencies": {
                 "@types/react": "*"
             }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,6 +4,7 @@
     "private": true,
     "type": "module",
     "dependencies": {
+        "@radix-ui/react-separator": "^1.0.3",
         "@radix-ui/react-slot": "^1.0.2",
         "@tanstack/react-query": "^5.32.0",
         "axios": "^1.6.8",

--- a/frontend/src/components/common/Divider.tsx
+++ b/frontend/src/components/common/Divider.tsx
@@ -3,7 +3,7 @@ import { cn } from '@/utils/tailwind-class';
 import * as SeparatorPrimitive from '@radix-ui/react-separator';
 import * as React from 'react';
 
-const Separator = React.forwardRef<
+const Divider = React.forwardRef<
     React.ElementRef<typeof SeparatorPrimitive.Root>,
     React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
 >(({ className, orientation = 'horizontal', decorative = true, ...props }, ref) => (
@@ -19,6 +19,6 @@ const Separator = React.forwardRef<
         {...props}
     />
 ));
-Separator.displayName = 'CommonSeparator';
+Divider.displayName = 'CommonDivider';
 
-export { Separator };
+export { Divider };

--- a/frontend/src/components/common/Separator.tsx
+++ b/frontend/src/components/common/Separator.tsx
@@ -1,0 +1,24 @@
+/* eslint-disable react/prop-types */
+import { cn } from '@/utils/tailwind-class';
+import * as SeparatorPrimitive from '@radix-ui/react-separator';
+import * as React from 'react';
+
+const Separator = React.forwardRef<
+    React.ElementRef<typeof SeparatorPrimitive.Root>,
+    React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(({ className, orientation = 'horizontal', decorative = true, ...props }, ref) => (
+    <SeparatorPrimitive.Root
+        ref={ref}
+        decorative={decorative}
+        orientation={orientation}
+        className={cn(
+            'shrink-0 bg-slate-200 dark:bg-slate-800',
+            orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
+            className
+        )}
+        {...props}
+    />
+));
+Separator.displayName = 'CommonSeparator';
+
+export { Separator };

--- a/frontend/src/components/common/Separator.tsx
+++ b/frontend/src/components/common/Separator.tsx
@@ -12,8 +12,8 @@ const Separator = React.forwardRef<
         decorative={decorative}
         orientation={orientation}
         className={cn(
-            'shrink-0 bg-slate-200 dark:bg-slate-800',
-            orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
+            'shrink-0',
+            orientation === 'horizontal' ? 'bg-[#f6f6f6] h-1 w-full' : 'bg-[#e4e4e4] h-5 w-[1px]',
             className
         )}
         {...props}


### PR DESCRIPTION
## 작업 내용 (Content)
구분선(Divider) 컴포넌트 구현

## 링크 (Links)
https://www.notion.so/do0ori/f730c7b9009b4275b9dcb5f0ad6d968f?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
