### PR TITLE
backend/DANG-436: Dogs birth field에 null option 추가

### DIFF
--- a/backend/src/dogs/dogs.entity.ts
+++ b/backend/src/dogs/dogs.entity.ts
@@ -39,8 +39,8 @@ export class Dogs {
     })
     gender: 'MALE' | 'FEMALE';
 
-    @Column()
-    birth: Date;
+    @Column({ nullable: true, default: null })
+    birth: Date | null;
 
     @Column({ name: 'is_neutered' })
     isNeutered: boolean;

--- a/backend/src/dogs/dto/dog.dto.ts
+++ b/backend/src/dogs/dto/dog.dto.ts
@@ -15,7 +15,7 @@ export class DogDto {
     isNeutered: boolean;
 
     @IsDate()
-    birth: Date;
+    birth: Date | null;
 
     @IsUrl()
     photoUrl: string;


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
강아지 등록 시 강아지의 생일을 모를 수도 있기 때문에 null 값을 허용했다.
default는 null이다.

## 링크 (Links)
https://www.notion.so/do0ori/Dogs-birth-nullable-default-null-130947f10c754caca56834bdce862446

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
