### PR TITLE
infra/DANG-401: 프론트엔드 백엔드 Auth 리다이렉트 CORS 허용

### DIFF
--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -12,7 +12,12 @@ async function bootstrap() {
     app.useLogger(new WinstonLoggerService());
 
     app.enableCors({
-        origin: ['http://localhost:3000', 'http://localhost:8080', 'http://dangdang-walk.prgms-fullcycle.com'],
+        origin: [
+            'http://localhost:3000',
+            'http://localhost:8080',
+            'http://dangdang-walk.prgms-fullcycle.com',
+            'http://dangdang-walk.prgms-fullcycle.com:3000',
+        ],
         methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
         allowedHeaders: ['Content-Type', 'Accept', 'Authorization'],
         credentials: true,

--- a/frontend/src/api/http.ts
+++ b/frontend/src/api/http.ts
@@ -1,11 +1,11 @@
 import axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
 
-const { REACT_APP_NEST_BASE_URL } = process.env;
+const { REACT_APP_NEST_BASE_URL: NEST_BASE_URL = '' } = window._ENV ?? process.env;
 const DEFAULT_TIMEOUT = 30000;
 
 export const createClient = (config?: AxiosRequestConfig): AxiosInstance => {
     const axiosInstance = axios.create({
-        baseURL: REACT_APP_NEST_BASE_URL,
+        baseURL: NEST_BASE_URL,
         timeout: DEFAULT_TIMEOUT,
         headers: {
             'Content-Type': `application/json;charset=UTF-8`,

--- a/frontend/src/utils/oauth.ts
+++ b/frontend/src/utils/oauth.ts
@@ -1,17 +1,24 @@
 import { getStorage } from '@/utils/storage';
 
 const getAuthorizeCodeCallbackUrl = (provider: string) => {
+    const {
+        REACT_APP_BASE_URL: BASE_URL = '',
+        REACT_APP_GOOGLE_CLIENT_ID: GOOGLE_CLIENT_ID = '',
+        REACT_APP_KAKAO_CLIENT_ID: KAKAO_CLIENT_ID = '',
+        REACT_APP_NAVER_CLIENT_ID: NAVER_CLIENT_ID = '',
+    } = window._ENV ?? process.env;
+
     let url = '';
     const currentUrl = getStorage('redirectURI');
     switch (provider) {
         case 'google':
-            url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${process.env.REACT_APP_GOOGLE_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_BASE_URL}${currentUrl}&response_type=code&access_type=offline&scope=https://www.googleapis.com/auth/userinfo.email&prompt=consent`;
+            url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${BASE_URL}${currentUrl}&response_type=code&access_type=offline&scope=https://www.googleapis.com/auth/userinfo.email&prompt=consent`;
             break;
         case 'kakao':
-            url = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${process.env.REACT_APP_KAKAO_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_BASE_URL}${currentUrl}`;
+            url = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${KAKAO_CLIENT_ID}&redirect_uri=${BASE_URL}${currentUrl}`;
             break;
         case 'naver':
-            url = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${process.env.REACT_APP_NAVER_CLIENT_ID}&redirect_uri=${process.env.REACT_APP_BASE_URL}${currentUrl}&state=naverLoginState`;
+            url = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&redirect_uri=${BASE_URL}${currentUrl}&state=naverLoginState`;
             break;
     }
     return url;


### PR DESCRIPTION
## 작업 내용 (Content)
백엔드 CORS 설정 확장
- backend/src/main.ts 파일에서 CORS 설정을 업데이트하여 프론트엔드 배포 도메인과 포트 (http://dangdang-walk.prgms-fullcycle.com:3000) 도 요청 허용하도록 변경했습니다.

프론트엔드 환경 변수 사용:
- 프론트엔드 코드에서 백엔드 API 베이스 URL (REACT_APP_NEST_BASE_URL)과 OAuth 클라이언트 ID (REACT_APP_GOOGLE_CLIENT_ID, REACT_APP_KAKAO_CLIENT_ID, REACT_APP_NAVER_CLIENT_ID) 를 가져오는 방식을 수정했습니다.
- 이전에는 process.env 객체를 직접 사용했습니다.
- 이번 커밋을 통해 앞서 설정된 window._ENV 객체를 사용하도록 변경되었습니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
