### PR TITLE
backend/DANG-471: session 관리를 위해 cookie에 isLoggedIn, expiresIn field 추가

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,125 +1,46 @@
-import { Body, Controller, Delete, Get, HttpCode, Post, Res, UseGuards } from '@nestjs/common';
-import { ConfigService } from '@nestjs/config';
-import { Response } from 'express';
+import { Body, Controller, Delete, Get, HttpCode, Post, UseGuards, UseInterceptors } from '@nestjs/common';
 import { User } from '../users/decorators/user.decorator';
 import { AuthService } from './auth.service';
 import { SkipAuthGuard } from './decorators/public.decorator';
 import { RefreshTokenGuard } from './guards/refreshToken.guard';
-import { AccessTokenPayload, RefreshTokenPayload, TOKEN_LIFETIME_MAP } from './token/token.service';
+import { CookieInterceptor } from './interceptors/cookie.interceptor';
+import { AccessTokenPayload, RefreshTokenPayload } from './token/token.service';
 
 export type OauthProvider = 'google' | 'kakao' | 'naver';
 
 @Controller('auth')
+@UseInterceptors(CookieInterceptor)
 export class AuthController {
-    constructor(
-        private configService: ConfigService,
-        private authService: AuthService
-    ) {}
+    constructor(private authService: AuthService) {}
 
     @Post('login')
     @HttpCode(200)
     @SkipAuthGuard()
-    async login(
-        @Body('authorizeCode') authorizeCode: string,
-        @Body('provider') provider: OauthProvider,
-        @Res({ passthrough: true }) response: Response
-    ) {
-        const { accessToken, refreshToken } = await this.authService.login(authorizeCode, provider);
-
-        response.cookie('refreshToken', refreshToken, {
-            httpOnly: true,
-            secure: this.configService.get<string>('NODE_ENV') === 'prod' ? true : false,
-            maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
-        });
-
-        response.cookie('isLoggedIn', true, {
-            secure: this.configService.get<string>('NODE_ENV') === 'prod' ? true : false,
-            maxAge: TOKEN_LIFETIME_MAP.access.maxAge,
-        });
-
-        response.cookie('expiresIn', TOKEN_LIFETIME_MAP.access.maxAge, {
-            secure: this.configService.get<string>('NODE_ENV') === 'prod' ? true : false,
-            maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
-        });
-
-        return {
-            accessToken,
-        };
+    async login(@Body('authorizeCode') authorizeCode: string, @Body('provider') provider: OauthProvider) {
+        return await this.authService.login(authorizeCode, provider);
     }
 
     @Post('signup')
     @SkipAuthGuard()
-    async signup(
-        @Body('authorizeCode') authorizeCode: string,
-        @Body('provider') provider: OauthProvider,
-        @Res({ passthrough: true }) response: Response
-    ) {
-        const { accessToken, refreshToken } = await this.authService.signup(authorizeCode, provider);
-
-        response.cookie('refreshToken', refreshToken, {
-            httpOnly: true,
-            secure: this.configService.get<string>('NODE_ENV') === 'prod' ? true : false,
-            maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
-        });
-
-        response.cookie('isLoggedIn', true, {
-            secure: this.configService.get<string>('NODE_ENV') === 'prod' ? true : false,
-            maxAge: TOKEN_LIFETIME_MAP.access.maxAge,
-        });
-
-        response.cookie('expiresIn', TOKEN_LIFETIME_MAP.access.maxAge, {
-            secure: this.configService.get<string>('NODE_ENV') === 'prod' ? true : false,
-            maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
-        });
-
-        return {
-            accessToken,
-        };
+    async signup(@Body('authorizeCode') authorizeCode: string, @Body('provider') provider: OauthProvider) {
+        return await this.authService.signup(authorizeCode, provider);
     }
 
     @Post('logout')
     @HttpCode(200)
-    async logout(@User() { userId, provider }: AccessTokenPayload, @Res({ passthrough: true }) response: Response) {
-        await this.authService.logout(userId, provider);
-
-        response.clearCookie('refreshToken');
-        response.clearCookie('isLoggedIn');
-        response.clearCookie('expiresIn');
+    async logout(@User() { userId, provider }: AccessTokenPayload) {
+        return await this.authService.logout(userId, provider);
     }
 
     @Delete('deactivate')
-    async deactivate(@User() { userId, provider }: AccessTokenPayload, @Res({ passthrough: true }) response: Response) {
-        await this.authService.deactivate(userId, provider);
-
-        response.clearCookie('refreshToken');
-        response.clearCookie('isLoggedIn');
-        response.clearCookie('expiresIn');
+    async deactivate(@User() { userId, provider }: AccessTokenPayload) {
+        return await this.authService.deactivate(userId, provider);
     }
 
     @Get('token')
     @SkipAuthGuard()
     @UseGuards(RefreshTokenGuard)
-    async token(@User() { oauthId, provider }: RefreshTokenPayload, @Res({ passthrough: true }) response: Response) {
-        const { accessToken, refreshToken } = await this.authService.reissueTokens(oauthId, provider);
-
-        response.cookie('refreshToken', refreshToken, {
-            httpOnly: true,
-            secure: this.configService.get<string>('NODE_ENV') === 'prod' ? true : false,
-            maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
-        });
-
-        response.cookie('isLoggedIn', true, {
-            secure: this.configService.get<string>('NODE_ENV') === 'prod' ? true : false,
-            maxAge: TOKEN_LIFETIME_MAP.access.maxAge,
-        });
-
-        response.cookie('expiresIn', TOKEN_LIFETIME_MAP.access.maxAge, {
-            secure: this.configService.get<string>('NODE_ENV') === 'prod' ? true : false,
-            maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
-        });
-
-        return {
-            accessToken,
-        };
+    async token(@User() { oauthId, provider }: RefreshTokenPayload) {
+        return await this.authService.reissueTokens(oauthId, provider);
     }
 }

--- a/backend/src/auth/interceptors/cookie.interceptor.ts
+++ b/backend/src/auth/interceptors/cookie.interceptor.ts
@@ -1,0 +1,46 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Response } from 'express';
+import { Observable, map } from 'rxjs';
+import { TOKEN_LIFETIME_MAP } from '../token/token.service';
+
+@Injectable()
+export class CookieInterceptor implements NestInterceptor {
+    constructor(private configService: ConfigService) {}
+
+    intercept(context: ExecutionContext, next: CallHandler<any>): Observable<any> | Promise<Observable<any>> {
+        const isProduction = this.configService.get<string>('NODE_ENV') === 'prod';
+
+        return next.handle().pipe(
+            map((data) => {
+                const response = context.switchToHttp().getResponse<Response>();
+
+                if (data) {
+                    const { accessToken, refreshToken } = data;
+
+                    response.cookie('refreshToken', refreshToken, {
+                        httpOnly: true,
+                        secure: isProduction,
+                        maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
+                    });
+
+                    response.cookie('isLoggedIn', true, {
+                        secure: isProduction,
+                        maxAge: TOKEN_LIFETIME_MAP.access.maxAge,
+                    });
+
+                    response.cookie('expiresIn', TOKEN_LIFETIME_MAP.access.maxAge, {
+                        secure: isProduction,
+                        maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
+                    });
+
+                    return { accessToken };
+                } else {
+                    response.clearCookie('refreshToken');
+                    response.clearCookie('isLoggedIn');
+                    response.clearCookie('expiresIn');
+                }
+            })
+        );
+    }
+}


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- accessToken 만료 시간을 seconds에서 miliseconds 단위로 변경했다. (Tanstack query(React query)에서 miliseconds 단위를 사용한다고 한다.)
- 크롬 브라우저에서 cache를 복구하는 기능 때문에 isLoggedIn 정보가 제대로 동작하지 않는 경우가 있어, server에서 cookie로 세션을 관리하기로 했다. client는 cookie에서 isLoggedIn을 꺼내 전역에서 로그인 상태를 관리한다.
- 중복되는 set/clear cookie 응답을 custom cookie interceptor를 만들어 처리했다.

## 링크 (Links)
https://www.notion.so/do0ori/cookie-isLoggedIn-true-expiresIn-number-ms-5428fa48f5bd4bbb83ac4c088ff23d85

## 기타 사항 (Etc)
`CookieInterceptor` 이름 추천 받습니다.🤗

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
