### PR TITLE
frontend/DANG-407: 공통 컴포넌트 Checkbox2 수정

### DIFF
--- a/frontend/src/components/common/Checkbox2.tsx
+++ b/frontend/src/components/common/Checkbox2.tsx
@@ -36,7 +36,7 @@ function newID() {
     return Math.random().toString(36).slice(2);
 }
 
-interface Props extends ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root> {
+interface Props extends Omit<ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>, 'asChild'> {
     checked: boolean;
     onCheckedChange: (checked: boolean) => void;
     labelText?: string;


### PR DESCRIPTION
## 작업 내용 (Content)
공통 컴포넌트 Checkbox2에서 asChild 프롭 제거

## 링크 (Links)
https://www.notion.so/do0ori/Checkbox2-ee24ccd920884a639798d34269449a52?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
