### PR TITLE
backend/DANG-551: 배포 환경(cross-site)에 맞게 cookie option 설정

### DIFF
--- a/backend/src/auth/interceptors/cookie.interceptor.ts
+++ b/backend/src/auth/interceptors/cookie.interceptor.ts
@@ -41,11 +41,13 @@ export class CookieInterceptor implements NestInterceptor {
     private setAuthCookies(response: Response, { refreshToken }: AuthData): void {
         const refreshCookieOptions: CookieOptions = {
             httpOnly: true,
+            sameSite: this.isProduction ? 'none' : 'lax',
             secure: this.isProduction,
             maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
         };
 
         const accessCookieOptions: CookieOptions = {
+            sameSite: this.isProduction ? 'none' : 'lax',
             secure: this.isProduction,
             maxAge: TOKEN_LIFETIME_MAP.access.maxAge,
         };
@@ -59,7 +61,11 @@ export class CookieInterceptor implements NestInterceptor {
         response: Response,
         { oauthAccessToken, oauthRefreshToken, oauthId, provider }: OauthData
     ): void {
-        const sessionCookieOptions: CookieOptions = { httpOnly: true, secure: false }; //this.isProduction };
+        const sessionCookieOptions: CookieOptions = {
+            httpOnly: true,
+            sameSite: this.isProduction ? 'none' : 'lax',
+            secure: this.isProduction,
+        };
 
         response.cookie('oauthAccessToken', oauthAccessToken, sessionCookieOptions);
         response.cookie('oauthRefreshToken', oauthRefreshToken, sessionCookieOptions);


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
client hosting을 vercel로 변경하면서 client와 server의 origin이 달라져 발생한 문제였다.

local 환경
- `sameSite: 'lax'`
- `secure: false`

prod 환경
- `sameSite: 'none'`
- `secure: true`

## 링크 (Links)
https://www.notion.so/do0ori/cookie-37f22e8ef5634b7586a3298f52f8ad5a

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
