### PR TITLE
backend/DANG-479: naver 로그아웃 시 token 만료 요청 사용하지 않기

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -75,7 +75,9 @@ export class AuthService {
     async logout(id: number, provider: OauthProvider): Promise<void> {
         const { oauthAccessToken } = await this.usersService.findOne({ id });
 
-        await this[`${provider}Service`].requestTokenExpiration(oauthAccessToken);
+        if (provider !== 'naver') {
+            await this[`${provider}Service`].requestTokenExpiration(oauthAccessToken);
+        }
     }
 
     async deactivate(id: number, provider: OauthProvider): Promise<void> {


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
네이버 로그아웃 후 재로그인 시 동의화면이 뜨는 현상이 발생한다.
네이버는 따로 로그아웃이나 회원탈퇴(연동해제)를 지원하는 API가 존재하지 않는다.
그래서 token 만료 요청을 사용했었는데 매 로그인마다 동의화면이 뜨는 관계로 로그아웃 시에는 요청을 보내지 않고 회원탈퇴 때에만 요청을 보내는 것으로 수정하였다.

로그아웃에 대해 정확히 찾아보니 다음과 같다.
- [Naver](https://developers.naver.com/docs/login/api/api.md#3-2--%EC%A0%91%EA%B7%BC-%ED%86%A0%ED%81%B0-%EB%B0%9C%EA%B8%89%EA%B0%B1%EC%8B%A0%EC%82%AD%EC%A0%9C-%EC%9A%94%EC%B2%AD)는 따로 로그아웃 api가 없다. 다음과 같은 방법이 존재한다.
    1. [http://nid.naver.com/nidlogin.logout으로](http://nid.naver.com/nidlogin.logout%EC%9C%BC%EB%A1%9C) 보내기
    2. [재인증 API](https://developers.naver.com/docs/login/devguide/devguide.md#5-2-%EC%9E%AC%EC%9D%B8%EC%A6%9D)(기존 로그인 요청 URL에 `auth_type=reauthenticate` query 추가): 간편 로그인 사용 불가능
    3. 토큰 만료 (회원탈퇴/연동해제 요청과 동일하게 처리): 이 경우 재로그인 시 동의화면이 뜸

여기서 우리는 원래 3번 방법을 사용했으나 1번이나 2번을 사용해야 하지 않을까 싶다. 일단 그쪽은 client에서 처리해야 해서 backend 코드만 수정했다.

## 링크 (Links)
https://www.notion.so/do0ori/e1052e4f84f44567aaaaa2532b5647df

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
