### PR TITLE
backend/DANG-433: UsersDogs dogId에 onDelete 추가

### DIFF
--- a/backend/src/dogs/dogs.controller.ts
+++ b/backend/src/dogs/dogs.controller.ts
@@ -32,8 +32,8 @@ export class DogsController {
     @Delete('/:id')
     @HttpCode(204)
     @UseGuards(AuthDogGuard)
-    async delete(@User() { userId }: AccessTokenPayload, @Param('id', ParseIntPipe) dogId: number) {
-        await this.dogsService.deleteDogFromUser(userId, { id: dogId });
+    async delete(@Param('id', ParseIntPipe) dogId: number) {
+        await this.dogsService.deleteDogFromUser({ id: dogId });
 
         return true;
     }

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -44,10 +44,9 @@ export class DogsService {
         return this.usersDogsService.create({ userId, dogId: dog.id });
     }
 
-    async deleteDogFromUser(userId: number, where: FindOptionsWhere<Dogs>) {
+    async deleteDogFromUser(where: FindOptionsWhere<Dogs>) {
         const dog = await this.findOne(where);
 
-        await this.usersDogsService.delete({ userId, dogId: dog.id });
         await this.dogWalkDayService.delete({ id: dog.walkDayId });
         await this.dailyWalkTimeService.delete({ id: dog.dailyWalkTimeId });
 

--- a/backend/src/users-dogs/users-dogs.entity.ts
+++ b/backend/src/users-dogs/users-dogs.entity.ts
@@ -10,7 +10,7 @@ export class UsersDogs {
     userId: number;
 
     @PrimaryColumn({ name: 'dog_id' })
-    @ManyToOne(() => Dogs, (dog) => dog.id)
+    @ManyToOne(() => Dogs, (dog) => dog.id, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'dog_id' })
     dogId: number;
 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
Dogs의 row가 삭제될 때 UsersDogs의 row도 자동으로 삭제되도록 option을 추가

## 링크 (Links)
https://www.notion.so/do0ori/UsersDogs-dogId-onDelete-f88f9c7f47054cc090d12a1a834486b9

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
