### PR TITLE
infra/DANG-348: 프론트엔드 및 백엔드 env.prod 분리하기

### DIFF
--- a/.github/workflows/backend_deploy.yaml
+++ b/.github/workflows/backend_deploy.yaml
@@ -64,6 +64,11 @@ jobs:
     needs: build
     runs-on: [ self-hosted, label-api ]
     steps:
+      - name: Create .env
+        env:
+          ENV_FILE: ${{ secrets.ENV_FILE_BACKEND }}
+        run: |
+          echo "$ENV_FILE" >> .env.prod
       - name: Deploy to Amazon EC2
         run : | 
           aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin ${{ env.REPO }}

--- a/.github/workflows/frontend_deploy.yaml
+++ b/.github/workflows/frontend_deploy.yaml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: Create .env
         env:
-          ENV_FILE: ${{ secrets.ENV_FILE }}
+          ENV_FILE: ${{ secrets.ENV_FILE_FRONTEND }}
         run: |
           echo "$ENV_FILE" >> .env.prod
       - name: Deploy to Amazon EC2

--- a/backend/src/breed/breed.spec.ts
+++ b/backend/src/breed/breed.spec.ts
@@ -1,0 +1,20 @@
+import { Breed } from './breed.entity';
+
+describe('Breed', () => {
+    it('breed 정보가 주어지면 breed 정보를 리턴해야 한다.', () => {
+        const breed = new Breed();
+        breed.id = 1;
+        breed.name = '골드리트리버';
+        breed.activity = 1;
+
+        expect(breed.id).toEqual(1);
+        expect(breed.name).toEqual('골드리트리버');
+        expect(breed.activity).toEqual(1);
+    });
+
+    it('breed 정보가 없으면 빈 객체를 리턴해야 한다.', () => {
+        const breed = new Breed();
+
+        expect(breed).toEqual({});
+    });
+});

--- a/frontend/src/vitest.test.ts
+++ b/frontend/src/vitest.test.ts
@@ -13,7 +13,4 @@ describe('Vitest 확인', () => {
     it('5의 결과값을 리턴해야 한다.', () => {
         expect(2 + 3).toEqual(5);
     });
-    it('6의 결과값을 리턴해야 한다.', () => {
-        expect(3 + 3).toEqual(6);
-    });
 });


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
주요 변경 사항
- 백엔드 배포 워크플로우에서 ENV_FILE_BACKEND 시크릿을 사용하여 .env.prod 파일을 생성하는 단계를 추가했습니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
