### PR TITLE
backend/DANG-360: NODE_ENV production에서 prod로 수정

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -49,7 +49,7 @@ export class AuthController {
 
         response.cookie('refreshToken', refreshToken, {
             httpOnly: true,
-            secure: Boolean(this.configService.get<string>('NODE_ENV', 'test') === 'production'),
+            secure: this.configService.get<string>('NODE_ENV') === 'prod' ? true : false,
             maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
         });
 
@@ -85,7 +85,7 @@ export class AuthController {
 
         response.cookie('refreshToken', refreshToken, {
             httpOnly: true,
-            secure: Boolean(this.configService.get<string>('NODE_ENV', 'test') === 'production'),
+            secure: this.configService.get<string>('NODE_ENV') === 'prod' ? true : false,
             maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
         });
 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
`NODE_ENV`가 `'production'`인지 확인했었는데 `package.json` script를 보면 `'prod'`로 사용 중이어서 수정했다.
또한 `Boolean`을 직접 사용해 boolean 값을 return하기 보다는 가독성을 높이기 위해 삼항연산자를 사용했다.

## 링크 (Links)
https://www.notion.so/do0ori/NODE_ENV-production-prod-21c0b9be9a064c43a8f992ab489bbf1e

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
