### PR TITLE
backend/DANG-511: 산책일지 수정, 삭제 API 구현

### DIFF
--- a/backend/src/excrements/excrements.entity.ts
+++ b/backend/src/excrements/excrements.entity.ts
@@ -6,7 +6,7 @@ import { ExcrementsType } from './types/excrements.enum';
 @Entity('excrements')
 export class Excrements {
     @PrimaryColumn({ name: 'journal_id' })
-    @ManyToOne(() => Journals, (WalkJournals) => WalkJournals.id)
+    @ManyToOne(() => Journals, (WalkJournals) => WalkJournals.id, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'journal_id' })
     journalId: number;
 

--- a/backend/src/journal-photos/journal-photos.entity.ts
+++ b/backend/src/journal-photos/journal-photos.entity.ts
@@ -6,7 +6,7 @@ export class JournalPhotos {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @ManyToOne(() => Journals, (journals) => journals.id)
+    @ManyToOne(() => Journals, (journals) => journals.id, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'journal_id' })
     journal: Journals;
 

--- a/backend/src/journals-dogs/journals-dogs.entity.ts
+++ b/backend/src/journals-dogs/journals-dogs.entity.ts
@@ -5,7 +5,7 @@ import { Journals } from '../journals/journals.entity';
 @Entity('journals_dogs')
 export class JournalsDogs {
     @PrimaryColumn({ name: 'journal_id' })
-    @ManyToOne(() => Journals, (walkJournals) => walkJournals.id)
+    @ManyToOne(() => Journals, (walkJournals) => walkJournals.id, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'journal_id' })
     journalId: number;
 

--- a/backend/src/journals/dto/journal-update.dto.ts
+++ b/backend/src/journals/dto/journal-update.dto.ts
@@ -1,0 +1,14 @@
+import { IsOptional, IsUrl, ValidateNested } from 'class-validator';
+
+export class UpdateJournalDto {
+    @IsOptional()
+    title: string;
+
+    @IsOptional()
+    memo: string;
+
+    @IsOptional()
+    @ValidateNested()
+    @IsUrl({}, { each: true })
+    photoUrls: string[];
+}

--- a/backend/src/journals/journals.controller.ts
+++ b/backend/src/journals/journals.controller.ts
@@ -1,6 +1,18 @@
-import { Body, Controller, ForbiddenException, Get, ParseIntPipe, Post, Query } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Delete,
+    ForbiddenException,
+    Get,
+    Param,
+    ParseIntPipe,
+    Patch,
+    Post,
+    Query,
+} from '@nestjs/common';
 import { AccessTokenPayload } from 'src/auth/token/token.service';
 import { User } from 'src/users/decorators/user.decorator';
+import { UpdateJournalDto } from './dto/journal-update.dto';
 import { CreateJournalDto } from './dto/journals-create.dto';
 import { JournalsService } from './journals.service';
 
@@ -23,5 +35,18 @@ export class JournalsController {
     @Post('/')
     async createJournal(@User() user: AccessTokenPayload, @Body() body: CreateJournalDto) {
         await this.journalsService.createJournal(user.userId, body);
+        return true;
+    }
+
+    @Patch('/:id')
+    async updateJournal(@Param('id', ParseIntPipe) journalId: number, @Body() body: UpdateJournalDto) {
+        await this.journalsService.updateJournal(journalId, body);
+        return true;
+    }
+
+    @Delete('/:id')
+    async deleteJournal(@Param('id', ParseIntPipe) journalId: number) {
+        await this.journalsService.deleteJournal(journalId);
+        return true;
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
산책일지 수정, 삭제 API를 구현했습니다.
삭제시 CASCADE 옵션을 추가해 자동으로 삭제되도록 구현했습니다.

추가적으로 필요한 작업
update 시 트랜잭션 처리가 필요한 것 같습니다.
create의 경우에도 마찬가지라 트랜잭션에 대해 조사 후 일괄적으로 적용이 필요해보임

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
