### PR TITLE
backend/DANG-452: dogs controller에서 AuthDogGuard를 적용하지 않은 endpoint에도 AuthDogGuard가 적용되는 문제 해결하기

### DIFF
--- a/backend/src/dogs/dogs.controller.ts
+++ b/backend/src/dogs/dogs.controller.ts
@@ -47,12 +47,6 @@ export class DogsController {
         return true;
     }
 
-    @Get('/:id')
-    @UseGuards(AuthDogGuard)
-    async getOneProfile(@Param('id', ParseIntPipe) dogId: number) {
-        return this.dogsService.getProfile(dogId);
-    }
-
     @Get('/walk-available')
     async getAvailableDogs(@User() { userId }: AccessTokenPayload): Promise<DogProfile[]> {
         const ownDogIds = await this.usersService.getOwnDogsList(userId);
@@ -63,5 +57,11 @@ export class DogsController {
     @Get('/statistics')
     async getDogsStatistics(@User() { userId }: AccessTokenPayload) {
         return this.dogsService.getDogsStatistics(userId);
+    }
+
+    @Get('/:id')
+    @UseGuards(AuthDogGuard)
+    async getOneProfile(@Param('id', ParseIntPipe) dogId: number) {
+        return this.dogsService.getProfile(dogId);
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
GET 요청에 대한 handler 순서의 문제였다.
getOneProfile handler는 `'/:id'` 형태로 endpoint를 받고 AuthDogGuard를 사용하는데 getAvailableDogs와 getDogsStatistics handler가 그 뒤에 위치하게 되면서 routing 시 `'/:id'`에 먼저 match가 되어 버린다.
즉 id 값이 statistics와 walk-available로 간주되는 것이다.
따라서 간단히 getOneProfile handler의 위치를 마지막으로 옮겨 해결했다.

## 링크 (Links)
https://www.notion.so/do0ori/dogs-controller-AuthDogGuard-endpoint-AuthDogGuard-ed4d23ba430544da98ce1974c86b83b1
https://www.notion.so/do0ori/Guard-endpoint-bc3e7599e6314d5292a31d06622db833

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
