### PR TITLE
infra/DANG-370: use NODE_ENV=production for production build

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,7 +45,7 @@
     "scripts": {
         "start": "craco start",
         "build": "craco build",
-        "build:prod": "FAST_REFRESH=false craco build",
+        "build:prod": "NODE_ENV=production craco build",
         "test": "vitest",
         "eject": "react-scripts eject",
         "typecheck": "tsc --noEmit --skipLibCheck",


### PR DESCRIPTION
## 작업 내용 (Content)
- 프로덕션 빌드 시 FAST_REFRESH=false 대신 NODE_ENV=production을 사용하도록 수정함
- NODE_ENV=production 설정을 통해 React의 프로덕션 모드를 활성화하고, 개발 환경에서만 사용되는 개발 관련 코드와 기능을 제거할 수 있음
- 이를 통해 프로덕션 빌드 시 불필요한 코드가 포함되지 않아 번들 크기 감소와 성능 최적화가 가능해짐

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
