### PR TITLE
backend/DANG-536: 로그아웃 에러 해결하기

### DIFF
--- a/backend/src/auth/interceptors/cookie.interceptor.ts
+++ b/backend/src/auth/interceptors/cookie.interceptor.ts
@@ -16,6 +16,11 @@ export class CookieInterceptor implements NestInterceptor {
             map((data) => {
                 const response = context.switchToHttp().getResponse<Response>();
 
+                if (!data) {
+                    this.clearAuthCookies(response);
+                    return;
+                }
+
                 if ('accessToken' in data && 'refreshToken' in data) {
                     this.setAuthCookies(response, data);
                     this.clearOauthCookies(response);
@@ -28,8 +33,6 @@ export class CookieInterceptor implements NestInterceptor {
                 ) {
                     this.setOauthCookies(response, data);
                     throw new NotFoundException('회원을 찾을 수 없습니다.');
-                } else {
-                    this.clearAuthCookies(response);
                 }
             })
         );


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
cookie interceptor에서 `Cannot use 'in' operator to search for 'accessToken' in undefined` 에러가 발생했다.
data가 먼저 존재하는지 확인하도록 수정하고 early return을 사용해 해결했다.

## 링크 (Links)
https://www.notion.so/do0ori/Cannot-use-in-operator-to-search-for-accessToken-in-undefined-02822655de5f4ff69ba41e8aaf575d14

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
