### PR TITLE
backend/DANG-335: DB module의 synchronize option을 prod일 때는 false가 되도록 수정

### DIFF
--- a/backend/src/common/database/database.module.ts
+++ b/backend/src/common/database/database.module.ts
@@ -25,7 +25,7 @@ import { EntityClassOrSchema } from '@nestjs/typeorm/dist/interfaces/entity-clas
                     password: config.get<string>('MYSQL_ROOT_PASSWORD'),
                     database: config.get<string>('MYSQL_DATABASE'),
                     entities: ['dist/**/*.entity{.ts,.js}'],
-                    synchronize: true,
+                    synchronize: process.env.NODE_ENV === 'prod' ? false : true,
                 };
             },
         }),


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
synchronize option은 매번 application을 실행할 때마다 database schema가 새롭게 생성되기 때문에 잘못하면 data가 사라질 수 있다. production에서는 이 option을 사용하지 말라고 option 설명에 나와있다.
```
(property) synchronize?: boolean | undefined
Indicates if database schema should be auto created on every application launch. Be careful with this option and don't use this in production - otherwise you can lose production data. This option is useful during debug and development. Alternative to it, you can use CLI and run schema:sync command.

Note that for MongoDB database it does not create schema, because MongoDB is schemaless. Instead, it syncs just by creating indices.
```

## 링크 (Links)
https://www.notion.so/do0ori/DB-module-synchronize-option-prod-false-68b7b02ddfe54a0ea738e24ff77f6fb5

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
