### PR TITLE
frontend/DANG-565: 산책기록 저장 페이지의 저장 취소 로직 구현

### DIFF
--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -14,9 +14,14 @@ import {
 } from '@/components/common/Modal';
 import Topbar from '@/components/common/Topbar';
 import WalkInfo from '@/components/walk/WalkInfo';
+import useToast from '@/hooks/useToast';
 import { useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 export default function CreateForm() {
+    const navigate = useNavigate();
+    const { show: showToast } = useToast();
+
     const [openModal, setOpenModal] = useState(false);
 
     const textAreaRef = useRef<HTMLTextAreaElement>(null);
@@ -110,10 +115,16 @@ export default function CreateForm() {
                     </ModalHeader>
                     <ModalFooter>
                         <ModalCancel onClick={() => setOpenModal(false)}>취소</ModalCancel>
-                        <ModalAction onClick={() => setOpenModal(false)}>삭제하기</ModalAction>
+                        <ModalAction onClick={handleDeleteSave}>삭제하기</ModalAction>
                     </ModalFooter>
                 </ModalContent>
             </Modal>
         </>
     );
+
+    function handleDeleteSave() {
+        showToast('산책 기록이 삭제되었습니다.');
+
+        navigate('/');
+    }
 }

--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -115,14 +115,14 @@ export default function CreateForm() {
                     </ModalHeader>
                     <ModalFooter>
                         <ModalCancel onClick={() => setOpenModal(false)}>취소</ModalCancel>
-                        <ModalAction onClick={handleDeleteSave}>삭제하기</ModalAction>
+                        <ModalAction onClick={handleCancelSave}>삭제하기</ModalAction>
                     </ModalFooter>
                 </ModalContent>
             </Modal>
         </>
     );
 
-    function handleDeleteSave() {
+    function handleCancelSave() {
         showToast('산책 기록이 삭제되었습니다.');
 
         navigate('/');


### PR DESCRIPTION
## 작업 내용 (Content)
산책기록 저장 페이지의 저장 취소 로직 구현

## 링크 (Links)
https://www.notion.so/do0ori/59c75e69c2e944a28349d0d3a0eb3e44?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
