### PR TITLE
backend/DANG-560: error 메시지 구체화, format 통일, 불필요한 log 제거

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,5 +1,4 @@
 import { Body, Controller, Delete, Get, HttpCode, Post, UseGuards, UseInterceptors } from '@nestjs/common';
-import { WinstonLoggerService } from 'src/common/logger/winstonLogger.service';
 import { User } from '../users/decorators/user.decorator';
 import { AuthService, OauthData } from './auth.service';
 import { OauthCookies } from './decorators/oauthData.decorator';
@@ -19,10 +18,7 @@ export interface OauthBody {
 @Controller('auth')
 @UseInterceptors(CookieInterceptor)
 export class AuthController {
-    constructor(
-        private authService: AuthService,
-        private logger: WinstonLoggerService
-    ) {}
+    constructor(private authService: AuthService) {}
 
     @Post('login')
     @HttpCode(200)
@@ -35,9 +31,6 @@ export class AuthController {
     @SkipAuthGuard()
     @UseGuards(OauthDataGuard)
     async signup(@OauthCookies() oauthData: OauthData) {
-        this.logger.log(`Signup Request arrived`);
-        this.logger.log(`Signup | Cookie : ${JSON.stringify(oauthData)}`);
-
         return await this.authService.signup(oauthData);
     }
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -39,7 +39,7 @@ export class AuthService {
         const { oauthAccessToken, oauthRefreshToken, oauthId } = await this.getOauthData(authorizeCode, provider);
 
         const refreshToken = this.tokenService.signRefreshToken(oauthId, provider);
-        this.logger.log(`Login | refreshToken : ${refreshToken}`);
+        this.logger.log(`login | signRefreshToken: ${refreshToken}`);
 
         try {
             const { id: userId } = await this.usersService.updateAndFindOne(
@@ -48,7 +48,7 @@ export class AuthService {
             );
 
             const accessToken = this.tokenService.signAccessToken(userId, provider);
-            this.logger.log(`Login | accessToken : ${accessToken}`);
+            this.logger.log(`login | signAccessToken: ${accessToken}`);
 
             return { accessToken, refreshToken };
         } catch (error) {
@@ -56,14 +56,13 @@ export class AuthService {
                 return { oauthAccessToken, oauthRefreshToken, oauthId, provider };
             }
             this.logger.error(`Login error`, error.stack ?? 'No stack');
-
             throw error;
         }
     }
 
     async signup({ oauthAccessToken, oauthRefreshToken, oauthId, provider }: OauthData): Promise<AuthData> {
         const refreshToken = this.tokenService.signRefreshToken(oauthId, provider);
-        this.logger.log(`signup | refreshToken : ${refreshToken}`);
+        this.logger.log(`signup | signRefreshToken: ${refreshToken}`);
 
         const { id: userId } = await this.usersService.createIfNotExists(
             oauthId,
@@ -130,10 +129,10 @@ export class AuthService {
     async validateAccessToken(userId: number): Promise<boolean> {
         try {
             const result = await this.usersService.findOne({ id: userId });
-            this.logger.log(`Validate Access Token find User result : ${result}`);
+            this.logger.debug(`validateAccessToken | find User result:\n${JSON.stringify(result, null, 2)}`);
 
             return true;
-        } catch (error) {
+        } catch {
             return false;
         }
     }

--- a/backend/src/auth/guards/oauthData.guard.ts
+++ b/backend/src/auth/guards/oauthData.guard.ts
@@ -11,14 +11,19 @@ export class OauthDataGuard implements CanActivate {
         const oauthId = request.cookies['oauthId'];
         const provider = request.cookies['provider'];
 
-        this.logger.log(`OauthDataGuard request cookies : ${JSON.stringify(request.cookies)}`);
-        this.logger.log(`OauthDataGuard data : ${oauthAccessToken} ${oauthRefreshToken}, ${oauthId} ${provider}`);
-
         if (!oauthAccessToken || !oauthRefreshToken || !oauthId || !provider) {
-            const e = new UnauthorizedException('OauthDataGuard failed');
+            const missingFields = [
+                !oauthAccessToken && 'oauthAccessToken',
+                !oauthRefreshToken && 'oauthRefreshToken',
+                !oauthId && 'oauthId',
+                !provider && 'provider',
+            ]
+                .filter(Boolean)
+                .join(', ');
 
-            this.logger.error(`No data in cookie`, e.stack ?? 'No stack');
-            throw e;
+            const error = new UnauthorizedException(`OAuth data missing in cookies: ${missingFields}.`);
+            this.logger.error(`OAuthDataGuard failed: missing ${missingFields}.`, error.stack ?? 'No stack');
+            throw error;
         }
         request.oauthData = { oauthAccessToken, oauthRefreshToken, oauthId, provider };
 

--- a/backend/src/auth/interceptors/cookie.interceptor.ts
+++ b/backend/src/auth/interceptors/cookie.interceptor.ts
@@ -56,11 +56,9 @@ export class CookieInterceptor implements NestInterceptor {
                 ) {
                     this.setOauthCookies(response, data);
 
-                    const e = new NotFoundException('회원을 찾을 수 없습니다.');
-
-                    this.logger.error(`Can't find user`, e.stack ?? 'No Stack');
-
-                    throw e;
+                    const error = new NotFoundException('No matching user found. Please sign up for an account.');
+                    this.logger.error(`No matching user found`, error.stack ?? 'No Stack');
+                    throw error;
                 }
             })
         );

--- a/backend/src/common/database/abstract.repository.ts
+++ b/backend/src/common/database/abstract.repository.ts
@@ -31,7 +31,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         const existingEntity = await this.entityRepository.findOne({ where });
 
         if (existingEntity) {
-            throw new ConflictException('createIfNotExists : Duplicate entry');
+            throw new ConflictException('createIfNotExists: Duplicate entry');
         }
 
         return this.create(entity);
@@ -47,7 +47,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         const entity = await this.entityRepository.findOne({ where });
 
         if (!entity) {
-            throw new NotFoundException('findOne : Entity not found');
+            throw new NotFoundException('findOne: Entity not found');
         }
 
         return entity;
@@ -61,7 +61,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         const updateResult = await this.entityRepository.update(where, partialEntity);
 
         if (!updateResult.affected) {
-            throw new NotFoundException('update : Entity not found');
+            throw new NotFoundException('update: Entity not found');
         }
 
         return updateResult;
@@ -71,7 +71,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         const deleteResult = await this.entityRepository.delete(where);
 
         if (!deleteResult.affected) {
-            throw new NotFoundException('delete : Entity not found');
+            throw new NotFoundException('delete: Entity not found');
         }
 
         return deleteResult;
@@ -81,7 +81,7 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         const updateResult = await this.entityRepository.update(where, partialEntity);
 
         if (!updateResult.affected) {
-            throw new NotFoundException('update : Entity not found');
+            throw new NotFoundException('update: Entity not found');
         }
 
         return this.findOne(where);

--- a/backend/src/daily-walk-time/daily-walk-time.service.ts
+++ b/backend/src/daily-walk-time/daily-walk-time.service.ts
@@ -22,8 +22,9 @@ export class DailyWalkTimeService {
     async getWalkTimeList(walkTimeIds: number[]) {
         const walkTimeList = await this.dailyWalkTimeRepository.find({ id: In(walkTimeIds) });
         if (!walkTimeList.length) {
-            const e = new NotFoundException();
-            this.logger.error(`No walkTime in table`, e.stack ?? 'No stack');
+            const error = new NotFoundException(`No walkTime found for the provided IDs: ${walkTimeIds}.`);
+            this.logger.error(`No walkTime found for the provided IDs: ${walkTimeIds}.`, error.stack ?? 'No stack');
+            throw error;
         }
         return walkTimeList.map((cur) => {
             return cur.duration;

--- a/backend/src/dogs/dogs.controller.ts
+++ b/backend/src/dogs/dogs.controller.ts
@@ -27,7 +27,6 @@ export class DogsController {
     @UseGuards(AuthDogGuard)
     async delete(@Param('id', ParseIntPipe) dogId: number) {
         await this.dogsService.deleteDogFromUser({ id: dogId });
-
         return true;
     }
 
@@ -36,18 +35,18 @@ export class DogsController {
     @UseGuards(AuthDogGuard)
     async update(@Param('id', ParseIntPipe) dogId: number, @Body() dogDto: DogDto) {
         await this.dogsService.updateDog(dogId, dogDto);
-
         return true;
+    }
+
+    @Get('/:id(\\d+)')
+    @UseGuards(AuthDogGuard)
+    async getOneProfile(@Param('id', ParseIntPipe) dogId: number) {
+        return this.dogsService.getProfile(dogId);
     }
 
     @Get('/walk-available')
     async getAvailableDogs(@User() { userId }: AccessTokenPayload): Promise<DogProfile[]> {
         return await this.dogsService.getAvailableDogs(userId);
-    }
-    @Get('/:id(\\d+)')
-    @UseGuards(AuthDogGuard)
-    async getOneProfile(@Param('id', ParseIntPipe) dogId: number) {
-        return this.dogsService.getProfile(dogId);
     }
 
     @Get('/statistics')

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -44,8 +44,9 @@ export class DogsService {
             const dog = await this.dogsRepository.create(newDog);
 
             return this.usersDogsService.create({ userId, dogId: dog.id });
-        } catch (e) {
-            this.logger.error(`Unknown breed`, e.stack ?? 'No stack');
+        } catch (error) {
+            this.logger.error(`Unknown breed.`, error.stack ?? 'No stack');
+            throw error;
         }
     }
 
@@ -165,9 +166,11 @@ export class DogsService {
             dailyWalkAmount.length !== length ||
             weeklyWalks.length !== length
         ) {
-            const e = new NotFoundException(
-                `Data not matched - Check dogs / breed / dog_walk_day / daily_walk_time table for dogId : ${ownDogIds} `
+            const error = new NotFoundException(
+                `Data not matched - Check dogs / breed / dog_walk_day / daily_walk_time table for dogId: ${ownDogIds}.`
             );
+            this.logger.error(`Data not matched for dogId-${ownDogIds}.`, error.stack ?? 'No stack');
+            throw error;
         }
 
         return this.makeStatisticData(dogProfiles, recommendedDailyWalkAmount, dailyWalkAmount, weeklyWalks);

--- a/backend/src/dogs/dogs.spec.ts
+++ b/backend/src/dogs/dogs.spec.ts
@@ -1,17 +1,17 @@
 import { Dogs } from './dogs.entity';
 
 describe('Dogs', () => {
-  it('dogs 정보가 주어지면 dogs 정보를 리턴해야 한다.', () => {
-    const dogs = new Dogs({ id : 1, name : '덕지', gender: 'MALE'});
+    it('dogs 정보가 주어지면 dogs 정보를 리턴해야 한다.', () => {
+        const dogs = new Dogs({ id: 1, name: '덕지', gender: 'MALE' });
 
-    expect(dogs.id).toEqual(1);
-    expect(dogs.name).toEqual('덕지');
-    expect(dogs.gender).toEqual('MALE');
-  });
+        expect(dogs.id).toEqual(1);
+        expect(dogs.name).toEqual('덕지');
+        expect(dogs.gender).toEqual('MALE');
+    });
 
-  it('dogs 정보가 없으면 빈 객체를 리턴해야 한다.', () => {
-    const breed = new Dogs({});
+    it('dogs 정보가 없으면 빈 객체를 리턴해야 한다.', () => {
+        const breed = new Dogs({});
 
-    expect(breed).toEqual({});
-  });
+        expect(breed).toEqual({});
+    });
 });

--- a/backend/src/dogs/guards/authDog.guard.ts
+++ b/backend/src/dogs/guards/authDog.guard.ts
@@ -17,9 +17,9 @@ export class AuthDogGuard implements CanActivate {
         const owned = await this.usersService.checkDogOwnership(userId, dogId);
 
         if (!owned) {
-            const e = new ForbiddenException(`User ${userId} does not own the dog ${dogId}`);
-            this.logger.error(`User ${userId} does not own the dog ${dogId}`, e.stack ?? 'No stack');
-            throw e;
+            const error = new ForbiddenException(`User ${userId} does not own the dog ${dogId}`);
+            this.logger.error(`User ${userId} does not own the dog ${dogId}`, error.stack ?? 'No stack');
+            throw error;
         }
 
         return true;

--- a/backend/src/journals/dto/journals-create.dto.ts
+++ b/backend/src/journals/dto/journals-create.dto.ts
@@ -9,7 +9,7 @@ import {
     IsUrl,
     ValidateNested,
 } from 'class-validator';
-//TODO : 문자열이면서 숫자 범위를 넘지 않는지 확인하는 custom Validator 만들기..?
+// TODO: 문자열이면서 숫자 범위를 넘지 않는지 확인하는 custom Validator 만들기..?
 export class Location {
     @IsNumber()
     lat: string;

--- a/backend/src/journals/dto/journals-detail.dto.ts
+++ b/backend/src/journals/dto/journals-detail.dto.ts
@@ -28,7 +28,7 @@ export class DogInfoForDetail {
     @IsNotEmpty()
     urinesCnt: number;
 
-    //TODO : reflect -metadata 사용하도록 변경
+    // TODO: reflect -metadata 사용하도록 변경
     static getKeysForDogTable() {
         return ['id', 'name', 'profilePhotoUrl'];
     }

--- a/backend/src/journals/journals.spec.ts
+++ b/backend/src/journals/journals.spec.ts
@@ -1,19 +1,18 @@
 import { Journals } from './journals.entity';
 
 describe('Journals', () => {
-  it('journals가 주어지면 journals 정보를 리턴해야 한다. ', () => {
-    const journals = new Journals({ id : 1, userId : 1, title: '오늘 하루 일지', calories: 11});
+    it('journals가 주어지면 journals 정보를 리턴해야 한다. ', () => {
+        const journals = new Journals({ id: 1, userId: 1, title: '오늘 하루 일지', calories: 11 });
 
-    expect(journals.id).toEqual(1);
-    expect(journals.userId).toEqual(1);
-    expect(journals.title).toEqual('오늘 하루 일지');
-    expect(journals.calories).toEqual(11);
-  });
+        expect(journals.id).toEqual(1);
+        expect(journals.userId).toEqual(1);
+        expect(journals.title).toEqual('오늘 하루 일지');
+        expect(journals.calories).toEqual(11);
+    });
 
-  it('journals 정보가 없으면 빈 객체를 리턴해야 한다.', () => {
-    const journals = new Journals({});
+    it('journals 정보가 없으면 빈 객체를 리턴해야 한다.', () => {
+        const journals = new Journals({});
 
-    expect(journals).toEqual({});
-  });
+        expect(journals).toEqual({});
+    });
 });
-


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- error 메시지를 구체적으로 작성
- 변수명은 `e`가 아니라 `error`로 명확히 작성
- 일반 log나 debug message 형식 통일
- `OauthDataGuard`에서 어떤 cookie 값이 빠졌는지 구체적인 message 생성
- `AuthGuard` 및 `RefreshTokenGuard`에서 TokenExpiredError, JsonWebTokenError 처리 코드 추가

## 링크 (Links)
https://www.notion.so/do0ori/error-format-log-cec47774c4fe41d1a65f8b0a6425f207

## 기타 사항 (Etc)
global한 error 처리, custom error class 필요

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
