### PR TITLE
backend/DANG-486: 산책일지 생성 API 구현

### DIFF
--- a/backend/src/excrements/excrements.entity.ts
+++ b/backend/src/excrements/excrements.entity.ts
@@ -15,11 +15,7 @@ export class Excrements {
     @JoinColumn({ name: 'dog_id' })
     dogId: number;
 
-    @Column({ name: '' })
-    @Column({
-        type: 'enum',
-        enum: ExcrementsType,
-    })
+    @PrimaryColumn({ name: 'type', type: 'enum', enum: ExcrementsType })
     type: ExcrementsType;
 
     @Column({ type: 'point', spatialFeatureType: 'Point', srid: 4326 })

--- a/backend/src/excrements/excrements.service.ts
+++ b/backend/src/excrements/excrements.service.ts
@@ -20,6 +20,7 @@ export class ExcrementsService {
         return this.excrementsRepository.createIfNotExists(newEntity, [
             'journalId' as keyof Excrements,
             'dogId' as keyof Excrements,
+            'type' as keyof Excrements,
         ]);
     }
 

--- a/backend/src/journal-photos/journal-photos.service.ts
+++ b/backend/src/journal-photos/journal-photos.service.ts
@@ -13,6 +13,11 @@ export class JournalPhotosService {
         return this.journalPhotosRepository.create(newEntity);
     }
 
+    async createIfNotExists(data: Partial<JournalPhotos>, keys: (keyof JournalPhotos)[]): Promise<JournalPhotos> {
+        const newEntity = new JournalPhotos(data);
+        return this.journalPhotosRepository.createIfNotExists(newEntity, keys);
+    }
+
     async findOne(where: FindOptionsWhere<JournalPhotos>): Promise<JournalPhotos> {
         return this.journalPhotosRepository.findOne(where);
     }

--- a/backend/src/journals-dogs/journals-dogs.entity.ts
+++ b/backend/src/journals-dogs/journals-dogs.entity.ts
@@ -13,4 +13,8 @@ export class JournalsDogs {
     @ManyToOne(() => Dogs, (dog) => dog.id, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'dog_id' })
     dogId: number;
+
+    constructor(entityData: JournalsDogs) {
+        Object.assign(this, entityData);
+    }
 }

--- a/backend/src/journals-dogs/journals-dogs.service.ts
+++ b/backend/src/journals-dogs/journals-dogs.service.ts
@@ -7,6 +7,16 @@ import { JournalsDogsRepository } from './journals-dogs.repository';
 export class JournalsDogsService {
     constructor(private readonly journalsDogsRepository: JournalsDogsRepository) {}
 
+    async create(journalId: number, dogId: number): Promise<JournalsDogs> {
+        const newEntity = new JournalsDogs({ journalId, dogId });
+        return await this.journalsDogsRepository.create(newEntity);
+    }
+
+    async createIfNotExists(journalId: number, dogId: number): Promise<JournalsDogs> {
+        const newEntity = new JournalsDogs({ journalId, dogId });
+        return await this.journalsDogsRepository.createIfNotExists(newEntity, ['journalId', 'dogId']);
+    }
+
     async findOne(where: FindOptionsWhere<JournalsDogs>): Promise<JournalsDogs> {
         return this.journalsDogsRepository.findOne(where);
     }

--- a/backend/src/journals/dto/journals-create.dto.ts
+++ b/backend/src/journals/dto/journals-create.dto.ts
@@ -1,0 +1,87 @@
+import { Type } from 'class-transformer';
+import {
+    IsArray,
+    IsDefined,
+    IsNotEmpty,
+    IsNotEmptyObject,
+    IsNumber,
+    IsOptional,
+    IsUrl,
+    ValidateNested,
+} from 'class-validator';
+//TODO : 문자열이면서 숫자 범위를 넘지 않는지 확인하는 custom Validator 만들기..?
+export class Location {
+    @IsNumber()
+    lat: string;
+
+    @IsNumber()
+    lng: string;
+}
+
+export class ExcrementsInfoForCreate {
+    @IsNotEmpty()
+    dogId: number;
+
+    @IsArray()
+    @ValidateNested()
+    @Type(() => Location)
+    fecesLocations: Location[];
+
+    @IsArray()
+    @ValidateNested()
+    @Type(() => Location)
+    urineLocations: Location[];
+}
+
+export class JournalInfoForCreate {
+    @IsNotEmpty()
+    title: string;
+
+    @IsNotEmpty()
+    distance: number;
+
+    @IsNotEmpty()
+    calories: number;
+
+    @IsNotEmpty()
+    startedAt: Date;
+
+    @IsNotEmpty()
+    duration: number;
+
+    @IsNotEmpty()
+    @IsUrl()
+    routeImageUrl: string;
+
+    @IsOptional()
+    memo: string;
+
+    @IsOptional()
+    @IsUrl({}, { each: true })
+    photoUrls: string[];
+
+    static getKeysForJournalTable() {
+        return ['title', 'distance', 'calories', 'startedAt', 'duration', 'routeImageUrl', 'memo'];
+    }
+    static getKeysForJournalPhotoTable() {
+        return ['photoUrls'];
+    }
+}
+
+export class CreateJournalDto {
+    @IsNotEmpty()
+    dogs: number[];
+
+    @IsDefined()
+    @IsNotEmptyObject()
+    @IsNotEmpty()
+    @ValidateNested()
+    @Type(() => JournalInfoForCreate)
+    journalInfo: JournalInfoForCreate;
+
+    @IsOptional()
+    @IsDefined()
+    @ValidateNested()
+    @Type(() => ExcrementsInfoForCreate)
+    excrements: ExcrementsInfoForCreate[];
+}

--- a/backend/src/journals/journals.controller.ts
+++ b/backend/src/journals/journals.controller.ts
@@ -1,16 +1,12 @@
-import { Controller, ForbiddenException, Get, ParseIntPipe, Post, Query } from '@nestjs/common';
+import { Body, Controller, ForbiddenException, Get, ParseIntPipe, Post, Query } from '@nestjs/common';
 import { AccessTokenPayload } from 'src/auth/token/token.service';
 import { User } from 'src/users/decorators/user.decorator';
+import { CreateJournalDto } from './dto/journals-create.dto';
 import { JournalsService } from './journals.service';
 
 @Controller('journals')
 export class JournalsController {
     constructor(private readonly journalsService: JournalsService) {}
-
-    @Post('/')
-    fakeJournalsSave() {
-        return true;
-    }
 
     @Get('/')
     getJournalDetail(
@@ -22,5 +18,10 @@ export class JournalsController {
             throw new ForbiddenException('허용되지 않은 접근입니다');
         }
         return this.journalsService.getJournalDetail(journalId, dogId);
+    }
+
+    @Post('/')
+    async createJournal(@User() user: AccessTokenPayload, @Body() body: CreateJournalDto) {
+        await this.journalsService.createJournal(user.userId, body);
     }
 }

--- a/backend/src/journals/journals.entity.ts
+++ b/backend/src/journals/journals.entity.ts
@@ -16,14 +16,11 @@ export class Journals {
     @Column()
     title: string;
 
-    @Column({ name: 'route_image_url' })
-    routeImageUrl: string;
+    @Column()
+    distance: number;
 
     @Column()
     calories: number;
-
-    @Column({ nullable: true })
-    memo: string;
 
     @Column({ name: 'started_at' })
     startedAt: Date;
@@ -31,8 +28,11 @@ export class Journals {
     @Column()
     duration: number;
 
-    @Column()
-    distance: number;
+    @Column({ name: 'route_image_url' })
+    routeImageUrl: string;
+
+    @Column({ nullable: true })
+    memo: string;
 
     constructor(entityData: Partial<Journals>) {
         Object.assign(this, entityData);

--- a/backend/src/journals/types/journal-types.ts
+++ b/backend/src/journals/types/journal-types.ts
@@ -1,10 +1,10 @@
-export interface CreateJournal {
+export interface CreateJournalData {
     userId: number;
     title: string;
-    logImageUrl: string;
+    distance: number;
     calories: number;
-    memo: string;
     startedAt: Date;
     duration: number;
-    distance: number;
+    routeImageUrl: string;
+    memo?: string;
 }


### PR DESCRIPTION
## 작업 내용 (Content)
산책일지 생성 API를 구현했습니다.

구현 과정에서 excrements의 type도 컴포지트 키에 포함하도록 변경했습니다.
이전에는 journalId, dogId만 pk로 되어있어, 같은 journalId와 dogId를 가지고 있으면 type이 달라도 중복 검사에 걸렸습니다. 
## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
