### PR TITLE
backend/DANG-501: dogs controller에서 usersService DI 제거

### DIFF
--- a/backend/src/dogs/dogs.controller.ts
+++ b/backend/src/dogs/dogs.controller.ts
@@ -1,8 +1,6 @@
 import { Body, Controller, Delete, Get, HttpCode, Param, ParseIntPipe, Patch, Post, UseGuards } from '@nestjs/common';
-import { In } from 'typeorm';
 import { AccessTokenPayload } from '../auth/token/token.service';
 import { User } from '../users/decorators/user.decorator';
-import { UsersService } from '../users/users.service';
 import { DogsService } from './dogs.service';
 import { DogDto } from './dto/dog.dto';
 import { AuthDogGuard } from './guards/authDog.guard';
@@ -15,10 +13,7 @@ export type DogProfile = {
 
 @Controller('dogs')
 export class DogsController {
-    constructor(
-        private readonly usersService: UsersService,
-        private readonly dogsService: DogsService
-    ) {}
+    constructor(private readonly dogsService: DogsService) {}
 
     @Post()
     async register(@User() { userId }: AccessTokenPayload, @Body() dogDto: DogDto) {
@@ -47,14 +42,12 @@ export class DogsController {
 
     @Get('/walk-available')
     async getAvailableDogs(@User() { userId }: AccessTokenPayload): Promise<DogProfile[]> {
-        const ownDogIds = await this.usersService.getOwnDogsList(userId);
-        return await this.dogsService.getProfileList({ id: In(ownDogIds), isWalking: false });
+        return await this.dogsService.getAvailableDogs(userId);
     }
 
     @Get('/statistics')
     async getDogsStatistics(@User() { userId }: AccessTokenPayload) {
-        const res = await this.dogsService.getDogsStatistics(userId);
-        return res;
+        return await this.dogsService.getDogsStatistics(userId);
     }
 
     @Get('/:id')

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
+import { makeSubObjectsArray } from 'src/utils/manipulate.util';
 import { FindOptionsWhere, In, UpdateResult } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { BreedService } from '../breed/breed.service';
@@ -73,7 +74,9 @@ export class DogsService {
         const attrs = {
             isWalking: stateToUpdate,
         };
+
         await this.update({ id: In(dogIds) }, attrs);
+
         return dogIds;
     }
 
@@ -86,13 +89,12 @@ export class DogsService {
     }
 
     private makeProfileList(dogs: Dogs[]): DogProfile[] {
-        return dogs.map((cur) => {
-            return {
-                id: cur.id,
-                name: cur.name,
-                profilePhotoUrl: cur.profilePhotoUrl,
-            };
-        });
+        return makeSubObjectsArray(dogs, ['id', 'name', 'profilePhotoUrl']);
+    }
+
+    async getAvailableDogs(userId: number): Promise<DogProfile[]> {
+        const ownDogIds = await this.usersService.getOwnDogsList(userId);
+        return this.getProfileList({ id: In(ownDogIds), isWalking: false });
     }
 
     async getProfileList(where: FindOptionsWhere<Dogs>): Promise<DogProfile[]> {


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
usersService logic을 dogsService로 옮겼다.
dogsService의 makeProfileList method에 안나(@opehn)님이 만든 util 함수를 적용했다.

## 링크 (Links)
https://www.notion.so/do0ori/dogs-controller-usersService-DI-5924c8b0004849b181528bf8458d6d3f

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
