### PR TITLE
backend/DANG-351: 강아지 프로필 조회 API 구현

### DIFF
--- a/backend/src/common/database/abstract.repository.ts
+++ b/backend/src/common/database/abstract.repository.ts
@@ -15,7 +15,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
     async findOne(where: FindOptionsWhere<T>): Promise<T> {
         const entity = await this.entityRepository.findOne({ where });
         if (!entity) {
-            throw new NotFoundException('Entity not found');
+            throw new NotFoundException('fidnOne : Entity not found');
         }
         return entity;
     }
@@ -27,7 +27,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
     async update(where: FindOptionsWhere<T>, partialEntity: QueryDeepPartialEntity<T>): Promise<UpdateResult> {
         const updateResult = await this.entityRepository.update(where, partialEntity);
         if (!updateResult.affected) {
-            throw new NotFoundException('Entity not found');
+            throw new NotFoundException('update : Entity not found');
         }
         return updateResult;
     }
@@ -36,7 +36,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         const deleteResult = await this.entityRepository.delete(where);
 
         if (!deleteResult.affected) {
-            throw new NotFoundException('Entity not found');
+            throw new NotFoundException('delete : Entity not found');
         }
         return deleteResult;
     }
@@ -44,7 +44,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
     async updateAndFindOne(where: FindOptionsWhere<T>, partialEntity: QueryDeepPartialEntity<T>): Promise<T | null> {
         const updateResult = await this.entityRepository.update(where, partialEntity);
         if (!updateResult.affected) {
-            throw new NotFoundException('Entity not found');
+            throw new NotFoundException('update : Entity not found');
         }
         return this.entityRepository.findOne({ where });
     }

--- a/backend/src/dogs/dogs.controller.ts
+++ b/backend/src/dogs/dogs.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, InternalServerErrorException, Param, ParseIntPipe } from '@nestjs/common';
+import { Controller, ForbiddenException, Get, Param, ParseIntPipe } from '@nestjs/common';
 import { AccessTokenPayload } from 'src/auth/token/token.service';
 import { Serialize } from 'src/common/interceptor/serialize.interceptor';
 import { User } from 'src/users/decorators/user.decorator';
@@ -36,7 +36,7 @@ export class DogsController {
     async getOneProfile(@User() user: AccessTokenPayload, @Param('id', ParseIntPipe) dogId: number) {
         const owned = await this.usersService.checkDogOwnership(user.userId, dogId);
         if (!owned) {
-            throw new InternalServerErrorException('주인이 아닌 강아지에 대한 요청 ');
+            throw new ForbiddenException('주인이 아닌 강아지에 대한 요청 ');
         }
         return this.dogsService.getProfile(dogId);
     }

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -37,6 +37,14 @@ export class DogsService {
         return dogIds;
     }
 
+    private makeProfile(dogInfo: Dogs): DogProfile {
+        return {
+            id: dogInfo.id,
+            name: dogInfo.name,
+            photoUrl: dogInfo.photoUrl,
+        };
+    }
+
     private makeProfileList(dogs: Dogs[]): DogProfile[] {
         return dogs.map((cur) => {
             return {
@@ -48,8 +56,13 @@ export class DogsService {
     }
 
     async getProfileList(where: FindOptionsWhere<Dogs>): Promise<DogProfile[]> {
-        const ownDogList = await this.dogsRepository.find(where);
-        return this.makeProfileList(ownDogList);
+        const dogInfos = await this.dogsRepository.find(where);
+        return this.makeProfileList(dogInfos);
+    }
+
+    async getProfile(dogId: number): Promise<DogProfile> {
+        const dogInfo = await this.dogsRepository.findOne({ id: dogId });
+        return this.makeProfile(dogInfo);
     }
 
     async getRelatedTableIdList(
@@ -89,7 +102,7 @@ export class DogsService {
     }
 
     async getDogsStatistics(userId: number): Promise<DogStatisticDto[]> {
-        const ownDogIds = await this.usersService.getDogsList(userId);
+        const ownDogIds = await this.usersService.getOwnDogsList(userId);
         const dogWalkDayIds = await this.getRelatedTableIdList(ownDogIds, 'walkDayId');
         const dailyWalkTimeIds = await this.getRelatedTableIdList(ownDogIds, 'dailyWalkTimeId');
         const breedIds = await this.getRelatedTableIdList(ownDogIds, 'breedId');

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -107,11 +107,15 @@ export class UsersService {
         return nickname;
     }
 
-    async getDogsList(userId: number): Promise<number[]> {
+    async getOwnDogsList(userId: number): Promise<number[]> {
         const foundDogs = await this.usersDogsRepo.find({ where: { userId } });
-        if (!foundDogs) {
-            throw new NotFoundException();
-        }
         return foundDogs.map((cur) => cur.dogId);
+    }
+
+    async checkDogOwnership(userId: number, dogId: number | number[]): Promise<boolean> {
+        const ownDogs = await this.usersDogsRepo.find({ where: { userId } });
+        const myDogIds = ownDogs.map((cur) => cur.dogId);
+
+        return Array.isArray(dogId) ? !dogId.every((id) => myDogIds.includes(id)) : myDogIds.includes(dogId);
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
    - 요청한 유저가 강아지의 소유자가 맞는지 확인합니다
    - 맞다면, 요청한 강아지에 대한 프로필을 리턴합니다
    - 강아지 프로필 만드는 로직에서, dogId가 배열일 경우와 아닐 경우를 합쳐서 한 메소드에서 구현하려고 했었는데, 그렇게 하면 statistics
      API에서 dogId가 하나일 때도 빈 배열로 반환하는 경우를 포함하지 못해서, 배열일 경우와 아닐 경우를 따로 메소드로 분리했습니다

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
