### PR TITLE
backend/DANG-399: AbstractRepository의 creatIfNotExsits method refactoring

### DIFF
--- a/backend/src/common/database/abstract.repository.ts
+++ b/backend/src/common/database/abstract.repository.ts
@@ -12,7 +12,22 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         return this.entityManager.save(entity);
     }
 
-    async createIfNotExists(where: FindOptionsWhere<T>, entity: T): Promise<T> {
+    /**
+     * 주어진 entity가 이미 존재하는지 확인하고, 존재하지 않으면 새로운 entity를 생성하는 비동기 함수입니다.
+     *
+     * @param entity database에 저장하려는 새로운 entity입니다.
+     * @param attributes entity를 식별하는 데 사용할 column(또는 속성)의 이름 또는 이름의 배열입니다.
+     * 여러 개의 column을 지정하면 해당하는 조건이 모두 일치해야 기존 entity로 간주됩니다.
+     * @returns entity가 성공적으로 생성되면 생성된 entity가 반환됩니다.
+     */
+    async createIfNotExists(entity: T, attributes: keyof T | (keyof T)[]): Promise<T> {
+        const attributeList = Array.isArray(attributes) ? attributes : [attributes];
+
+        const where: Partial<T> = {};
+        for (const attribute of attributeList) {
+            where[attribute] = entity[attribute];
+        }
+
         const existingEntity = await this.entityRepository.findOne({ where });
 
         if (existingEntity) {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -49,7 +49,6 @@ export class UsersService {
         const nickname = await this.generateUniqueNickname();
 
         return await this.usersRepository.createIfNotExists(
-            { oauthId },
             new Users({
                 nickname,
                 role: Role.User,
@@ -58,7 +57,8 @@ export class UsersService {
                 oauthAccessToken,
                 oauthRefreshToken,
                 refreshToken,
-            })
+            }),
+            'oauthId'
         );
     }
 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- `createIfNotExists` method
  - 안나님(@opehn)이 entity와 이를 식별할 값을 where 조건으로 따로 받으면 실수를 유발할 수 있기 때문에 entity에 있는 column 명을 받도록 개선하자는 의견을 제시해주셨다.
  - 그래서 attribute로 column 명을 받도록 method를 수정했고 이에 더해 entity를 식별하는 데에 여러 개의 column을 사용할 수도 있기 때문에 확장성을 고려하여 attributes 형식으로 작성했다.
  - method를 설명하는 주석을 추가했다.
- `createIfNotExists` method를 사용하던 users service의 `createIfNotExists` method도  바뀐 형식에 맞게 수정해주었다.
- 
## 링크 (Links)
https://www.notion.so/do0ori/AbstractRepository-creatIfNotExsits-2cdc2708acef4914ac68dfce74fef006

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
