### PR TITLE
frontend/DANG-456: kakao Map 로드 방식 변경 및 타입 정의

### DIFF
--- a/frontend/src/components/walk/Map.tsx
+++ b/frontend/src/components/walk/Map.tsx
@@ -2,20 +2,18 @@ import { NAV_HEIGHT, TOP_BAR_HEIGHT, WALK_INFO_HEIGHT } from '@/constants/style'
 import { Position } from '@/models/location.model';
 import React, { useEffect } from 'react';
 
-declare global {
-    interface Window {
-        kakao: any;
-    }
-}
+const { REACT_APP_KAKAO_MAP_ID: KAKAO_MAP_ID = '' } = window._ENV ?? process.env;
+
 export default function Map({ position }: { position: Position | null }) {
     useEffect(() => {
         const kakaoScript = document.getElementById('kakao-script');
         if (kakaoScript) return;
         if (!position) return;
+
         const script = document.createElement('script');
         script.id = 'kakao-map';
         script.async = true;
-        script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.REACT_APP_KAKAO_MAP_ID}`;
+        script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_MAP_ID}&autoload=false`;
 
         document.head.appendChild(script);
 
@@ -33,10 +31,12 @@ export default function Map({ position }: { position: Position | null }) {
                 marker.setMap(map);
             });
         };
+
         script.addEventListener('load', onLoadKakaoMap);
 
         return () => script.removeEventListener('load', onLoadKakaoMap);
     }, [position]);
+
     return (
         <div
             id="map"

--- a/frontend/src/typed/window.d.ts
+++ b/frontend/src/typed/window.d.ts
@@ -1,3 +1,4 @@
 interface Window {
     _ENV: Record<string, string>;
+    kakao: any;
 }


### PR DESCRIPTION

## 작업 내용 (Content)
- 카카오맵 스크립트 로드 방식을 변경하였습니다. 이전에는 window.kakao 객체를 글로벌로 사용하였지만, 이번 변경으로 스크립트 로드 후 이벤트 리스너를 통해 지도를 초기화하도록 변경되었습니다.
- 환경 변수 REACT_APP_KAKAO_MAP_ID를 window._ENV 객체에서 가져오도록 변경하였습니다. 기존에는 process.env에서 직접 가져왔습니다.
- window.kakao 타입을 window.d.ts 파일에 정의하였습니다. 이전에는 Map.tsx 파일 내부에 선언되어 있었습니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
