### PR TITLE
backend/DANG-557: 에러 로깅 전체적으로 추가

### DIFF
--- a/backend/src/auth/guards/oauthData.guard.ts
+++ b/backend/src/auth/guards/oauthData.guard.ts
@@ -14,8 +14,12 @@ export class OauthDataGuard implements CanActivate {
         this.logger.log(`OauthDataGuard request cookies : ${JSON.stringify(request.cookies)}`);
         this.logger.log(`OauthDataGuard data : ${oauthAccessToken} ${oauthRefreshToken}, ${oauthId} ${provider}`);
 
-        if (!oauthAccessToken || !oauthRefreshToken || !oauthId || !provider) throw new UnauthorizedException();
+        if (!oauthAccessToken || !oauthRefreshToken || !oauthId || !provider) {
+            const e = new UnauthorizedException('OauthDataGuard failed');
 
+            this.logger.error(`No data in cookie`, e.stack ?? 'No stack');
+            throw e;
+        }
         request.oauthData = { oauthAccessToken, oauthRefreshToken, oauthId, provider };
 
         return true;

--- a/backend/src/daily-walk-time/daily-walk-time.module.ts
+++ b/backend/src/daily-walk-time/daily-walk-time.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
+import { WinstonLoggerModule } from 'src/common/logger/winstonLogger.module';
 import { DatabaseModule } from '../common/database/database.module';
 import { DailyWalkTime } from './daily-walk-time.entity';
 import { DailyWalkTimeRepository } from './daily-walk-time.repository';
 import { DailyWalkTimeService } from './daily-walk-time.service';
 
 @Module({
-    imports: [DatabaseModule.forFeature([DailyWalkTime])],
+    imports: [DatabaseModule.forFeature([DailyWalkTime]), WinstonLoggerModule],
     providers: [DatabaseModule, DailyWalkTimeRepository, DailyWalkTimeService],
     exports: [DatabaseModule, DailyWalkTimeRepository, DailyWalkTimeService],
 })

--- a/backend/src/daily-walk-time/daily-walk-time.service.ts
+++ b/backend/src/daily-walk-time/daily-walk-time.service.ts
@@ -1,11 +1,15 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
+import { WinstonLoggerService } from 'src/common/logger/winstonLogger.service';
 import { FindOptionsWhere, In } from 'typeorm';
 import { DailyWalkTime } from './daily-walk-time.entity';
 import { DailyWalkTimeRepository } from './daily-walk-time.repository';
 
 @Injectable()
 export class DailyWalkTimeService {
-    constructor(private readonly dailyWalkTimeRepository: DailyWalkTimeRepository) {}
+    constructor(
+        private readonly dailyWalkTimeRepository: DailyWalkTimeRepository,
+        private readonly logger: WinstonLoggerService
+    ) {}
 
     async find(where: FindOptionsWhere<DailyWalkTime>): Promise<DailyWalkTime[]> {
         return this.dailyWalkTimeRepository.find(where);
@@ -18,7 +22,8 @@ export class DailyWalkTimeService {
     async getWalkTimeList(walkTimeIds: number[]) {
         const walkTimeList = await this.dailyWalkTimeRepository.find({ id: In(walkTimeIds) });
         if (!walkTimeList.length) {
-            throw new NotFoundException();
+            const e = new NotFoundException();
+            this.logger.error(`No walkTime in table`, e.stack ?? 'No stack');
         }
         return walkTimeList.map((cur) => {
             return cur.duration;

--- a/backend/src/journals/journals.controller.ts
+++ b/backend/src/journals/journals.controller.ts
@@ -27,9 +27,13 @@ export class JournalsController {
         @Query('dogId', ParseIntPipe) dogId: number
     ) {
         if (!this.journalsService.checkJournalOwnership(user.userId, journalId)) {
-            throw new ForbiddenException('허용되지 않은 접근입니다');
+            throw new ForbiddenException(`User ${user.userId} does not have access to journal ${journalId}`);
         }
-        return this.journalsService.getJournalDetail(journalId, dogId);
+        try {
+            return this.journalsService.getJournalDetail(journalId, dogId);
+        } catch (e) {
+            throw e;
+        }
     }
 
     @Post('/')

--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -92,7 +92,7 @@ export class JournalsService {
         const journalDogIds = journalDogs.map((cur) => cur.dogId);
 
         if (!checkIfExistsInArr(journalDogIds, dogId)) {
-            throw new ForbiddenException('이 일지에 속하지 않은 강아지에 대한 요청');
+            throw new ForbiddenException(`Dog ${dogId} is not included in current journal `);
         }
         return;
     }


### PR DESCRIPTION
## 작업 내용 (Content)
에러 로그 추가
한글이 한글자당 바이트가 더 많이 들어갔던 것 같아서 영어로 바꿨습니다

필요한 추가 작업 
1.
abstract repository에서 던지는 에러 로그를 메소드별로 구분하기 위해
error의 stack에서 메소드 명을 추출해서 repository에 인자로 넣어줘야 할 것 같은데
Nest의 디폴트 에러에는 에러 스택이 없다고 함
Custom 에러를 정의하고 error 스택을 가져오게 한 뒤에, 메소드를 추출해서 repository에 인자로 넘겨주어 
해당 에러가 어떤 메소드에서 난 에러인지 구분하는 작업이 필요해보임


## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
