### PR TITLE
backend/DANG-488: 변경된 로그인/회원가입 flow에 맞게 auth 코드 수정

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,12 +1,19 @@
 import { Body, Controller, Delete, Get, HttpCode, Post, UseGuards, UseInterceptors } from '@nestjs/common';
 import { User } from '../users/decorators/user.decorator';
-import { AuthService } from './auth.service';
+import { AuthService, OauthData } from './auth.service';
+import { OauthCookies } from './decorators/oauthData.decorator';
 import { SkipAuthGuard } from './decorators/public.decorator';
+import { OauthDataGuard } from './guards/oauthData.guard';
 import { RefreshTokenGuard } from './guards/refreshToken.guard';
 import { CookieInterceptor } from './interceptors/cookie.interceptor';
 import { AccessTokenPayload, RefreshTokenPayload } from './token/token.service';
 
 export type OauthProvider = 'google' | 'kakao' | 'naver';
+
+export interface OauthBody {
+    authorizeCode: string;
+    provider: OauthProvider;
+}
 
 @Controller('auth')
 @UseInterceptors(CookieInterceptor)
@@ -16,31 +23,32 @@ export class AuthController {
     @Post('login')
     @HttpCode(200)
     @SkipAuthGuard()
-    async login(@Body('authorizeCode') authorizeCode: string, @Body('provider') provider: OauthProvider) {
-        return await this.authService.login(authorizeCode, provider);
+    async login(@Body() oauthBody: OauthBody) {
+        return await this.authService.login(oauthBody);
     }
 
     @Post('signup')
     @SkipAuthGuard()
-    async signup(@Body('authorizeCode') authorizeCode: string, @Body('provider') provider: OauthProvider) {
-        return await this.authService.signup(authorizeCode, provider);
+    @UseGuards(OauthDataGuard)
+    async signup(@OauthCookies() oauthData: OauthData) {
+        return await this.authService.signup(oauthData);
     }
 
     @Post('logout')
     @HttpCode(200)
-    async logout(@User() { userId, provider }: AccessTokenPayload) {
-        return await this.authService.logout(userId, provider);
+    async logout(@User() user: AccessTokenPayload) {
+        return await this.authService.logout(user);
     }
 
     @Delete('deactivate')
-    async deactivate(@User() { userId, provider }: AccessTokenPayload) {
-        return await this.authService.deactivate(userId, provider);
+    async deactivate(@User() user: AccessTokenPayload) {
+        return await this.authService.deactivate(user);
     }
 
     @Get('token')
     @SkipAuthGuard()
     @UseGuards(RefreshTokenGuard)
-    async token(@User() { oauthId, provider }: RefreshTokenPayload) {
-        return await this.authService.reissueTokens(oauthId, provider);
+    async token(@User() user: RefreshTokenPayload) {
+        return await this.authService.reissueTokens(user);
     }
 }

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -7,12 +7,14 @@ import { mockUser } from '../fixtures/users.fixture';
 import { Users } from '../users/users.entity';
 import { UsersRepository } from '../users/users.repository';
 import { UsersService } from '../users/users.service';
-import { OauthProvider } from './auth.controller';
-import { AuthService } from './auth.service';
+import { OauthBody } from './auth.controller';
+import { AuthService, OauthData } from './auth.service';
 import { GoogleService } from './oauth/google.service';
 import { KakaoService } from './oauth/kakao.service';
 import { NaverService } from './oauth/naver.service';
 import { TokenService } from './token/token.service';
+
+const context = describe;
 
 describe('AuthService', () => {
     let service: AuthService;
@@ -76,35 +78,62 @@ describe('AuthService', () => {
     const providerList = ['google', 'kakao', 'naver'];
 
     describe('login', () => {
-        for (let i = 0; i < 3; i++) {
-            const provider = providerList[i];
-            it(`${provider} 로그인 후 access token과 refresh token을 반환해야 한다.`, async () => {
-                jest.spyOn(usersService, 'updateAndFindOne').mockResolvedValue({ id: 1 } as Users);
+        context('사용자가 존재하면', () => {
+            for (let i = 0; i < 3; i++) {
+                const provider = providerList[i];
+                it(`${provider} 로그인 후 access token과 refresh token을 반환해야 한다.`, async () => {
+                    jest.spyOn(usersService, 'updateAndFindOne').mockResolvedValue({ id: 1 } as Users);
 
-                const result = await service.login(authorizeCode, provider as OauthProvider);
+                    const result = await service.login({ authorizeCode, provider } as OauthBody);
 
-                expect(result).toEqual({
-                    accessToken: mockUser.refreshToken,
-                    refreshToken: mockUser.refreshToken,
+                    expect(result).toEqual({
+                        accessToken: mockUser.refreshToken,
+                        refreshToken: mockUser.refreshToken,
+                    });
                 });
-            });
-        }
+            }
+        });
+
+        context('사용자가 존재하지 않으면', () => {
+            for (let i = 0; i < 3; i++) {
+                const provider = providerList[i];
+                it(`${provider} 로그인 후 oauth data를 반환해야 한다.`, async () => {
+                    jest.spyOn(usersService, 'updateAndFindOne').mockRejectedValue(new NotFoundException());
+
+                    const result = await service.login({ authorizeCode, provider } as OauthBody);
+
+                    expect(result).toEqual({
+                        oauthAccessToken: mockUser.oauthAccessToken,
+                        oauthRefreshToken: mockUser.oauthRefreshToken,
+                        oauthId: mockUser.oauthId,
+                        provider,
+                    });
+                });
+            }
+        });
     });
 
     describe('signup', () => {
-        for (let i = 0; i < 3; i++) {
-            const provider = providerList[i];
-            it(`${provider} 회원가입 후 access token과 refresh token을 반환해야 한다.`, async () => {
-                jest.spyOn(usersService, 'createIfNotExists').mockResolvedValue({ id: 1 } as Users);
+        context('사용자가 존재하지 않으면', () => {
+            for (let i = 0; i < 3; i++) {
+                const provider = providerList[i];
+                it(`${provider} 회원가입 후 access token과 refresh token을 반환해야 한다.`, async () => {
+                    jest.spyOn(usersService, 'createIfNotExists').mockResolvedValue({ id: 1 } as Users);
 
-                const result = await service.signup(authorizeCode, provider as OauthProvider);
+                    const result = await service.signup({
+                        oauthAccessToken: mockUser.oauthAccessToken,
+                        oauthRefreshToken: mockUser.oauthRefreshToken,
+                        oauthId: mockUser.oauthId,
+                        provider,
+                    } as OauthData);
 
-                expect(result).toEqual({
-                    accessToken: mockUser.refreshToken,
-                    refreshToken: mockUser.refreshToken,
+                    expect(result).toEqual({
+                        accessToken: mockUser.refreshToken,
+                        refreshToken: mockUser.refreshToken,
+                    });
                 });
-            });
-        }
+            }
+        });
     });
 
     describe('validateAccessToken', () => {

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -1,12 +1,24 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Users } from '../users/users.entity';
 import { UsersService } from '../users/users.service';
-import { OauthProvider } from './auth.controller';
+import { OauthBody, OauthProvider } from './auth.controller';
 import { GoogleService } from './oauth/google.service';
 import { KakaoService } from './oauth/kakao.service';
 import { NaverService } from './oauth/naver.service';
-import { TokenService } from './token/token.service';
+import { AccessTokenPayload, RefreshTokenPayload, TokenService } from './token/token.service';
+
+export interface AuthData {
+    accessToken: string;
+    refreshToken: string;
+}
+
+export interface OauthData {
+    oauthAccessToken: string;
+    oauthRefreshToken: string;
+    oauthId: string;
+    provider: OauthProvider;
+}
 
 @Injectable()
 export class AuthService {
@@ -21,43 +33,30 @@ export class AuthService {
 
     private readonly redirectURI = this.configService.get<string>('CORS_ORIGIN') + '/callback';
 
-    private async getOauthData(
-        authorizeCode: string,
-        provider: OauthProvider
-    ): Promise<{ oauthAccessToken: string; oauthRefreshToken: string; oauthId: string }> {
-        const { access_token: oauthAccessToken, refresh_token: oauthRefreshToken } = await this[
-            `${provider}Service`
-        ].requestToken(authorizeCode, this.redirectURI);
-
-        const oauthId = await this[`${provider}Service`].requestUserId(oauthAccessToken);
-
-        return { oauthAccessToken, oauthRefreshToken, oauthId };
-    }
-
-    async login(
-        authorizeCode: string,
-        provider: OauthProvider
-    ): Promise<{ accessToken: string; refreshToken: string }> {
+    async login({ authorizeCode, provider }: OauthBody): Promise<AuthData | OauthData | undefined> {
         const { oauthAccessToken, oauthRefreshToken, oauthId } = await this.getOauthData(authorizeCode, provider);
 
         const refreshToken = this.tokenService.signRefreshToken(oauthId, provider);
 
-        const { id: userId } = await this.usersService.updateAndFindOne(
-            { oauthId },
-            { oauthAccessToken, oauthRefreshToken, refreshToken }
-        );
+        try {
+            const { id: userId } = await this.usersService.updateAndFindOne(
+                { oauthId },
+                { oauthAccessToken, oauthRefreshToken, refreshToken }
+            );
 
-        const accessToken = this.tokenService.signAccessToken(userId, provider);
+            const accessToken = this.tokenService.signAccessToken(userId, provider);
 
-        return { accessToken, refreshToken };
+            return { accessToken, refreshToken };
+        } catch (error) {
+            if (error instanceof NotFoundException) {
+                return { oauthAccessToken, oauthRefreshToken, oauthId, provider };
+            }
+
+            throw error;
+        }
     }
 
-    async signup(
-        authorizeCode: string,
-        provider: OauthProvider
-    ): Promise<{ accessToken: string; refreshToken: string }> {
-        const { oauthAccessToken, oauthRefreshToken, oauthId } = await this.getOauthData(authorizeCode, provider);
-
+    async signup({ oauthAccessToken, oauthRefreshToken, oauthId, provider }: OauthData): Promise<AuthData> {
         const refreshToken = this.tokenService.signRefreshToken(oauthId, provider);
 
         const { id: userId } = await this.usersService.createIfNotExists(
@@ -72,45 +71,27 @@ export class AuthService {
         return { accessToken, refreshToken };
     }
 
-    async logout(id: number, provider: OauthProvider): Promise<void> {
-        const { oauthAccessToken } = await this.usersService.findOne({ id });
+    async logout({ userId, provider }: AccessTokenPayload): Promise<void> {
+        const { oauthAccessToken } = await this.usersService.findOne({ id: userId });
 
         if (provider === 'kakao') {
-            await this[`${provider}Service`].requestTokenExpiration(oauthAccessToken);
+            await this.kakaoService.requestTokenExpiration(oauthAccessToken);
         }
     }
 
-    async deactivate(id: number, provider: OauthProvider): Promise<void> {
-        const { oauthAccessToken } = await this.usersService.findOne({ id });
+    async deactivate({ userId, provider }: AccessTokenPayload): Promise<void> {
+        const { oauthAccessToken } = await this.usersService.findOne({ id: userId });
 
         if (provider === 'kakao') {
-            await this[`${provider}Service`].requestUnlink(oauthAccessToken);
+            await this.kakaoService.requestUnlink(oauthAccessToken);
         } else {
             await this[`${provider}Service`].requestTokenExpiration(oauthAccessToken);
         }
 
-        await this.usersService.delete({ id });
+        await this.usersService.delete({ id: userId });
     }
 
-    async validateAccessToken(id: number): Promise<boolean> {
-        try {
-            await this.usersService.findOne({ id });
-            return true;
-        } catch (error) {
-            return false;
-        }
-    }
-
-    async validateRefreshToken(token: string, oauthId: string): Promise<boolean> {
-        const { refreshToken } = await this.usersService.findOne({ oauthId });
-
-        return refreshToken === token;
-    }
-
-    async reissueTokens(
-        oauthId: string,
-        provider: OauthProvider
-    ): Promise<{ accessToken: string; refreshToken: string }> {
+    async reissueTokens({ oauthId, provider }: RefreshTokenPayload): Promise<AuthData> {
         const { id: userId, oauthRefreshToken } = await this.usersService.findOne({ oauthId });
 
         const { access_token: newOauthAccessToken, refresh_token: newOauthRefreshToken } =
@@ -126,5 +107,30 @@ export class AuthService {
         this.usersService.update({ id: userId }, attr);
 
         return { accessToken: newAccessToken, refreshToken: newRefreshToken };
+    }
+
+    private async getOauthData(authorizeCode: string, provider: OauthProvider): Promise<Omit<OauthData, 'provider'>> {
+        const { access_token: oauthAccessToken, refresh_token: oauthRefreshToken } = await this[
+            `${provider}Service`
+        ].requestToken(authorizeCode, this.redirectURI);
+
+        const oauthId = await this[`${provider}Service`].requestUserId(oauthAccessToken);
+
+        return { oauthAccessToken, oauthRefreshToken, oauthId };
+    }
+
+    async validateAccessToken(userId: number): Promise<boolean> {
+        try {
+            await this.usersService.findOne({ id: userId });
+            return true;
+        } catch (error) {
+            return false;
+        }
+    }
+
+    async validateRefreshToken(token: string, oauthId: string): Promise<boolean> {
+        const { refreshToken } = await this.usersService.findOne({ oauthId });
+
+        return refreshToken === token;
     }
 }

--- a/backend/src/auth/decorators/oauthData.decorator.ts
+++ b/backend/src/auth/decorators/oauthData.decorator.ts
@@ -1,0 +1,7 @@
+import { ExecutionContext, createParamDecorator } from '@nestjs/common';
+import { OauthData } from '../auth.service';
+
+export const OauthCookies = createParamDecorator((data: never, context: ExecutionContext): OauthData => {
+    const request = context.switchToHttp().getRequest();
+    return request.oauthData;
+});

--- a/backend/src/auth/guards/oauthData.guard.ts
+++ b/backend/src/auth/guards/oauthData.guard.ts
@@ -1,0 +1,18 @@
+import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from '@nestjs/common';
+
+@Injectable()
+export class OauthDataGuard implements CanActivate {
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const request = context.switchToHttp().getRequest();
+        const oauthAccessToken = request.cookies['oauthAccessToken'];
+        const oauthRefreshToken = request.cookies['oauthRefreshToken'];
+        const oauthId = request.cookies['oauthId'];
+        const provider = request.cookies['provider'];
+
+        if (!oauthAccessToken || !oauthRefreshToken || !oauthId || !provider) throw new UnauthorizedException();
+
+        request.oauthData = { oauthAccessToken, oauthRefreshToken, oauthId, provider };
+
+        return true;
+    }
+}

--- a/backend/src/auth/interceptors/cookie.interceptor.ts
+++ b/backend/src/auth/interceptors/cookie.interceptor.ts
@@ -1,46 +1,79 @@
-import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Response } from 'express';
+import { CookieOptions, Response } from 'express';
 import { Observable, map } from 'rxjs';
+import { AuthData, OauthData } from '../auth.service';
 import { TOKEN_LIFETIME_MAP } from '../token/token.service';
 
 @Injectable()
 export class CookieInterceptor implements NestInterceptor {
     constructor(private configService: ConfigService) {}
 
-    intercept(context: ExecutionContext, next: CallHandler<any>): Observable<any> | Promise<Observable<any>> {
-        const isProduction = this.configService.get<string>('NODE_ENV') === 'prod';
+    private readonly isProduction = this.configService.get<string>('NODE_ENV') === 'prod';
 
+    intercept(context: ExecutionContext, next: CallHandler<any>): Observable<any> | Promise<Observable<any>> {
         return next.handle().pipe(
             map((data) => {
                 const response = context.switchToHttp().getResponse<Response>();
 
-                if (data) {
-                    const { accessToken, refreshToken } = data;
-
-                    response.cookie('refreshToken', refreshToken, {
-                        httpOnly: true,
-                        secure: isProduction,
-                        maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
-                    });
-
-                    response.cookie('isLoggedIn', true, {
-                        secure: isProduction,
-                        maxAge: TOKEN_LIFETIME_MAP.access.maxAge,
-                    });
-
-                    response.cookie('expiresIn', TOKEN_LIFETIME_MAP.access.maxAge, {
-                        secure: isProduction,
-                        maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
-                    });
-
-                    return { accessToken };
+                if ('accessToken' in data && 'refreshToken' in data) {
+                    this.setAuthCookies(response, data);
+                    this.clearOauthCookies(response);
+                    return { accessToken: data.accessToken };
+                } else if (
+                    'oauthAccessToken' in data &&
+                    'oauthRefreshToken' in data &&
+                    'oauthId' in data &&
+                    'provider' in data
+                ) {
+                    this.setOauthCookies(response, data);
+                    throw new NotFoundException('회원을 찾을 수 없습니다.');
                 } else {
-                    response.clearCookie('refreshToken');
-                    response.clearCookie('isLoggedIn');
-                    response.clearCookie('expiresIn');
+                    this.clearAuthCookies(response);
                 }
             })
         );
+    }
+
+    private setAuthCookies(response: Response, { refreshToken }: AuthData): void {
+        const refreshCookieOptions: CookieOptions = {
+            httpOnly: true,
+            secure: this.isProduction,
+            maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
+        };
+
+        const accessCookieOptions: CookieOptions = {
+            ...refreshCookieOptions,
+            maxAge: TOKEN_LIFETIME_MAP.access.maxAge,
+        };
+
+        response.cookie('refreshToken', refreshToken, refreshCookieOptions);
+        response.cookie('isLoggedIn', true, accessCookieOptions);
+        response.cookie('expiresIn', TOKEN_LIFETIME_MAP.access.maxAge, refreshCookieOptions);
+    }
+
+    private setOauthCookies(
+        response: Response,
+        { oauthAccessToken, oauthRefreshToken, oauthId, provider }: OauthData
+    ): void {
+        const sessionCookieOptions: CookieOptions = { httpOnly: true, secure: this.isProduction };
+
+        response.cookie('oauthAccessToken', oauthAccessToken, sessionCookieOptions);
+        response.cookie('oauthRefreshToken', oauthRefreshToken, sessionCookieOptions);
+        response.cookie('oauthId', oauthId, sessionCookieOptions);
+        response.cookie('provider', provider, sessionCookieOptions);
+    }
+
+    private clearAuthCookies(response: Response): void {
+        response.clearCookie('refreshToken');
+        response.clearCookie('isLoggedIn');
+        response.clearCookie('expiresIn');
+    }
+
+    private clearOauthCookies(response: Response): void {
+        response.clearCookie('oauthAccessToken');
+        response.clearCookie('oauthRefreshToken');
+        response.clearCookie('oauthId');
+        response.clearCookie('provider');
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 로그인 시 회원이 아닌 경우 oauth 관련 cookie를 생성하고, 회원가입 시 cookie에 담긴 oauth 정보를 사용한 후 해당 cookie는 삭제한다.
- oauth 관련 cookie가 존재하는지 검증하고 `request.oauthData` property에 cookie 정보들을 객체로 담는 `OauthDataGuard `추가
- 회원가입 api에서 `request.oauthData` 객체를 쉽게 가져오기 위해 `OauthCookies` decorator 추가
- 바뀐 로그인/회원가입 flow에 맞게 auth controller, service 및 test code 업데이트

## 링크 (Links)
https://www.notion.so/do0ori/oauth-cookie-api-cookie-oauth-cookie-api-2dcf262f5fe24046815e5069ebce8993

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
