### PR TITLE
frontend/DANG-354: currentPage ‘/join’일때 Navbar, LoginBottomSheet 없애기

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import Navbar from './components/Navbar';
 import React, { useEffect, useRef } from 'react';
 import queryClient from './api/queryClient';
@@ -8,6 +8,8 @@ import LoginBottomSheet from '@/components/LoginBottomSheet';
 var console;
 function App() {
     const { isLoginBottomSheetOpen, setLoginBottomSheetState } = useLoginBottomSheetStateStore();
+    const location = useLocation();
+    const currentPage = location.pathname;
     const outletRef = useRef<HTMLDivElement>(null);
     //TODO: 일시적인 배포시 console.log 제거 추가로 환경설정으로 빼줘야함ㄴ
     if (process.env.NODE_ENV === 'production') {
@@ -33,16 +35,18 @@ function App() {
                 <div ref={outletRef}>
                     <Outlet />
                 </div>
-
-                <div className={`fixed z-10`}>
-                    <Navbar />
-                </div>
-
-                <div
-                    className={`fixed z-20 w-full duration-300 ${isLoginBottomSheetOpen ? ' translate-y-72' : 'translate-y-full'}`}
-                >
-                    <LoginBottomSheet />
-                </div>
+                {currentPage !== '/join' && (
+                    <>
+                        <div className={`fixed z-10`}>
+                            <Navbar />
+                        </div>
+                        <div
+                            className={`fixed z-20 w-full duration-300 ${isLoginBottomSheetOpen ? ' translate-y-72' : 'translate-y-full'}`}
+                        >
+                            <LoginBottomSheet />
+                        </div>
+                    </>
+                )}
             </div>
         </QueryClientProvider>
     );

--- a/frontend/src/pages/Join.tsx
+++ b/frontend/src/pages/Join.tsx
@@ -1,9 +1,12 @@
 import CheckBox from '@/components/common/CheckBox';
 import React, { ChangeEvent, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 
 export default function Join() {
     const navigate = useNavigate();
+    const location = useLocation();
+    const state = location.state;
+    console.log(state);
     const [allAgreed, setAllAgreed] = useState(false);
     const [agreements, setAgreements] = useState({
         service: false,


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
currentPage ‘/join’일때 Navbar, LoginBottomSheet 없애기
App.tsx에서 현재페이지 path를 감지해서 '/join'일때 fixed 상태인 Navbar와 LoginBottomSheet를 조건부로 렌더링하지 않게 만들었습니다.

추후 산책중 관련 페이지일때도 추가해야됩니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
