### PR TITLE
backend/DANG-485: google 로그아웃 시 token 만료 요청 사용하지 않기

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -75,7 +75,7 @@ export class AuthService {
     async logout(id: number, provider: OauthProvider): Promise<void> {
         const { oauthAccessToken } = await this.usersService.findOne({ id });
 
-        if (provider !== 'naver') {
+        if (provider === 'kakao') {
             await this[`${provider}Service`].requestTokenExpiration(oauthAccessToken);
         }
     }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
naver와 마찬가지로 로그아웃 후 재로그인 시 동의화면이 뜨는 현상이 발생한다.
google도 따로 로그아웃 API가 없어서 token 만료 요청을 사용했는데 매 로그인마다 동의화면이 뜨는 관계로 로그아웃 시에는 요청을 보내지 않는 것으로 수정한다.

## 링크 (Links)
https://www.notion.so/do0ori/4de1d75169024bcaa6cd3989cd466e93

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
