### PR TITLE
backend/DANG-470: 회원가입, 로그인 API의 Body 값에서 redirectURI를 삭제하고 origin + /callback 고정값 사용

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -27,10 +27,9 @@ export class AuthController {
     async login(
         @Body('authorizeCode') authorizeCode: string,
         @Body('provider') provider: OauthProvider,
-        @Body('redirectURI') redirectURI: string,
         @Res({ passthrough: true }) response: Response
     ): Promise<accessTokenResponse> {
-        const { accessToken, refreshToken } = await this.authService.login(authorizeCode, provider, redirectURI);
+        const { accessToken, refreshToken } = await this.authService.login(authorizeCode, provider);
 
         response.cookie('refreshToken', refreshToken, {
             httpOnly: true,
@@ -49,10 +48,9 @@ export class AuthController {
     async signup(
         @Body('authorizeCode') authorizeCode: string,
         @Body('provider') provider: OauthProvider,
-        @Body('redirectURI') redirectURI: string,
         @Res({ passthrough: true }) response: Response
     ): Promise<accessTokenResponse> {
-        const { accessToken, refreshToken } = await this.authService.signup(authorizeCode, provider, redirectURI);
+        const { accessToken, refreshToken } = await this.authService.signup(authorizeCode, provider);
 
         response.cookie('refreshToken', refreshToken, {
             httpOnly: true,

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -81,7 +81,7 @@ describe('AuthService', () => {
             it(`${provider} 로그인 후 access token과 refresh token을 반환해야 한다.`, async () => {
                 jest.spyOn(usersService, 'updateAndFindOne').mockResolvedValue({ id: 1 } as Users);
 
-                const result = await service.login(authorizeCode, provider as OauthProvider, '/refresh');
+                const result = await service.login(authorizeCode, provider as OauthProvider);
 
                 expect(result).toEqual({
                     accessToken: mockUser.refreshToken,
@@ -97,7 +97,7 @@ describe('AuthService', () => {
             it(`${provider} 회원가입 후 access token과 refresh token을 반환해야 한다.`, async () => {
                 jest.spyOn(usersService, 'createIfNotExists').mockResolvedValue({ id: 1 } as Users);
 
-                const result = await service.signup(authorizeCode, provider as OauthProvider, '/refresh');
+                const result = await service.signup(authorizeCode, provider as OauthProvider);
 
                 expect(result).toEqual({
                     accessToken: mockUser.refreshToken,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -19,20 +19,15 @@ export class AuthService {
         private readonly configService: ConfigService
     ) {}
 
-    private getFullURI(redirectURI: string) {
-        if (!redirectURI.startsWith('/')) return redirectURI;
-
-        return this.configService.get<string>('CORS_ORIGIN') + redirectURI;
-    }
+    private readonly redirectURI = this.configService.get<string>('CORS_ORIGIN') + '/callback';
 
     private async getOauthData(
         authorizeCode: string,
-        provider: OauthProvider,
-        redirectURI: string
+        provider: OauthProvider
     ): Promise<{ oauthAccessToken: string; oauthRefreshToken: string; oauthId: string }> {
         const { access_token: oauthAccessToken, refresh_token: oauthRefreshToken } = await this[
             `${provider}Service`
-        ].requestToken(authorizeCode, this.getFullURI(redirectURI));
+        ].requestToken(authorizeCode, this.redirectURI);
 
         const oauthId = await this[`${provider}Service`].requestUserId(oauthAccessToken);
 
@@ -41,14 +36,9 @@ export class AuthService {
 
     async login(
         authorizeCode: string,
-        provider: OauthProvider,
-        redirectURI: string
+        provider: OauthProvider
     ): Promise<{ accessToken: string; refreshToken: string }> {
-        const { oauthAccessToken, oauthRefreshToken, oauthId } = await this.getOauthData(
-            authorizeCode,
-            provider,
-            redirectURI
-        );
+        const { oauthAccessToken, oauthRefreshToken, oauthId } = await this.getOauthData(authorizeCode, provider);
 
         const refreshToken = this.tokenService.signRefreshToken(oauthId, provider);
 
@@ -64,14 +54,9 @@ export class AuthService {
 
     async signup(
         authorizeCode: string,
-        provider: OauthProvider,
-        redirectURI: string
+        provider: OauthProvider
     ): Promise<{ accessToken: string; refreshToken: string }> {
-        const { oauthAccessToken, oauthRefreshToken, oauthId } = await this.getOauthData(
-            authorizeCode,
-            provider,
-            redirectURI
-        );
+        const { oauthAccessToken, oauthRefreshToken, oauthId } = await this.getOauthData(authorizeCode, provider);
 
         const refreshToken = this.tokenService.signRefreshToken(oauthId, provider);
 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
OAuth App마다 등록 가능한 redirectURI 개수에 제한이 있는터라 그냥 origin + /callback으로 redirectURI를 고정하기로 했다.

## 링크 (Links)
https://www.notion.so/do0ori/redirectUri-origin-callback-1b3a59e2cd0b4f72986c79fdd8ea6d64

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
