### PR TITLE
backend/DANG-357: 산책일지 상세 API 구현

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -14,11 +14,12 @@ import { WinstonLoggerModule } from './common/logger/winstonLogger.module';
 import { DogWalkDayModule } from './dog-walk-day/dog-walk-day.module';
 import { DogsModule } from './dogs/dogs.module';
 import { ExcrementsModule } from './excrements/excrements.module';
+import { JournalPhotosModule } from './journal-photos/journal-photos.module';
+import { JournalsDogsModule } from './journals-dogs/journals-dogs.module';
 import { JournalModule } from './journals/journals.module';
 import { UsersModule } from './users/users.module';
 import { WalkLogPhotosModule } from './walk-log-photos/walk-log-photos.module';
 import { WalkModule } from './walk/walk.module';
-import { JournalPhotosModule } from './journal-photos/journal-photos.module';
 
 @Module({
     imports: [
@@ -45,6 +46,7 @@ import { JournalPhotosModule } from './journal-photos/journal-photos.module';
         ExcrementsModule,
         WalkLogPhotosModule,
         JournalPhotosModule,
+        JournalsDogsModule,
     ],
     controllers: [AppController, HealthController],
     providers: [

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -18,7 +18,6 @@ import { JournalPhotosModule } from './journal-photos/journal-photos.module';
 import { JournalsDogsModule } from './journals-dogs/journals-dogs.module';
 import { JournalModule } from './journals/journals.module';
 import { UsersModule } from './users/users.module';
-import { WalkLogPhotosModule } from './walk-log-photos/walk-log-photos.module';
 import { WalkModule } from './walk/walk.module';
 
 @Module({
@@ -44,7 +43,6 @@ import { WalkModule } from './walk/walk.module';
         DogWalkDayModule,
         JournalModule,
         ExcrementsModule,
-        WalkLogPhotosModule,
         JournalPhotosModule,
         JournalsDogsModule,
     ],

--- a/backend/src/journals-dogs/journals-dogs.entity.ts
+++ b/backend/src/journals-dogs/journals-dogs.entity.ts
@@ -1,6 +1,6 @@
 import { Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
 import { Dogs } from '../dogs/dogs.entity';
-import { Journals } from './journals.entity';
+import { Journals } from '../journals/journals.entity';
 
 @Entity('journals_dogs')
 export class JournalsDogs {

--- a/backend/src/journals-dogs/journals-dogs.module.ts
+++ b/backend/src/journals-dogs/journals-dogs.module.ts
@@ -1,7 +1,12 @@
 import { Module } from '@nestjs/common';
+import { DatabaseModule } from 'src/common/database/database.module';
+import { JournalsDogs } from './journals-dogs.entity';
+import { JournalsDogsRepository } from './journals-dogs.repository';
 import { JournalsDogsService } from './journals-dogs.service';
 
 @Module({
-  providers: [JournalsDogsService]
+    imports: [DatabaseModule.forFeature([JournalsDogs])],
+    providers: [JournalsDogsService, JournalsDogsRepository],
+    exports: [JournalsDogsService],
 })
 export class JournalsDogsModule {}

--- a/backend/src/journals-dogs/journals-dogs.module.ts
+++ b/backend/src/journals-dogs/journals-dogs.module.ts
@@ -1,5 +1,5 @@
 import { Module } from '@nestjs/common';
-import { DatabaseModule } from 'src/common/database/database.module';
+import { DatabaseModule } from '../common/database/database.module';
 import { JournalsDogs } from './journals-dogs.entity';
 import { JournalsDogsRepository } from './journals-dogs.repository';
 import { JournalsDogsService } from './journals-dogs.service';

--- a/backend/src/journals-dogs/journals-dogs.module.ts
+++ b/backend/src/journals-dogs/journals-dogs.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { JournalsDogsService } from './journals-dogs.service';
+
+@Module({
+  providers: [JournalsDogsService]
+})
+export class JournalsDogsModule {}

--- a/backend/src/journals-dogs/journals-dogs.repository.ts
+++ b/backend/src/journals-dogs/journals-dogs.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { AbstractRepository } from 'src/common/database/abstract.repository';
-import { JournalsDogs } from 'src/journals/journals-dogs.entity';
+import { JournalsDogs } from 'src/journals-dogs/journals-dogs.entity';
 import { EntityManager, Repository } from 'typeorm';
 
 @Injectable()

--- a/backend/src/journals-dogs/journals-dogs.repository.ts
+++ b/backend/src/journals-dogs/journals-dogs.repository.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { AbstractRepository } from 'src/common/database/abstract.repository';
-import { JournalsDogs } from 'src/journals-dogs/journals-dogs.entity';
 import { EntityManager, Repository } from 'typeorm';
+import { AbstractRepository } from '../common/database/abstract.repository';
+import { JournalsDogs } from './journals-dogs.entity';
 
 @Injectable()
 export class JournalsDogsRepository extends AbstractRepository<JournalsDogs> {

--- a/backend/src/journals-dogs/journals-dogs.repository.ts
+++ b/backend/src/journals-dogs/journals-dogs.repository.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { AbstractRepository } from 'src/common/database/abstract.repository';
+import { JournalsDogs } from 'src/journals/journals-dogs.entity';
+import { EntityManager, Repository } from 'typeorm';
+
+@Injectable()
+export class JournalsDogsRepository extends AbstractRepository<JournalsDogs> {
+    constructor(
+        @InjectRepository(JournalsDogs)
+        journalsDogsRepository: Repository<JournalsDogs>,
+        entityManager: EntityManager
+    ) {
+        super(journalsDogsRepository, entityManager);
+    }
+}

--- a/backend/src/journals-dogs/journals-dogs.service.ts
+++ b/backend/src/journals-dogs/journals-dogs.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { JournalsDogs } from 'src/journals/journals-dogs.entity';
+import { FindOptionsWhere } from 'typeorm';
+import { JournalsDogsRepository } from './journals-dogs.repository';
+
+@Injectable()
+export class JournalsDogsService {
+    constructor(private readonly journalsDogsRepository: JournalsDogsRepository) {}
+
+    async findOne(where: FindOptionsWhere<JournalsDogs>): Promise<JournalsDogs> {
+        return this.journalsDogsRepository.findOne(where);
+    }
+
+    async find(where: FindOptionsWhere<JournalsDogs>): Promise<JournalsDogs[]> {
+        return this.journalsDogsRepository.find(where);
+    }
+}

--- a/backend/src/journals-dogs/journals-dogs.service.ts
+++ b/backend/src/journals-dogs/journals-dogs.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { JournalsDogs } from 'src/journals-dogs/journals-dogs.entity';
 import { FindOptionsWhere } from 'typeorm';
+import { JournalsDogs } from './journals-dogs.entity';
 import { JournalsDogsRepository } from './journals-dogs.repository';
 
 @Injectable()

--- a/backend/src/journals-dogs/journals-dogs.service.ts
+++ b/backend/src/journals-dogs/journals-dogs.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { JournalsDogs } from 'src/journals/journals-dogs.entity';
+import { JournalsDogs } from 'src/journals-dogs/journals-dogs.entity';
 import { FindOptionsWhere } from 'typeorm';
 import { JournalsDogsRepository } from './journals-dogs.repository';
 

--- a/backend/src/journals/dto/journals-detail.dto.ts
+++ b/backend/src/journals/dto/journals-detail.dto.ts
@@ -1,8 +1,19 @@
 import { Type } from 'class-transformer';
 import { IsNotEmpty, IsUrl, ValidateNested } from 'class-validator';
-export class JournalDetailDogDto {
+
+export class PhotoUrlDto {
     @IsNotEmpty()
-    id: string;
+    @IsUrl()
+    photoUrl: string;
+
+    static getKey() {
+        return 'photoUrl';
+    }
+}
+
+export class DogInfoForDetail {
+    @IsNotEmpty()
+    id: number;
 
     @IsNotEmpty()
     name: string;
@@ -16,6 +27,22 @@ export class JournalDetailDogDto {
 
     @IsNotEmpty()
     urinesCnt: number;
+
+    //TODO : reflect -metadata 사용하도록 변경
+    static getKeysForDogTable() {
+        return ['id', 'name', 'photoUrl'];
+    }
+}
+
+export class Companions {
+    @IsNotEmpty()
+    id: number;
+
+    @IsNotEmpty()
+    name: string;
+
+    @IsNotEmpty()
+    photoUrl: string;
 }
 
 export class RouteDto {
@@ -26,7 +53,7 @@ export class RouteDto {
     y: number;
 }
 
-export class JournalDetailDto {
+export class JournalInfoForDetail {
     @IsNotEmpty()
     title: string;
 
@@ -40,27 +67,42 @@ export class JournalDetailDto {
     duration: number;
 
     @IsNotEmpty()
-    @ValidateNested({ each: true })
-    @Type(() => RouteDto)
-    routes: RouteDto[];
-
-    @IsNotEmpty()
     @IsUrl()
     routeUrl: string;
-
-    @IsNotEmpty()
-    @IsUrl({}, { each: true })
-    photoUrls: string[];
 
     @IsNotEmpty()
     memo: string;
 
     @IsNotEmpty()
+    @IsUrl({}, { each: true })
+    photoUrls: string[];
+
+    static getKeysForJournalTable() {
+        return ['title', 'distance', 'calories', 'duration', 'logImageUrl', 'memo'];
+    }
+    static getKeysForJournalPhotoTable() {
+        return ['photoUrls'];
+    }
+}
+
+export class JournalDetailDto {
+    @IsNotEmpty()
     @ValidateNested()
-    @Type(() => JournalDetailDogDto)
-    dog: JournalDetailDogDto;
+    @Type(() => JournalInfoForDetail)
+    journalInfo: JournalInfoForDetail;
 
     @IsNotEmpty()
-    @IsUrl({}, { each: true })
-    companions: string[];
+    @ValidateNested()
+    @Type(() => DogInfoForDetail)
+    dog: DogInfoForDetail;
+
+    @IsNotEmpty()
+    @Type(() => Companions)
+    companions: Companions[];
+
+    constructor(journalInfo: JournalInfoForDetail, dogInfo: DogInfoForDetail, companions: Companions[]) {
+        this.journalInfo = journalInfo;
+        this.dog = dogInfo;
+        this.companions = companions;
+    }
 }

--- a/backend/src/journals/dto/journals-detail.dto.ts
+++ b/backend/src/journals/dto/journals-detail.dto.ts
@@ -1,66 +1,66 @@
 import { Type } from 'class-transformer';
 import { IsNotEmpty, IsUrl, ValidateNested } from 'class-validator';
-class DogDto {
+export class JournalDetailDogDto {
     @IsNotEmpty()
     id: string;
-  
+
     @IsNotEmpty()
     name: string;
-  
+
     @IsNotEmpty()
     @IsUrl()
     photoUrl: string;
-  
+
     @IsNotEmpty()
     fecesCnt: number;
-  
+
     @IsNotEmpty()
     urinesCnt: number;
-  }
-  
-  class RouteDto {
+}
+
+export class RouteDto {
     @IsNotEmpty()
     x: number;
-  
+
     @IsNotEmpty()
     y: number;
-  }
-  
-  export class CreateWalkDto {
+}
+
+export class JournalDetailDto {
     @IsNotEmpty()
     title: string;
-  
+
     @IsNotEmpty()
     distance: number;
-  
+
     @IsNotEmpty()
     calorie: number;
-  
+
     @IsNotEmpty()
     duration: number;
-  
+
     @IsNotEmpty()
     @ValidateNested({ each: true })
     @Type(() => RouteDto)
     routes: RouteDto[];
-  
+
     @IsNotEmpty()
     @IsUrl()
     routeUrl: string;
-  
+
     @IsNotEmpty()
-    @IsUrl({},{ each: true })
+    @IsUrl({}, { each: true })
     photoUrls: string[];
-  
+
     @IsNotEmpty()
     memo: string;
-  
+
     @IsNotEmpty()
     @ValidateNested()
-    @Type(() => DogDto)
-    dog: DogDto;
-  
+    @Type(() => JournalDetailDogDto)
+    dog: JournalDetailDogDto;
+
     @IsNotEmpty()
     @IsUrl({}, { each: true })
     companions: string[];
-  }
+}

--- a/backend/src/journals/dto/journals-detail.dto.ts
+++ b/backend/src/journals/dto/journals-detail.dto.ts
@@ -1,0 +1,66 @@
+import { Type } from 'class-transformer';
+import { IsNotEmpty, IsUrl, ValidateNested } from 'class-validator';
+class DogDto {
+    @IsNotEmpty()
+    id: string;
+  
+    @IsNotEmpty()
+    name: string;
+  
+    @IsNotEmpty()
+    @IsUrl()
+    photoUrl: string;
+  
+    @IsNotEmpty()
+    fecesCnt: number;
+  
+    @IsNotEmpty()
+    urinesCnt: number;
+  }
+  
+  class RouteDto {
+    @IsNotEmpty()
+    x: number;
+  
+    @IsNotEmpty()
+    y: number;
+  }
+  
+  export class CreateWalkDto {
+    @IsNotEmpty()
+    title: string;
+  
+    @IsNotEmpty()
+    distance: number;
+  
+    @IsNotEmpty()
+    calorie: number;
+  
+    @IsNotEmpty()
+    duration: number;
+  
+    @IsNotEmpty()
+    @ValidateNested({ each: true })
+    @Type(() => RouteDto)
+    routes: RouteDto[];
+  
+    @IsNotEmpty()
+    @IsUrl()
+    routeUrl: string;
+  
+    @IsNotEmpty()
+    @IsUrl({},{ each: true })
+    photoUrls: string[];
+  
+    @IsNotEmpty()
+    memo: string;
+  
+    @IsNotEmpty()
+    @ValidateNested()
+    @Type(() => DogDto)
+    dog: DogDto;
+  
+    @IsNotEmpty()
+    @IsUrl({}, { each: true })
+    companions: string[];
+  }

--- a/backend/src/journals/journals.controller.ts
+++ b/backend/src/journals/journals.controller.ts
@@ -1,16 +1,26 @@
-import { Controller, Post } from '@nestjs/common';
-import { ExcrementsService } from '../excrements/excrements.service';
+import { Controller, ForbiddenException, Get, ParseIntPipe, Post, Query } from '@nestjs/common';
+import { AccessTokenPayload } from 'src/auth/token/token.service';
+import { User } from 'src/users/decorators/user.decorator';
 import { JournalsService } from './journals.service';
 
 @Controller('journals')
 export class JournalsController {
-    constructor(
-        private readonly journalsService: JournalsService,
-        private readonly excrementsService: ExcrementsService
-    ) {}
+    constructor(private readonly journalsService: JournalsService) {}
 
     @Post('/')
     fakeJournalsSave() {
         return true;
+    }
+
+    @Get('/')
+    getJournalDetail(
+        @User() user: AccessTokenPayload,
+        @Query('journalId', ParseIntPipe) journalId: number,
+        @Query('dogId', ParseIntPipe) dogId: number
+    ) {
+        if (!this.journalsService.checkJournalOwnership(user.userId, journalId)) {
+            throw new ForbiddenException('허용되지 않은 접근입니다');
+        }
+        return this.journalsService.getJournalDetail(journalId, dogId);
     }
 }

--- a/backend/src/journals/journals.module.ts
+++ b/backend/src/journals/journals.module.ts
@@ -1,14 +1,18 @@
 import { Module } from '@nestjs/common';
+import { DogsModule } from 'src/dogs/dogs.module';
+import { Excrements } from 'src/excrements/excrements.entity';
+import { JournalPhotosModule } from 'src/journal-photos/journal-photos.module';
 import { DatabaseModule } from '../common/database/database.module';
-import { ExcrementsModule } from '../excrements/excrements.module';
+import { JournalsDogsModule } from '../journals-dogs/journals-dogs.module';
 import { JournalsController } from './journals.controller';
 import { Journals } from './journals.entity';
-import { WalkJournalsRepository } from './journals.repository';
+import { JournalsRepository } from './journals.repository';
 import { JournalsService } from './journals.service';
+import { ExcrementsModule } from 'src/excrements/excrements.module';
 
 @Module({
-    imports: [DatabaseModule.forFeature([Journals]), ExcrementsModule],
-    providers: [JournalsService, WalkJournalsRepository],
+    imports: [DatabaseModule.forFeature([Journals, Excrements]), JournalsDogsModule, DogsModule, JournalPhotosModule, ExcrementsModule],
+    providers: [JournalsService, JournalsRepository],
     controllers: [JournalsController],
 })
 export class JournalModule {}

--- a/backend/src/journals/journals.repository.ts
+++ b/backend/src/journals/journals.repository.ts
@@ -5,7 +5,7 @@ import { AbstractRepository } from '../common/database/abstract.repository';
 import { Journals } from './journals.entity';
 
 @Injectable()
-export class WalkJournalsRepository extends AbstractRepository<Journals> {
+export class JournalsRepository extends AbstractRepository<Journals> {
     constructor(
         @InjectRepository(Journals)
         walkJournalRepository: Repository<Journals>,

--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -1,42 +1,132 @@
-import { Injectable } from '@nestjs/common';
-import { DeleteResult, FindOptionsWhere, UpdateResult } from 'typeorm';
+import { ForbiddenException, Injectable } from '@nestjs/common';
+import { DogsService } from 'src/dogs/dogs.service';
+import { ExcrementsService } from 'src/excrements/excrements.service';
+import { ExcrementsType } from 'src/excrements/types/excrements.enum';
+import { JournalPhotos } from 'src/journal-photos/journal-photos.entity';
+import { JournalPhotosService } from 'src/journal-photos/journal-photos.service';
+import { JournalsDogs } from 'src/journals-dogs/journals-dogs.entity';
+import { JournalsDogsService } from 'src/journals-dogs/journals-dogs.service';
+import { checkIfExistsInArr, makeSubObject } from 'src/utils/manipulate.util';
+import { DeleteResult, FindOptionsWhere, In, UpdateResult } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
+import { DogInfoForDetail, JournalDetailDto, JournalInfoForDetail, PhotoUrlDto } from './dto/journals-detail.dto';
 import { Journals } from './journals.entity';
-import { WalkJournalsRepository } from './journals.repository';
+import { JournalsRepository } from './journals.repository';
 import { CreateJournal } from './types/journal-types';
 
 @Injectable()
 export class JournalsService {
-    constructor(private readonly walkJournalsRepository: WalkJournalsRepository) {}
+    constructor(
+        private readonly journalsRepository: JournalsRepository,
+        private readonly journalsDogsService: JournalsDogsService,
+        private readonly dogsService: DogsService,
+        private readonly journalPhotosService: JournalPhotosService,
+        private readonly excrementsService: ExcrementsService
+    ) {}
 
     async create(entityData: CreateJournal) {
-        const walkJournals = new Journals(entityData);
-        return this.walkJournalsRepository.create(walkJournals);
+        const journals = new Journals(entityData);
+        return this.journalsRepository.create(journals);
     }
 
     async find(where: FindOptionsWhere<Journals>) {
-        return this.walkJournalsRepository.find(where);
+        return this.journalsRepository.find(where);
     }
 
     async findOne(where: FindOptionsWhere<Journals>): Promise<Journals> {
-        return await this.walkJournalsRepository.findOne(where);
+        return await this.journalsRepository.findOne(where);
     }
 
     async update(
         where: FindOptionsWhere<Journals>,
         partialEntity: QueryDeepPartialEntity<Journals>
     ): Promise<UpdateResult> {
-        return this.walkJournalsRepository.update(where, partialEntity);
+        return this.journalsRepository.update(where, partialEntity);
     }
 
     async delete(where: FindOptionsWhere<Journals>): Promise<DeleteResult> {
-        return this.walkJournalsRepository.delete(where);
+        return this.journalsRepository.delete(where);
     }
 
     async updateAndFindOne(
         where: FindOptionsWhere<Journals>,
         partialEntity: QueryDeepPartialEntity<Journals>
     ): Promise<Journals | null> {
-        return this.walkJournalsRepository.updateAndFindOne(where, partialEntity);
+        return this.journalsRepository.updateAndFindOne(where, partialEntity);
+    }
+
+    async getOwnJournals(userId: number): Promise<Journals[]> {
+        return this.journalsRepository.find({ id: userId });
+    }
+
+    async getOwnJournalIds(userId: number): Promise<number[]> {
+        const ownJournals = await this.journalsRepository.find({ id: userId });
+        return ownJournals.map((cur) => cur.id);
+    }
+
+    async getJournalPhotos(journalId: number) {
+        const photoUrlsRaw = await this.journalPhotosService.find({ journalId });
+        const photoUrls = photoUrlsRaw.map((cur) => cur[PhotoUrlDto.getKey() as keyof JournalPhotos]);
+        return photoUrls;
+    }
+
+    async getJournalInfoForDetail(journalId: number): Promise<JournalInfoForDetail> {
+        const journalInfoRaw = await this.findOne({ id: journalId });
+        const keys = JournalInfoForDetail.getKeysForJournalTable();
+        const journalInfo = makeSubObject(journalInfoRaw, keys);
+        journalInfo.photoUrls = this.getJournalPhotos(journalId);
+        return journalInfo;
+    }
+
+    async checkDogExistsInJournal(journalDogs: JournalsDogs[], dogId: number) {
+        const journalDogIds = journalDogs.map((cur) => cur.dogId);
+
+        if (!checkIfExistsInArr(journalDogIds, dogId)) {
+            throw new ForbiddenException('이 일지에 속하지 않은 강아지에 대한 요청');
+        }
+        return;
+    }
+
+    async getExcrementsCnt(journalId: number, dogId: number, type: ExcrementsType): Promise<number> {
+        const excrements = await this.excrementsService.find({ journalId, dogId, type });
+
+        return excrements.length;
+    }
+
+    async getDogInfoForDetail(journalId: number, dogId: number): Promise<DogInfoForDetail> {
+        const dogInfoRaw = await this.dogsService.findOne({ id: dogId });
+        const dogInfo = makeSubObject(dogInfoRaw, DogInfoForDetail.getKeysForDogTable());
+        const fecesCnt = await this.getExcrementsCnt(journalId, dogId, ExcrementsType.feces);
+        const urineCnt = await this.getExcrementsCnt(journalId, dogId, ExcrementsType.urine);
+        dogInfo.fecesCnt = fecesCnt;
+        dogInfo.urineCnt = urineCnt;
+        return dogInfo;
+    }
+
+    async getCompanionsProfile(journalDogs: JournalsDogs[], dogId: number) {
+        const companions = journalDogs.filter((cur) => cur.dogId !== dogId).map((cur) => cur.dogId);
+        const companionsProfile = await this.dogsService.getProfileList({ id: In(companions) });
+        return companionsProfile;
+    }
+
+    //TODO : 예외처리 제대로 되지 않고 있어 개선 필요
+    async getJournalDetail(journalId: number, dogId: number): Promise<JournalDetailDto> {
+        try {
+            const journalDogs = await this.journalsDogsService.find({ journalId });
+            this.checkDogExistsInJournal(journalDogs, dogId);
+
+            const journalInfo = await this.getJournalInfoForDetail(journalId);
+            const dogInfo = await this.getDogInfoForDetail(journalId, dogId);
+            const companionsProfile = await this.getCompanionsProfile(journalDogs, dogId);
+
+            return new JournalDetailDto(journalInfo, dogInfo, companionsProfile);
+        } catch (e) {
+            throw e;
+        }
+    }
+
+    async checkJournalOwnership(userId: number, journalIds: number | number[]): Promise<boolean> {
+        const myJournalIds = await this.getOwnJournalIds(userId);
+        return checkIfExistsInArr(myJournalIds, journalIds);
     }
 }

--- a/backend/src/utils/manipulate.util.ts
+++ b/backend/src/utils/manipulate.util.ts
@@ -63,3 +63,19 @@ export function makeSubObjectsArray(targetArr: any[], attributes: string | strin
     }
     return resArr;
 }
+
+/**
+ * 주어진 타겟 객체에서 지정된 속성만을 포함하는 새 객체를 생성합니다.
+ *
+ * @param target - 속성을 추출할 원본 객체입니다.
+ * @param attributes - 새 객체에 포함할 속성 이름의 배열입니다.
+ * @returns 타겟 객체에서 지정된 속성만을 포함하는 새 객체입니다.
+ *
+ */
+export function makeSubObject(target: any, attributes: string[]): any {
+    const resObj: { [key: string]: any } = {};
+    for (let i = 0; i < attributes.length; i++) {
+        resObj[`${attributes[i]}`] = target[`${attributes[i]}`];
+    }
+    return resObj;
+}

--- a/backend/src/walk-log-photos/walk-log-photos.module.ts
+++ b/backend/src/walk-log-photos/walk-log-photos.module.ts
@@ -1,4 +1,0 @@
-import { Module } from '@nestjs/common';
-
-@Module({})
-export class WalkLogPhotosModule {}

--- a/backend/src/walk-log-photos/walk-log-photos.service.ts
+++ b/backend/src/walk-log-photos/walk-log-photos.service.ts
@@ -1,4 +1,0 @@
-import { Injectable } from '@nestjs/common';
-
-@Injectable()
-export class WalkLogPhotosService {}


### PR DESCRIPTION
## 작업 내용 (Content)
- 산책일지 상세 API를 구현했습니다 
- util 함수인 makeSubObjectsArray와 makeSubObject 함수와 DTO의 getKey() 함수를 조합해 각 테이블에서 필요한 컬럼을 손으로 하드코딩 하지 않고 DTO에 정의해둔 대로 가져올 수 있도록 구조를 만들었습니다

추가 작업이 필요한 부분
- 컬럼명 변경. Dog엔티티까지 수정해야 할 부분이 있어서 여기서 안하고 따로 티켓 만들어서 같이 할 예정
- DTO의 getKey 함수는 하드코딩 되어있기에 이를 reflect-metadata 와 같은 라이브러리를 사용해서 하드코딩된 부분 없앨 수 있는지 찾아보기
- checkDogExistsInJournal의 예외가 제대로 처리되지 않고 있음 (예외를 throw했을 때 컨트롤러 -> 프론트로 전달되는 게 아니라 콘솔에 찍히고 프로그램이 종료되어버림), nest의 예외에 대해 찾아보고 고쳐야 할 것 같음

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
