### PR TITLE
backend/DANG-574: cookie domain 속성 삭제, body에 isLoggedIn, expiresIn 추가

### DIFF
--- a/backend/src/auth/interceptors/cookie.interceptor.ts
+++ b/backend/src/auth/interceptors/cookie.interceptor.ts
@@ -14,28 +14,24 @@ export class CookieInterceptor implements NestInterceptor {
     ) {}
 
     private readonly isProduction = this.configService.get<string>('NODE_ENV') === 'prod';
-    private readonly cookieDomain = this.isProduction ? '.dangdang-walk.vercel.app' : 'localhost';
 
     private readonly refreshCookieOptions: CookieOptions = {
         httpOnly: true,
         sameSite: this.isProduction ? 'none' : 'lax',
         secure: this.isProduction,
         maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
-        domain: this.cookieDomain,
     };
 
     private readonly accessCookieOptions: CookieOptions = {
         sameSite: this.isProduction ? 'none' : 'lax',
         secure: this.isProduction,
         maxAge: TOKEN_LIFETIME_MAP.access.maxAge,
-        domain: this.cookieDomain,
     };
 
     private readonly sessionCookieOptions: CookieOptions = {
         httpOnly: true,
         sameSite: this.isProduction ? 'none' : 'lax',
         secure: this.isProduction,
-        domain: this.cookieDomain,
     };
 
     intercept(context: ExecutionContext, next: CallHandler<any>): Observable<any> | Promise<Observable<any>> {
@@ -51,7 +47,11 @@ export class CookieInterceptor implements NestInterceptor {
                 if ('accessToken' in data && 'refreshToken' in data) {
                     this.setAuthCookies(response, data);
                     this.clearOauthCookies(response);
-                    return { accessToken: data.accessToken };
+                    return {
+                        accessToken: data.accessToken,
+                        isLoggedIn: true,
+                        expiresIn: TOKEN_LIFETIME_MAP.access.maxAge,
+                    };
                 } else if (
                     'oauthAccessToken' in data &&
                     'oauthRefreshToken' in data &&


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
cookie의 domain 설정은 보안상의 이유로 host url로만 설정 가능하다. 때문에 우리는 배포환경이 cross-site인데 이 경우 domain을 client url로 설정이 불가능해 일단 삭제했다. client에서 test를 위해 body에 isLoggedIn과 expiresIn을 추가했다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
