### PR TITLE
backend/DANG-556: id 파라미터가 숫자만 받을 수 있도록 제한

### DIFF
--- a/backend/src/dogs/dogs.controller.ts
+++ b/backend/src/dogs/dogs.controller.ts
@@ -22,7 +22,7 @@ export class DogsController {
         return true;
     }
 
-    @Delete('/:id')
+    @Delete('/:id(\\d+)')
     @HttpCode(204)
     @UseGuards(AuthDogGuard)
     async delete(@Param('id', ParseIntPipe) dogId: number) {
@@ -31,7 +31,7 @@ export class DogsController {
         return true;
     }
 
-    @Patch('/:id')
+    @Patch('/:id(\\d+)')
     @HttpCode(204)
     @UseGuards(AuthDogGuard)
     async update(@Param('id', ParseIntPipe) dogId: number, @Body() dogDto: DogDto) {
@@ -44,15 +44,14 @@ export class DogsController {
     async getAvailableDogs(@User() { userId }: AccessTokenPayload): Promise<DogProfile[]> {
         return await this.dogsService.getAvailableDogs(userId);
     }
+    @Get('/:id(\\d+)')
+    @UseGuards(AuthDogGuard)
+    async getOneProfile(@Param('id', ParseIntPipe) dogId: number) {
+        return this.dogsService.getProfile(dogId);
+    }
 
     @Get('/statistics')
     async getDogsStatistics(@User() { userId }: AccessTokenPayload) {
         return await this.dogsService.getDogsStatistics(userId);
-    }
-
-    @Get('/:id')
-    @UseGuards(AuthDogGuard)
-    async getOneProfile(@Param('id', ParseIntPipe) dogId: number) {
-        return this.dogsService.getProfile(dogId);
     }
 }

--- a/backend/src/journals/journals.controller.ts
+++ b/backend/src/journals/journals.controller.ts
@@ -38,13 +38,13 @@ export class JournalsController {
         return true;
     }
 
-    @Patch('/:id')
+    @Patch('/:id(\\d+)')
     async updateJournal(@Param('id', ParseIntPipe) journalId: number, @Body() body: UpdateJournalDto) {
         await this.journalsService.updateJournal(journalId, body);
         return true;
     }
 
-    @Delete('/:id')
+    @Delete('/:id(\\d+)')
     async deleteJournal(@Param('id', ParseIntPipe) journalId: number) {
         await this.journalsService.deleteJournal(journalId);
         return true;


### PR DESCRIPTION
## 작업 내용 (Content)
id params가 숫자만 받을수 있도록 정규식으로 제한을 걸었습니다. 
https://velog.io/@unogle/URL-%ED%8C%8C%EB%9D%BC%EB%AF%B8%ED%84%B0-GET-POST 참고

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
