### PR TITLE
backend/DANG-355: 강아지 등록, 삭제, 정보 수정 api 추가

### DIFF
--- a/backend/src/breed/breed.service.ts
+++ b/backend/src/breed/breed.service.ts
@@ -11,6 +11,10 @@ export class BreedService {
         return this.breedRepository.find(where);
     }
 
+    async findOne(where: FindOptionsWhere<Breed>): Promise<Breed> {
+        return this.breedRepository.findOne(where);
+    }
+
     async getActivityList(ownDogs: number[]): Promise<number[]> {
         const foundBreed = await this.breedRepository.find({ id: In(ownDogs) });
         if (!foundBreed.length) {

--- a/backend/src/daily-walk-time/daily-walk-time.entity.ts
+++ b/backend/src/daily-walk-time/daily-walk-time.entity.ts
@@ -5,7 +5,7 @@ export class DailyWalkTime {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Column()
+    @Column({ default: 0 })
     duration: number;
 
     @CreateDateColumn({ name: 'updated_at' })

--- a/backend/src/daily-walk-time/daily-walk-time.service.ts
+++ b/backend/src/daily-walk-time/daily-walk-time.service.ts
@@ -11,6 +11,10 @@ export class DailyWalkTimeService {
         return this.dailyWalkTimeRepository.find(where);
     }
 
+    async delete(where: FindOptionsWhere<DailyWalkTime>) {
+        return this.dailyWalkTimeRepository.delete(where);
+    }
+
     async getWalkTimeList(walkTimeIds: number[]) {
         const walkTimeList = await this.dailyWalkTimeRepository.find({ id: In(walkTimeIds) });
         if (!walkTimeList.length) {

--- a/backend/src/dog-walk-day/dog-walk-day.service.ts
+++ b/backend/src/dog-walk-day/dog-walk-day.service.ts
@@ -11,6 +11,10 @@ export class DogWalkDayService {
         return this.dogWalkDayRepository.find(where);
     }
 
+    async delete(where: FindOptionsWhere<DogWalkDay>) {
+        return this.dogWalkDayRepository.delete(where);
+    }
+
     private getValuesOnly(walkDays: any[]) {
         const daysValues = walkDays.map((curWeek) => {
             const valueArr = [];

--- a/backend/src/dogs/dogs.controller.ts
+++ b/backend/src/dogs/dogs.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, ForbiddenException, Get, Param, ParseIntPipe } from '@nestjs/common';
+import { Body, Controller, ForbiddenException, Get, Param, ParseIntPipe, Post } from '@nestjs/common';
 import { AccessTokenPayload } from 'src/auth/token/token.service';
 import { Serialize } from 'src/common/interceptor/serialize.interceptor';
 import { User } from 'src/users/decorators/user.decorator';
@@ -6,6 +6,7 @@ import { UsersService } from 'src/users/users.service';
 import { In } from 'typeorm';
 import { DogsService } from './dogs.service';
 import { DogStatisticDto } from './dto/dog-statistic.dto';
+import { DogDto } from './dto/dog.dto';
 
 export type DogProfile = {
     id: number;
@@ -19,6 +20,13 @@ export class DogsController {
         private readonly usersService: UsersService,
         private readonly dogsService: DogsService
     ) {}
+
+    @Post()
+    async register(@User() { userId }: AccessTokenPayload, @Body() dogDto: DogDto) {
+        this.dogsService.createDogToUser(userId, dogDto);
+
+        return true;
+    }
 
     @Get('/walk-available')
     async getAvailableDogs(@User() user: AccessTokenPayload): Promise<DogProfile[]> {

--- a/backend/src/dogs/dogs.controller.ts
+++ b/backend/src/dogs/dogs.controller.ts
@@ -1,4 +1,15 @@
-import { Body, Controller, Delete, ForbiddenException, Get, HttpCode, Param, ParseIntPipe, Post } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Delete,
+    ForbiddenException,
+    Get,
+    HttpCode,
+    Param,
+    ParseIntPipe,
+    Patch,
+    Post,
+} from '@nestjs/common';
 import { AccessTokenPayload } from 'src/auth/token/token.service';
 import { Serialize } from 'src/common/interceptor/serialize.interceptor';
 import { User } from 'src/users/decorators/user.decorator';
@@ -31,14 +42,30 @@ export class DogsController {
     @Delete('/:id')
     @HttpCode(204)
     async delete(@User() { userId }: AccessTokenPayload, @Param('id') dogId: number) {
+        const owned = await this.usersService.checkDogOwnership(userId, dogId);
+        if (!owned) {
+            throw new ForbiddenException('주인이 아닌 강아지에 대한 요청 ');
+        }
         await this.dogsService.deleteDogFromUser(userId, { id: dogId });
 
         return true;
     }
 
+    @Patch('/:id')
+    @HttpCode(204)
+    async update(@User() { userId }: AccessTokenPayload, @Param('id') dogId: number, @Body() dogDto: DogDto) {
+        const owned = await this.usersService.checkDogOwnership(userId, dogId);
+        if (!owned) {
+            throw new ForbiddenException('주인이 아닌 강아지에 대한 요청 ');
+        }
+        await this.dogsService.updateDog(dogId, dogDto);
+
+        return true;
+    }
+
     @Get('/:id')
-    async getOneProfile(@User() user: AccessTokenPayload, @Param('id', ParseIntPipe) dogId: number) {
-        const owned = await this.usersService.checkDogOwnership(user.userId, dogId);
+    async getOneProfile(@User() { userId }: AccessTokenPayload, @Param('id', ParseIntPipe) dogId: number) {
+        const owned = await this.usersService.checkDogOwnership(userId, dogId);
         if (!owned) {
             throw new ForbiddenException('주인이 아닌 강아지에 대한 요청 ');
         }
@@ -46,14 +73,14 @@ export class DogsController {
     }
 
     @Get('/walk-available')
-    async getAvailableDogs(@User() user: AccessTokenPayload): Promise<DogProfile[]> {
-        const ownDogIds = await this.usersService.getOwnDogsList(user.userId);
+    async getAvailableDogs(@User() { userId }: AccessTokenPayload): Promise<DogProfile[]> {
+        const ownDogIds = await this.usersService.getOwnDogsList(userId);
         return await this.dogsService.getProfileList({ id: In(ownDogIds), isWalking: false });
     }
 
     @Serialize(DogStatisticDto)
     @Get('/statistics')
-    async getDogsStatistics(@User() user: AccessTokenPayload) {
-        return this.dogsService.getDogsStatistics(user.userId);
+    async getDogsStatistics(@User() { userId }: AccessTokenPayload) {
+        return this.dogsService.getDogsStatistics(userId);
     }
 }

--- a/backend/src/dogs/dogs.entity.ts
+++ b/backend/src/dogs/dogs.entity.ts
@@ -9,14 +9,14 @@ export class Dogs {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @OneToOne(() => DogWalkDay, { nullable: false })
+    @OneToOne(() => DogWalkDay, { nullable: false, cascade: true, onDelete: 'CASCADE' })
     @JoinColumn({ name: 'walk_day_id' })
     walkDay: DogWalkDay;
 
     @Column({ name: 'walk_day_id' })
     walkDayId: number;
 
-    @OneToOne(() => DailyWalkTime, { nullable: false })
+    @OneToOne(() => DailyWalkTime, { nullable: false, cascade: true, onDelete: 'CASCADE' })
     @JoinColumn({ name: 'daily_walk_time_id' })
     dailyWalkTime: DailyWalkTime;
 
@@ -48,7 +48,7 @@ export class Dogs {
     @Column({ name: 'photo_url' })
     photoUrl: string;
 
-    @Column({ name: 'is_walking' })
+    @Column({ name: 'is_walking', default: false })
     isWalking: boolean;
 
     constructor(entityData: Partial<Dogs>) {

--- a/backend/src/dogs/dogs.entity.ts
+++ b/backend/src/dogs/dogs.entity.ts
@@ -50,4 +50,8 @@ export class Dogs {
 
     @Column({ name: 'is_walking' })
     isWalking: boolean;
+
+    constructor(entityData: Partial<Dogs>) {
+        Object.assign(this, entityData);
+    }
 }

--- a/backend/src/dogs/dogs.module.ts
+++ b/backend/src/dogs/dogs.module.ts
@@ -7,6 +7,7 @@ import { DailyWalkTime } from 'src/daily-walk-time/daily-walk-time.entity';
 import { DailyWalkTimeModule } from 'src/daily-walk-time/daily-walk-time.module';
 import { DogWalkDay } from 'src/dog-walk-day/dog-walk-day.entity';
 import { DogWalkDayModule } from 'src/dog-walk-day/dog-walk-day.module';
+import { UsersDogsModule } from 'src/users-dogs/users-dogs.module';
 import { UsersModule } from 'src/users/users.module';
 import { DogsController } from './dogs.controller';
 import { Dogs } from './dogs.entity';
@@ -17,6 +18,7 @@ import { DogsService } from './dogs.service';
     imports: [
         DatabaseModule.forFeature([Dogs, Breed, DogWalkDay, DailyWalkTime]),
         UsersModule,
+        UsersDogsModule,
         BreedModule,
         DailyWalkTimeModule,
         WinstonLoggerModule,

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -44,6 +44,16 @@ export class DogsService {
         return this.usersDogsService.create({ userId, dogId: dog.id });
     }
 
+    async deleteDogFromUser(userId: number, where: FindOptionsWhere<Dogs>) {
+        const dog = await this.findOne(where);
+
+        await this.usersDogsService.delete({ userId, dogId: dog.id });
+        await this.dogWalkDayService.delete({ id: dog.walkDayId });
+        await this.dailyWalkTimeService.delete({ id: dog.dailyWalkTimeId });
+
+        return dog;
+    }
+
     async findOne(where: FindOptionsWhere<Dogs>) {
         return this.dogsRepository.findOne(where);
     }

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -62,6 +62,14 @@ export class DogsService {
         return await this.dogsRepository.update(where, partialEntity);
     }
 
+    async updateDog(dogId: number, dogDto: DogDto) {
+        const { breed: breedName, ...otherAttributes } = dogDto;
+
+        const breed = await this.breedService.findOne({ name: breedName });
+
+        return this.update({ id: dogId }, { breed, ...otherAttributes });
+    }
+
     async updateIsWalking(dogIds: number[], stateToUpdate: boolean) {
         const attrs = {
             isWalking: stateToUpdate,

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -10,6 +10,7 @@ import { DogProfile } from './dogs.controller';
 import { Dogs } from './dogs.entity';
 import { DogsRepository } from './dogs.repository';
 import { DogStatisticDto } from './dto/dog-statistic.dto';
+import { DogDto } from './dto/dog.dto';
 
 @Injectable()
 export class DogsService {
@@ -22,9 +23,17 @@ export class DogsService {
         private readonly logger: WinstonLoggerService
     ) {}
 
-    async find(where: FindOptionsWhere<Dogs>) {
-        return this.dogsRepository.find(where);
+    async create(entityData: DogDto) {
+        const { breed: breedName, ...rest } = entityData;
+        const breed = await this.breedService.findOne({ name: breedName });
+        const dog = new Dogs({ breedId: breed.id, ...rest });
+        return this.dogsRepository.create(dog);
     }
+
+    async findOne(where: FindOptionsWhere<Dogs>) {
+        return this.dogsRepository.findOne(where);
+    }
+
     async update(where: FindOptionsWhere<Dogs>, partialEntity: QueryDeepPartialEntity<Dogs>): Promise<UpdateResult> {
         return await this.dogsRepository.update(where, partialEntity);
     }

--- a/backend/src/dogs/dto/dog.dto.ts
+++ b/backend/src/dogs/dto/dog.dto.ts
@@ -1,0 +1,22 @@
+import { IsBoolean, IsDate, IsEnum, IsString, IsUrl } from 'class-validator';
+import { Gender } from '../dogs-gender.enum';
+
+export class DogDto {
+    @IsString()
+    name: string;
+
+    @IsString()
+    breed: string;
+
+    @IsEnum(Gender)
+    gender: 'MALE' | 'FEMALE';
+
+    @IsBoolean()
+    isNeutered: boolean;
+
+    @IsDate()
+    birth: Date;
+
+    @IsUrl()
+    photoUrl: string;
+}

--- a/backend/src/excrements/excrements.entity.ts
+++ b/backend/src/excrements/excrements.entity.ts
@@ -10,7 +10,7 @@ export class Excrements {
     journalId: number;
 
     @PrimaryColumn({ name: 'dog_id' })
-    @ManyToOne(() => Dogs, (dog) => dog.id)
+    @ManyToOne(() => Dogs, (dog) => dog.id, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'dog_id' })
     dogId: number;
 

--- a/backend/src/journals/journals-dogs.entity.ts
+++ b/backend/src/journals/journals-dogs.entity.ts
@@ -10,7 +10,7 @@ export class JournalsDogs {
     journalId: number;
 
     @PrimaryColumn({ name: 'dog_id' })
-    @ManyToOne(() => Dogs, (dog) => dog.id)
+    @ManyToOne(() => Dogs, (dog) => dog.id, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'dog_id' })
     dogId: number;
 }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- `Dogs` entity
  - walkDay 및 dailyWalkTime field에 cascade 및 onDelete 설정 추가
  - isWalking field에 default 값 false 추가
- `DailyWalkTime` entity
  - duration field에 default 값 0 추가
- `JournalsDogs`와 `Excrements`에서 dog가 삭제되면 해당 dogId를 가진 row는 모두 삭제되어야 하므로 `onDelete: 'CASCADE'` option 추가
- `onDelete: 'CASCADE'` option이 적용된 row는 부모 table에서 참조하는 row가 삭제되면 해당 row도 삭제된다.
  - UsersDogs table에는 onDelete option이 없기 때문에 직접 삭제해주었고,
    `DogWalkDay`와 `DailyWalkTime`에 있는 row를 삭제해주면 Dogs에 있는 강아지 정보는 onDelete option에 의해 자동 삭제된다.
  - Dogs에 있는 강아지 정보가 삭제되었으므로 dogId를 외래키로 가지고 있으면서 onDelete option을 설정해두었던 `Excrements`와 `JournalsDogs`에 있는 row 또한 자동 삭제된다.

## 링크 (Links)
https://www.notion.so/do0ori/api-2b8963c1773d4cbb8ac4e926f82437f6

## 기타 사항 (Etc)
DB로 manual하게 동작 테스트 완료. 추후 테스트 코드 작성이 필요해 보임.

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
