### PR TITLE
backend/DANG-356: Users module이 abstract Repository 사용하도록 변경

### DIFF
--- a/backend/src/common/database/abstract.repository.ts
+++ b/backend/src/common/database/abstract.repository.ts
@@ -15,7 +15,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
     async findOne(where: FindOptionsWhere<T>): Promise<T> {
         const entity = await this.entityRepository.findOne({ where });
         if (!entity) {
-            throw new NotFoundException('fidnOne : Entity not found');
+            throw new NotFoundException('findOne : Entity not found');
         }
         return entity;
     }

--- a/backend/src/dogs/dogs.module.ts
+++ b/backend/src/dogs/dogs.module.ts
@@ -1,17 +1,13 @@
 import { Module } from '@nestjs/common';
 import { Breed } from 'src/breed/breed.entity';
 import { BreedModule } from 'src/breed/breed.module';
-import { BreedService } from 'src/breed/breed.service';
 import { DatabaseModule } from 'src/common/database/database.module';
 import { WinstonLoggerModule } from 'src/common/logger/winstonLogger.module';
 import { DailyWalkTime } from 'src/daily-walk-time/daily-walk-time.entity';
 import { DailyWalkTimeModule } from 'src/daily-walk-time/daily-walk-time.module';
-import { DailyWalkTimeService } from 'src/daily-walk-time/daily-walk-time.service';
 import { DogWalkDay } from 'src/dog-walk-day/dog-walk-day.entity';
 import { DogWalkDayModule } from 'src/dog-walk-day/dog-walk-day.module';
-import { DogWalkDayService } from 'src/dog-walk-day/dog-walk-day.service';
 import { UsersModule } from 'src/users/users.module';
-import { UsersService } from 'src/users/users.service';
 import { DogsController } from './dogs.controller';
 import { Dogs } from './dogs.entity';
 import { DogsRepository } from './dogs.repository';
@@ -26,16 +22,8 @@ import { DogsService } from './dogs.service';
         WinstonLoggerModule,
         DogWalkDayModule,
     ],
-    providers: [
-        DatabaseModule,
-        DogsRepository,
-        DogsService,
-        UsersService,
-        BreedService,
-        DogWalkDayService,
-        DailyWalkTimeService,
-    ],
-    exports: [DatabaseModule, DogsRepository, DogsService],
+    providers: [DogsRepository, DogsService],
+    exports: [DogsService],
     controllers: [DogsController],
 })
 export class DogsModule {}

--- a/backend/src/fixture/users.fixture.ts
+++ b/backend/src/fixture/users.fixture.ts
@@ -1,21 +1,21 @@
 import { Role } from '../users/user-roles.enum';
 import { Users } from '../users/users.entity';
 
-const ACCESS_TOKEN =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTY2ODc1NzUzNCwiZXhwIjoxNjY4ODQzOTM0fQ.fwjmKJZ7enTKt7tPfNx-ZG_rczvhkz2ktMV5pDNbxkw';
 const REFRESH_TOKEN =
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM';
+const OAUTH_ACCESS_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTY2ODc1NzUzNCwiZXhwIjoxNjY4ODQzOTM0fQ.fwjmKJZ7enTKt7tPfNx-ZG_rczvhkz2ktMV5pDNbxkw';
 const OAUTH_REFRESH_TOKEN =
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM';
 
-export const mockUser = Users.create(
-    1,
-    '오징어1234',
-    Role.User,
-    1,
-    '1',
-    ACCESS_TOKEN,
-    OAUTH_REFRESH_TOKEN,
-    REFRESH_TOKEN,
-    new Date('2019-01-01')
-);
+export const mockUser = new Users({
+    id: 1,
+    nickname: '오징어1234',
+    role: Role.User,
+    mainDogId: 1,
+    oauthId: '1',
+    oauthAccessToken: OAUTH_ACCESS_TOKEN,
+    oauthRefreshToken: OAUTH_REFRESH_TOKEN,
+    refreshToken: REFRESH_TOKEN,
+    createdAt: new Date('2019-01-01'),
+});

--- a/backend/src/users-dogs/users-dogs.entity.ts
+++ b/backend/src/users-dogs/users-dogs.entity.ts
@@ -1,6 +1,6 @@
+import { Users } from 'src/users/users.entity';
 import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
 import { Dogs } from '../dogs/dogs.entity';
-import { Users } from './users.entity';
 
 @Entity('users_dogs')
 export class UsersDogs {
@@ -13,4 +13,8 @@ export class UsersDogs {
     @ManyToOne(() => Dogs, (dog) => dog.id)
     @JoinColumn({ name: 'dog_id' })
     dogId: number;
+
+    constructor(entityData: Partial<UsersDogs>) {
+        Object.assign(this, entityData);
+    }
 }

--- a/backend/src/users-dogs/users-dogs.module.ts
+++ b/backend/src/users-dogs/users-dogs.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { DatabaseModule } from 'src/common/database/database.module';
+import { WinstonLoggerModule } from '../common/logger/winstonLogger.module';
+import { UsersDogs } from './users-dogs.entity';
+import { UsersDogsRepository } from './users-dogs.repository';
+import { UsersDogsService } from './users-dogs.service';
+
+@Module({
+    imports: [DatabaseModule.forFeature([UsersDogs]), WinstonLoggerModule],
+    providers: [UsersDogsService, UsersDogsRepository],
+    exports: [UsersDogsService],
+})
+export class UsersDogsModule {}

--- a/backend/src/users-dogs/users-dogs.repository.ts
+++ b/backend/src/users-dogs/users-dogs.repository.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { AbstractRepository } from 'src/common/database/abstract.repository';
+import { EntityManager, Repository } from 'typeorm';
+import { UsersDogs } from './users-dogs.entity';
+
+@Injectable()
+export class UsersDogsRepository extends AbstractRepository<UsersDogs> {
+    constructor(
+        @InjectRepository(UsersDogs)
+        usersDogsRepository: Repository<UsersDogs>,
+        entityManager: EntityManager
+    ) {
+        super(usersDogsRepository, entityManager);
+    }
+}

--- a/backend/src/users-dogs/users-dogs.service.ts
+++ b/backend/src/users-dogs/users-dogs.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@nestjs/common';
+import { FindOptionsWhere } from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
+import { UsersDogs } from './users-dogs.entity';
+import { UsersDogsRepository } from './users-dogs.repository';
+
+@Injectable()
+export class UsersDogsService {
+    constructor(private readonly usersDogsRepository: UsersDogsRepository) {}
+
+    async create(entityData: UsersDogs) {
+        const userDog = new UsersDogs(entityData);
+        return this.usersDogsRepository.create(userDog);
+    }
+
+    async find(where: FindOptionsWhere<UsersDogs>) {
+        return this.usersDogsRepository.find(where);
+    }
+
+    async findOne(where: FindOptionsWhere<UsersDogs>) {
+        return this.usersDogsRepository.findOne(where);
+    }
+
+    async update(where: FindOptionsWhere<UsersDogs>, partialEntity: QueryDeepPartialEntity<UsersDogs>) {
+        return this.usersDogsRepository.update(where, partialEntity);
+    }
+
+    async delete(where: FindOptionsWhere<UsersDogs>) {
+        return this.usersDogsRepository.delete(where);
+    }
+}

--- a/backend/src/users/types/user-types.ts
+++ b/backend/src/users/types/user-types.ts
@@ -1,0 +1,11 @@
+import { Role } from '../user-roles.enum';
+
+export interface CreateUser {
+    nickname: string;
+    role: Role;
+    mainDogId: number | undefined;
+    oauthId: string;
+    oauthAccessToken: string;
+    oauthRefreshToken: string;
+    refreshToken: string;
+}

--- a/backend/src/users/users.entity.ts
+++ b/backend/src/users/users.entity.ts
@@ -39,29 +39,7 @@ export class Users {
     @CreateDateColumn()
     createdAt: Date;
 
-    constructor() {}
-
-    static create(
-        id: number,
-        nickname: string,
-        role: Role,
-        mainDogId: number,
-        oauthId: string,
-        oauthAccessToken: string,
-        oauthRefreshToken: string,
-        refreshToken: string,
-        createAt: Date
-    ) {
-        const user = new Users();
-        user.id = id;
-        user.nickname = nickname;
-        user.role = role;
-        user.mainDogId = mainDogId;
-        user.oauthId = oauthId;
-        user.oauthAccessToken = oauthAccessToken;
-        user.oauthRefreshToken = oauthRefreshToken;
-        user.refreshToken = refreshToken;
-        user.createdAt = createAt;
-        return user;
+    constructor(entityData: Partial<Users>) {
+        Object.assign(this, entityData);
     }
 }

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,15 +1,17 @@
 import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { UsersDogs } from 'src/users/user-dogs.entity';
+import { DatabaseModule } from 'src/common/database/database.module';
+import { UsersDogs } from 'src/users-dogs/users-dogs.entity';
+import { UsersDogsModule } from 'src/users-dogs/users-dogs.module';
 import { WinstonLoggerModule } from '../common/logger/winstonLogger.module';
 import { UsersController } from './users.controller';
 import { Users } from './users.entity';
+import { UsersRepository } from './users.repository';
 import { UsersService } from './users.service';
 
 @Module({
-    imports: [TypeOrmModule.forFeature([Users, UsersDogs]), WinstonLoggerModule],
+    imports: [DatabaseModule.forFeature([Users, UsersDogs]), UsersDogsModule, WinstonLoggerModule],
     controllers: [UsersController],
-    providers: [UsersService],
-    exports: [TypeOrmModule, UsersService],
+    providers: [UsersService, UsersRepository],
+    exports: [UsersService],
 })
 export class UsersModule {}

--- a/backend/src/users/users.repository.ts
+++ b/backend/src/users/users.repository.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { AbstractRepository } from 'src/common/database/abstract.repository';
+import { EntityManager, Repository } from 'typeorm';
+import { Users } from './users.entity';
+
+@Injectable()
+export class UsersRepository extends AbstractRepository<Users> {
+    constructor(
+        @InjectRepository(Users)
+        usersRepository: Repository<Users>,
+        entityManager: EntityManager
+    ) {
+        super(usersRepository, entityManager);
+    }
+}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,69 +1,39 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { WinstonLoggerService } from 'src/common/logger/winstonLogger.service';
-import { UsersDogs } from 'src/users/user-dogs.entity';
-import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { UsersDogsService } from 'src/users-dogs/users-dogs.service';
+import { FindOptionsWhere } from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { generateUuid } from '../utils/hash.utils';
+import { CreateUser } from './types/user-types';
 import { Role } from './user-roles.enum';
 import { Users } from './users.entity';
+import { UsersRepository } from './users.repository';
 
 @Injectable()
 export class UsersService {
     constructor(
-        @InjectRepository(Users) private userRepo: Repository<Users>,
-        @InjectRepository(UsersDogs) private usersDogsRepo: Repository<UsersDogs>,
-        private logger: WinstonLoggerService
+        private readonly usersRepository: UsersRepository,
+        private readonly usersDogsService: UsersDogsService
     ) {}
 
-    async create(
-        nickname: string,
-        role: Role,
-        mainDogId: number | undefined,
-        oauthId: string,
-        oauthAccessToken: string,
-        oauthRefreshToken: string,
-        refreshToken: string
-    ) {
-        const user = await this.userRepo.create({
-            nickname,
-            role,
-            mainDogId,
-            oauthId,
-            oauthAccessToken,
-            oauthRefreshToken,
-            refreshToken,
-        });
-
-        return this.userRepo.save(user);
+    async create(entityData: CreateUser) {
+        const user = new Users(entityData);
+        return this.usersRepository.create(user);
     }
 
-    async findOne(id: number) {
-        const user = await this.userRepo.findOne({ where: { id } });
-        if (!user) {
-            throw new NotFoundException('User not found');
-        }
-        return user;
+    async find(where: FindOptionsWhere<Users>) {
+        return this.usersRepository.find(where);
     }
 
-    async update(id: number, attrs: Partial<Users>) {
-        const user = await this.findOne(id);
-        if (!user) {
-            throw new NotFoundException('users not found');
-        }
-        Object.assign(user, attrs);
-        return this.userRepo.save(user);
+    async findOne(where: FindOptionsWhere<Users>) {
+        return this.usersRepository.findOne(where);
     }
 
-    async remove(id: number) {
-        const user = await this.findOne(id);
-        if (!user) throw new NotFoundException('users not found');
-        return this.userRepo.remove(user);
+    async update(where: FindOptionsWhere<Users>, partialEntity: QueryDeepPartialEntity<Users>) {
+        return this.usersRepository.update(where, partialEntity);
     }
 
-    async findOneWithOauthId(oauthId: string) {
-        const user = await this.userRepo.findOne({ where: { oauthId } });
-        if (!user) throw new NotFoundException('User not found');
-        return user;
+    async delete(where: FindOptionsWhere<Users>) {
+        return this.usersRepository.delete(where);
     }
 
     async loginOrCreateUser(
@@ -72,24 +42,21 @@ export class UsersService {
         oauthRefreshToken: string,
         refreshToken: string
     ) {
-        let user = await this.userRepo.findOne({ where: { oauthId } });
+        let user = await this.findOne({ oauthId });
 
         if (!user) {
             const nickname = await this.generateUniqueNickname();
-            user = await this.create(
+            user = await this.create({
                 nickname,
-                Role.User,
-                undefined,
+                role: Role.User,
+                mainDogId: undefined,
                 oauthId,
                 oauthAccessToken,
                 oauthRefreshToken,
-                refreshToken
-            );
+                refreshToken,
+            });
         } else {
-            user.oauthAccessToken = oauthAccessToken;
-            user.oauthRefreshToken = oauthRefreshToken;
-            user.refreshToken = refreshToken;
-            await this.userRepo.save(user);
+            await this.update({ oauthId }, { oauthAccessToken, oauthRefreshToken, refreshToken });
         }
 
         return user.id;
@@ -97,23 +64,23 @@ export class UsersService {
 
     async generateUniqueNickname(): Promise<string> {
         let nickname = generateUuid();
-        let user = await this.userRepo.findOne({ where: { nickname } });
+        let user = await this.findOne({ nickname });
 
         while (user) {
             nickname = generateUuid();
-            user = await this.userRepo.findOne({ where: { nickname } });
+            user = await this.findOne({ nickname });
         }
 
         return nickname;
     }
 
     async getOwnDogsList(userId: number): Promise<number[]> {
-        const foundDogs = await this.usersDogsRepo.find({ where: { userId } });
+        const foundDogs = await this.usersDogsService.find({ userId });
         return foundDogs.map((cur) => cur.dogId);
     }
 
     async checkDogOwnership(userId: number, dogId: number | number[]): Promise<boolean> {
-        const ownDogs = await this.usersDogsRepo.find({ where: { userId } });
+        const ownDogs = await this.usersDogsService.find({ userId });
         const myDogIds = ownDogs.map((cur) => cur.dogId);
 
         return Array.isArray(dogId) ? dogId.every((id) => myDogIds.includes(id)) : myDogIds.includes(dogId);


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- abstract repository class 오타 수정 (fidnOne -> findOne)
- users service에서 repository를 직접 주입해 사용했던 user-dogs를 분리했다.
- users module이 abstract repository를 사용하도록 수정: abstract repository를 extends해 UsersRepository를 정의하고, UsersService에서 UsersRepository와 UsersDogsService를 의존성 주입해 class를 업데이트했다.
- 변경된 users 구조에 맞게 fixture와 test 코드(`users.service.spec.ts`) 수정
- 변경된 users service에 맞게 auth service 수정
- DogsModule에 추가된 불필요한 providers, exports 제거

## 링크 (Links)
https://www.notion.so/do0ori/Users-Repository-f10163438bed4fc9b289266d4d231bd6

## 기타 사항 (Etc)
`npm test`, `npm start` 성공

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
