### PR TITLE
backend/DANG-434: Log format 가독성 높이기

### DIFF
--- a/backend/src/common/interceptors/logging.interceptor.ts
+++ b/backend/src/common/interceptors/logging.interceptor.ts
@@ -1,5 +1,6 @@
 import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from '@nestjs/common';
 import { Observable, tap } from 'rxjs';
+import { Color, bold, color, italic } from 'src/utils/ansi.utils';
 import { generateUuid } from '../../utils/hash.utils';
 import { WinstonLoggerService } from '../logger/winstonLogger.service';
 
@@ -12,6 +13,16 @@ export class LoggingInterceptor implements NestInterceptor {
     intercept(context: ExecutionContext, next: CallHandler<any>): Observable<any> {
         const request = context.switchToHttp().getRequest();
         const userInfo = request.user || '';
+
+        let user;
+        if (userInfo.userId) {
+            user = `UserID-${userInfo.userId}`;
+        } else if (userInfo.oauthId) {
+            user = `OAuthID-${userInfo.oauthId}`;
+        } else {
+            user = 'GUEST';
+        }
+
         const requestId = generateUuid();
         const { ip, method, path: url } = request;
 
@@ -20,17 +31,26 @@ export class LoggingInterceptor implements NestInterceptor {
         }
 
         this.logger.log(
-            `[REQUEST][${method} | ${url} | ${ip} | ${userInfo.userId || userInfo.oauthId || 'GUEST'}] ${requestId}`
+            `${color('REQUEST', 'Cyan')}  [ ${bold(method)} | ${bold(url)} | ${ip} | ${italic(user)} ] ${color(requestId, 'Black')}`
         );
 
-        const now = Date.now();
+        const startTime = Date.now();
         return next.handle().pipe(
             tap((res) => {
                 const response = context.switchToHttp().getResponse();
                 const { statusCode } = response;
 
-                this.logger.log(`[RESPONSE][${method}|${url}|${ip}|${statusCode}|${Date.now() - now}ms]${requestId}`);
-                this.logger.debug(`Response Object : ${JSON.stringify(res)}`);
+                const endTime = Date.now();
+                const responseTime = endTime - startTime;
+
+                let responseTimeColor: Color = 'Yellow';
+                if (responseTime > 1000) responseTimeColor = 'Red';
+
+                this.logger.log(
+                    `${color('RESPONSE', 'Magenta')} [ ${bold(method)} | ${bold(url)} | ${ip} | ${statusCode} | ${color(`+${responseTime}ms`, responseTimeColor)} ] ${color(requestId, 'Black')}`
+                );
+
+                this.logger.debug(`Response Object:\n${JSON.stringify(res, null, 2)}`);
             })
         );
     }

--- a/backend/src/utils/ansi.utils.ts
+++ b/backend/src/utils/ansi.utils.ts
@@ -1,0 +1,49 @@
+// https://github.com/chalk/ansi-regex/blob/main/index.js
+function ansiRegex({ onlyFirst = false } = {}): RegExp {
+    const pattern = [
+        '[\\u001B\\u009B][[\\]()#;?]*(?:(?:(?:(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]+)*|[a-zA-Z\\d]+(?:;[-a-zA-Z\\d\\/#&.:=?%@~_]*)*)?\\u0007)',
+        '(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-nq-uy=><~]))',
+    ].join('|');
+
+    return new RegExp(pattern, onlyFirst ? undefined : 'g');
+}
+
+// https://github.com/chalk/strip-ansi/blob/main/index.js
+const regex = ansiRegex();
+
+export default function stripAnsi(text: string): string {
+    if (typeof text !== 'string') {
+        throw new TypeError(`Expected a \`string\`, got \`${typeof text}\``);
+    }
+
+    return text.replace(regex, '');
+}
+
+export function bold(text: string) {
+    return `\x1b[1m${text}\x1b[22m`;
+}
+
+export function italic(text: string) {
+    return `\x1b[3m${text}\x1b[23m`;
+}
+
+export type Color = 'Black' | 'Red' | 'Green' | 'Yellow' | 'Blue' | 'Magenta' | 'Cyan' | 'White';
+type ColorCodes = Record<Color, string>;
+
+const colorCodes: ColorCodes = {
+    Black: '\x1b[30m',
+    Red: '\x1b[31m',
+    Green: '\x1b[32m',
+    Yellow: '\x1b[33m',
+    Blue: '\x1b[34m',
+    Magenta: '\x1b[35m',
+    Cyan: '\x1b[36m',
+    White: '\x1b[37m',
+};
+
+const colorResetCode = '\x1b[0m';
+
+export function color(text: string, color: Color): string {
+    const colorCode = colorCodes[color];
+    return `${colorCode}${text}${colorResetCode}`;
+}


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- log message format 변경
- ansi code를 이용해 log message에 색상 적용
- userId와 oauthId 앞에 prefix를 붙여 구분

![image](https://github.com/jihwooon/dangdang-walk/assets/71831926/ccd1da2d-1d25-4767-9235-ae0428fcdd8a)

## 링크 (Links)
https://www.notion.so/do0ori/Log-format-1c3530dcee944d9ab5929e41981675d8

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
