### PR TITLE
frontend/DANG-349: 공통 컴포넌트에서 import 방식 변경

### DIFF
--- a/frontend/src/components/common/Button.tsx
+++ b/frontend/src/components/common/Button.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@/utils/tailwind-class';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
-import * as React from 'react';
+import { ButtonHTMLAttributes, forwardRef } from 'react';
 
 const buttonVariants = cva(
     'inline-flex items-center justify-center whitespace-nowrap h-12 px-4 text-base font-semibold ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:pointer-events-none',
@@ -25,7 +25,7 @@ const buttonVariants = cva(
     }
 );
 
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     ({ className, color, rounded, asChild = false, ...props }, ref) => {
         const Comp = asChild ? Slot : 'button';
 
@@ -35,7 +35,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 Button.displayName = 'CommonButton';
 
 interface ButtonProps
-    extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'color'>,
+    extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'color'>,
         VariantProps<typeof buttonVariants> {
     asChild?: boolean;
 }

--- a/frontend/src/components/common/Divider.tsx
+++ b/frontend/src/components/common/Divider.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable react/prop-types */
 import { cn } from '@/utils/tailwind-class';
 import * as SeparatorPrimitive from '@radix-ui/react-separator';
-import * as React from 'react';
+import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react';
 
-const Divider = React.forwardRef<
-    React.ElementRef<typeof SeparatorPrimitive.Root>,
-    React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+const Divider = forwardRef<
+    ElementRef<typeof SeparatorPrimitive.Root>,
+    ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
 >(({ className, orientation = 'horizontal', decorative = true, ...props }, ref) => (
     <SeparatorPrimitive.Root
         ref={ref}


### PR DESCRIPTION
## 작업 내용 (Content)
공통 컴포넌트에서 import 방식 변경

## 링크 (Links)
https://www.notion.so/do0ori/import-7827c4854f3c405b9f87a0a8efbccfe4?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
