### PR TITLE
frontend/DANG-476: 대소변 컴포넌트의 color 프롭을 선택 사항으로 변경

### DIFF
--- a/frontend/src/components/icon/Feces.tsx
+++ b/frontend/src/components/icon/Feces.tsx
@@ -13,7 +13,7 @@ const variants = {
     },
 } as const;
 
-function Feces({ color, ...props }: Props) {
+function Feces({ color = 'primary', ...props }: Props) {
     return (
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" {...props}>
             <circle cx={12} cy={12} r={11.5} className={variants[color].circle1} />
@@ -29,7 +29,7 @@ function Feces({ color, ...props }: Props) {
 type Color = keyof typeof variants;
 
 interface Props extends Omit<SVGProps<SVGSVGElement>, 'color'> {
-    color: Color;
+    color?: Color;
 }
 
 export { Feces };

--- a/frontend/src/components/icon/Urine.tsx
+++ b/frontend/src/components/icon/Urine.tsx
@@ -13,7 +13,7 @@ const variants = {
     },
 } as const;
 
-function Urine({ color, ...props }: Props) {
+function Urine({ color = 'primary', ...props }: Props) {
     return (
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" {...props}>
             <circle cx={12} cy={12} r={11.5} className={variants[color].circle1} />
@@ -29,7 +29,7 @@ function Urine({ color, ...props }: Props) {
 type Color = keyof typeof variants;
 
 interface Props extends Omit<SVGProps<SVGSVGElement>, 'color'> {
-    color: Color;
+    color?: Color;
 }
 
 export { Urine };


### PR DESCRIPTION
## 작업 내용 (Content)
대소변 컴포넌트의 color 프롭을 선택 사항으로 변경

## 링크 (Links)
https://www.notion.so/do0ori/color-a27cd52a071645c99451fec64c2c581c?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
