### PR TITLE
frontend/DANG-469: 로그인 상태 관리 관련 로직 리펙토링

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -2,7 +2,6 @@ import { httpClient } from './http';
 
 export type ResponseToken = {
     accessToken: string;
-    expiresIn: number;
 };
 
 const getAccessToken = async (): Promise<ResponseToken> => {
@@ -13,7 +12,6 @@ const getAccessToken = async (): Promise<ResponseToken> => {
 export interface LoginParams {
     authorizeCode: string;
     provider: string;
-    redirectURI: string;
 }
 const requestLogin = async (params: LoginParams) => {
     const { data } = await httpClient.post('/auth/login', params);

--- a/frontend/src/components/OAuthButton.tsx
+++ b/frontend/src/components/OAuthButton.tsx
@@ -5,6 +5,7 @@ import icKakao from '@/assets/icons/ic-kakao.svg';
 import icNaver from '@/assets/icons/ic-naver.svg';
 import { useLoginBottomSheetStateStore } from '@/store/loginBottomSheetStore';
 import { getAuthorizeCodeCallbackUrl } from '@/utils/oauth';
+import { storageKeys } from '@/constants';
 
 type Props = {
     provider: string;
@@ -37,8 +38,8 @@ const OAuthButton = ({ provider, name }: Props) => {
         }
     };
     const handleCallOAuth = (provider: string) => {
-        setStorage('provider', provider);
-        setStorage('redirectURI', window.location.pathname);
+        setStorage(storageKeys.PROVIDER, provider);
+        setStorage(storageKeys.REDIRECT_URI, window.location.pathname);
         let url = getAuthorizeCodeCallbackUrl(provider);
         window.location.href = url;
     };

--- a/frontend/src/constants/keys.ts
+++ b/frontend/src/constants/keys.ts
@@ -1,6 +1,21 @@
 const tokenKeys = {
-    ACCESS_TOKEN: 'accessToken',
     AUTHORIZATION: 'Authorization',
 } as const;
 
-export { tokenKeys };
+const cookieKeys = {
+    EXPIRES_IN: 'expiresIn',
+    IS_LOGGED_IN: 'isLoggedIn',
+} as const;
+
+const queryKeys = {
+    AUTH: 'auth',
+    GET_ACCESS_TOKEN: 'getAccessToken',
+} as const;
+
+const storageKeys = {
+    IS_JOINING: 'isJoining',
+    REDIRECT_URI: 'redirectURI',
+    PROVIDER: 'provider',
+} as const;
+
+export { tokenKeys, cookieKeys, queryKeys, storageKeys };

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -10,6 +10,7 @@ import './index.css';
 import reportWebVitals from './reportWebVitals';
 import Join from '@/pages/Join';
 import Walk from '@/pages/Walk';
+import OauthCallback from '@/pages/OauthCallback';
 const router = createBrowserRouter([
     {
         path: '/',
@@ -39,6 +40,10 @@ const router = createBrowserRouter([
             {
                 path: '/walk',
                 element: <Walk />,
+            },
+            {
+                path: '/callback',
+                element: <OauthCallback />,
             },
         ],
     },

--- a/frontend/src/models/dog.model.ts
+++ b/frontend/src/models/dog.model.ts
@@ -18,3 +18,5 @@ export interface WalkingDog extends Dog {
     fecesLocations: Position[];
     urineLocations: Position[];
 }
+
+export type Gender = 'MALE' | 'FEMALE' | null;

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -2,14 +2,12 @@ import LoginAlertModal from '@/components/LoginAlertModal';
 import DogCardList from '@/components/home/DogCardList';
 import WeatherInfo from '@/components/home/WeatherInfo';
 import { useAuth } from '@/hooks/useAuth';
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Button } from '@/components/common/Button';
 import { NAV_HEIGHT, TOP_BAR_HEIGHT } from '@/constants/style';
 import { DogStatistic } from '@/components/home/DogCard';
 import Notification from '@/assets/icons/notification.svg';
 import Topbar from '@/components/common/Topbar';
-import { useLocation } from 'react-router-dom';
-import { getStorage } from '@/utils/storage';
 
 const dogs: DogStatistic[] = [
     {
@@ -39,17 +37,7 @@ const dogs: DogStatistic[] = [
 ];
 
 function Home() {
-    const { search } = useLocation();
-    const params = new URLSearchParams(search);
-    const authorizeCode = params.get('code');
-    const provider = getStorage('provider');
-    const redirectURI = window.location.pathname;
-    const { isLoggedIn, loginMutation } = useAuth();
-    useEffect(() => {
-        if (authorizeCode && provider && !isLoggedIn) {
-            loginMutation.mutate({ authorizeCode, provider, redirectURI });
-        }
-    }, []);
+    const { isLoggedIn } = useAuth();
     return (
         <>
             <Topbar>

--- a/frontend/src/pages/Join.tsx
+++ b/frontend/src/pages/Join.tsx
@@ -10,14 +10,18 @@ import PetOwner from '@/pages/JoinStep/PetOwner';
 import DogRegister1 from '@/pages/JoinStep/DogRegister1';
 import Cancel from '@/assets/icons/ic-top-cancel.svg';
 import DogRegister2 from '@/pages/JoinStep/DogRegister2';
+import { Gender } from '@/models/dog.model';
+import { getAuthorizeCodeCallbackUrl } from '@/utils/oauth';
+import { storageKeys } from '@/constants';
 export default function Join() {
     const navigate = useNavigate();
     const location = useLocation();
     const state = location.state;
-    const backToPathname = getStorage('redirectURI') || '';
+    const backToPathname = getStorage(storageKeys.REDIRECT_URI) || '';
     const [haveADog, sethaveADog] = useState(true);
-    const [gender, setGender] = useState('');
-    const handleGenderChange = (gender: string) => {
+    const [gender, setGender] = useState<Gender>(null);
+    const provider = getStorage(storageKeys.PROVIDER) || '';
+    const handleGenderChange = (gender: Gender) => {
         setGender(gender);
     };
     console.log(state);
@@ -97,8 +101,8 @@ export default function Join() {
     const handleNextStep = () => {
         if (step === 'PetOwner' && !haveADog) {
             //바로 로그인
-            // const url = getAuthorizeCodeCallbackUrl(provider);
-            // window.location.href = url;
+            const url = getAuthorizeCodeCallbackUrl(provider);
+            window.location.href = url;
         }
         switch (step) {
             case 'Agreements':
@@ -127,13 +131,12 @@ export default function Join() {
         }, 250);
     };
     const handleCancel = () => {
-        //바로 로그인
-        // const url = getAuthorizeCodeCallbackUrl(provider);
-        // window.location.href = url;
+        const url = getAuthorizeCodeCallbackUrl(provider);
+        window.location.href = url;
     };
     const disabled = !agreements.service || !agreements.location || !agreements.personalInfo;
     useEffect(() => {
-        setStorage('isJoinning', 'true');
+        setStorage(storageKeys.IS_JOINING, 'true');
     }, []);
     return (
         <div

--- a/frontend/src/pages/JoinStep/DogRegister2.tsx
+++ b/frontend/src/pages/JoinStep/DogRegister2.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import Male from '@/assets/icons/ic-sex-male.svg';
 import FeMale from '@/assets/icons/ic-sex-femal.svg';
 import { Divider } from '@/components/common/Divider';
+import { Checkbox } from '@/components/common/Checkbox2';
+import { Gender } from '@/models/dog.model';
 interface Props {
-    gender: string;
-    handleGenderChange: (gender: string) => void;
+    gender: Gender;
+    handleGenderChange: (gender: Gender) => void;
 }
 export default function DogRegister2({ gender, handleGenderChange }: Props) {
     return (
@@ -67,8 +69,15 @@ export default function DogRegister2({ gender, handleGenderChange }: Props) {
                 </button>
             </div>
             <div className="mt-2">
-                <input type="checkbox" name="isNeutered" id="isNeutered" />
-                <label htmlFor="isNeutered">중성화 했어요</label>
+                {/* <input type="checkbox" name="isNeutered" id="isNeutered" />
+                <label htmlFor="isNeutered">중성화 했어요</label> */}
+                <Checkbox
+                    checked={true}
+                    onCheckedChange={(checked: boolean) => {
+                        console.log(checked);
+                    }}
+                    labelText="중성화 했어요"
+                />
             </div>
             <div className="mt-8">
                 <div className="py-3 relative">

--- a/frontend/src/pages/OauthCallback.tsx
+++ b/frontend/src/pages/OauthCallback.tsx
@@ -1,0 +1,21 @@
+import { storageKeys } from '@/constants';
+import { useAuth } from '@/hooks/useAuth';
+import { getStorage } from '@/utils/storage';
+import React, { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function OauthCallback() {
+    const { loginMutation } = useAuth();
+    const { search } = useLocation();
+    const params = new URLSearchParams(search);
+    const authorizeCode = params.get('code');
+    const provider = getStorage(storageKeys.PROVIDER);
+
+    useEffect(() => {
+        if (authorizeCode && provider) {
+            loginMutation.mutate({ authorizeCode, provider });
+        }
+    }, []);
+
+    return <div>Loading...</div>;
+}

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,28 +1,14 @@
 import React from 'react';
 import LoginAlertModal from '@/components/LoginAlertModal';
 import { useAuth } from '@/hooks/useAuth';
-import { getStorage } from '@/utils/storage';
-import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
 
 function Profile() {
-    const { search } = useLocation();
-    const params = new URLSearchParams(search);
-    const authorizeCode = params.get('code');
-    const provider = getStorage('provider');
-    const redirectURI = window.location.pathname;
-    const { loginMutation, isLoggedIn, logoutMutation } = useAuth();
+    const { isLoggedIn, logoutMutation } = useAuth();
 
-    useEffect(() => {
-        if (authorizeCode && provider && !isLoggedIn) {
-            loginMutation.mutate({ authorizeCode, provider, redirectURI });
-        }
-    }, []);
     return (
         <div className="flex flex-col w-full items-center h-full">
             <div className={`w-full h-full ${isLoggedIn ? '' : 'blur-sm'}`}>
                 <button onClick={() => logoutMutation.mutate(null)}>로그아웃</button>
-                <div>fdsfdsfdsafdsafdhskafhkdshflds</div>
                 <div>fdsfdsfdsafdsafdhskafhkdshflds</div>
                 <div>fdsfdsfdsafdsafdhskafhkdshflds</div>
                 <div>fdsfdsfdsafdsafdhskafhkdshflds</div>

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,0 +1,25 @@
+import { cookieKeys, storageKeys, tokenKeys } from '@/constants';
+import { getCookie } from '@/utils/cookie';
+import { removeHeader, setHeader } from '@/utils/header';
+import { removeStorage } from '@/utils/storage';
+import { create } from 'zustand';
+
+interface StoreState {
+    isStoreLogin: boolean;
+    storeLogin: (token: string) => void;
+    storeLogout: () => void;
+}
+
+export const useAuthStore = create<StoreState>((set) => ({
+    isStoreLogin: getCookie(cookieKeys.IS_LOGGED_IN),
+    storeLogin: (token: string) => {
+        setHeader(tokenKeys.AUTHORIZATION, `Bearer ${token}`);
+        set({ isStoreLogin: getCookie(cookieKeys.IS_LOGGED_IN) });
+    },
+    storeLogout: () => {
+        set({ isStoreLogin: getCookie(cookieKeys.IS_LOGGED_IN) });
+        removeHeader(tokenKeys.AUTHORIZATION);
+        removeStorage(storageKeys.REDIRECT_URI);
+        removeStorage(storageKeys.PROVIDER);
+    },
+}));

--- a/frontend/src/types/common.ts
+++ b/frontend/src/types/common.ts
@@ -1,4 +1,4 @@
-import { UseMutationOptions } from '@tanstack/react-query';
+import { QueryKey, UseMutationOptions, UseQueryOptions } from '@tanstack/react-query';
 import { AxiosError } from 'axios';
 
 type ResponseError = AxiosError<{ statusCode: string; message: string; error: string }>;
@@ -8,4 +8,8 @@ type UseMutationCustomOptions<TData = unknown, TVariables = unknown> = Omit<
     'mutationFn'
 >;
 
-export type { ResponseError, UseMutationCustomOptions };
+type UseQueryCustomOptions<TQueryFnData = unknown, TData = TQueryFnData> = Omit<
+    UseQueryOptions<TQueryFnData, ResponseError, TData, QueryKey>,
+    'queryKey'
+>;
+export type { ResponseError, UseMutationCustomOptions, UseQueryCustomOptions };

--- a/frontend/src/utils/cookie.ts
+++ b/frontend/src/utils/cookie.ts
@@ -1,0 +1,9 @@
+import { Cookies } from 'react-cookie';
+
+const cookie = new Cookies();
+
+const getCookie = (key: string) => {
+    return cookie.get(key);
+};
+
+export { getCookie };

--- a/frontend/src/utils/oauth.ts
+++ b/frontend/src/utils/oauth.ts
@@ -1,5 +1,3 @@
-import { getStorage } from '@/utils/storage';
-
 const getAuthorizeCodeCallbackUrl = (provider: string) => {
     const {
         REACT_APP_BASE_URL: BASE_URL = '',
@@ -9,16 +7,15 @@ const getAuthorizeCodeCallbackUrl = (provider: string) => {
     } = window._ENV ?? process.env;
 
     let url = '';
-    const currentUrl = getStorage('redirectURI');
     switch (provider) {
         case 'google':
-            url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${BASE_URL}${currentUrl}&response_type=code&access_type=offline&scope=https://www.googleapis.com/auth/userinfo.email&prompt=consent`;
+            url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${BASE_URL}/callback&response_type=code&access_type=offline&scope=https://www.googleapis.com/auth/userinfo.email&prompt=consent`;
             break;
         case 'kakao':
-            url = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${KAKAO_CLIENT_ID}&redirect_uri=${BASE_URL}${currentUrl}`;
+            url = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${KAKAO_CLIENT_ID}&redirect_uri=${BASE_URL}/callback`;
             break;
         case 'naver':
-            url = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&redirect_uri=${BASE_URL}${currentUrl}&state=naverLoginState`;
+            url = `https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=${NAVER_CLIENT_ID}&redirect_uri=${BASE_URL}/callback&state=naverLoginState`;
             break;
     }
     return url;


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
기존 로그인 상태를 관리를 getAccessToken api의 성공여부로 관리를 했지만,
chrome caching(back/forward) 관련 이슈때문에 cookie 상태로 로그인 상태를 관리하는 것으로 리펙토링

## 링크 (Links)
참고 https://blog.hoseung.me/2020-10-31-chrome-back-forward-cache
## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
