### PR TITLE
backend/DANG-584: isLoggedIn, expiresIn 삭제

### DIFF
--- a/backend/src/auth/interceptors/cookie.interceptor.ts
+++ b/backend/src/auth/interceptors/cookie.interceptor.ts
@@ -22,12 +22,6 @@ export class CookieInterceptor implements NestInterceptor {
         maxAge: TOKEN_LIFETIME_MAP.refresh.maxAge,
     };
 
-    private readonly accessCookieOptions: CookieOptions = {
-        // sameSite: this.isProduction ? 'none' : 'lax',
-        // secure: this.isProduction,
-        maxAge: TOKEN_LIFETIME_MAP.access.maxAge,
-    };
-
     private readonly sessionCookieOptions: CookieOptions = {
         httpOnly: true,
         sameSite: this.isProduction ? 'none' : 'lax',
@@ -47,11 +41,7 @@ export class CookieInterceptor implements NestInterceptor {
                 if ('accessToken' in data && 'refreshToken' in data) {
                     this.setAuthCookies(response, data);
                     this.clearOauthCookies(response);
-                    return {
-                        accessToken: data.accessToken,
-                        isLoggedIn: true,
-                        expiresIn: TOKEN_LIFETIME_MAP.access.maxAge,
-                    };
+                    return { accessToken: data.accessToken };
                 } else if (
                     'oauthAccessToken' in data &&
                     'oauthRefreshToken' in data &&
@@ -70,8 +60,6 @@ export class CookieInterceptor implements NestInterceptor {
 
     private setAuthCookies(response: Response, { refreshToken }: AuthData): void {
         response.cookie('refreshToken', refreshToken, this.refreshCookieOptions);
-        response.cookie('isLoggedIn', true, this.accessCookieOptions);
-        response.cookie('expiresIn', TOKEN_LIFETIME_MAP.access.maxAge, this.accessCookieOptions);
     }
 
     private setOauthCookies(
@@ -86,8 +74,6 @@ export class CookieInterceptor implements NestInterceptor {
 
     private clearAuthCookies(response: Response): void {
         response.clearCookie('refreshToken', this.refreshCookieOptions);
-        response.clearCookie('isLoggedIn', this.accessCookieOptions);
-        response.clearCookie('expiresIn', this.accessCookieOptions);
     }
 
     private clearOauthCookies(response: Response): void {

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -12,12 +12,8 @@ async function bootstrap() {
     app.useLogger(new WinstonLoggerService());
 
     app.enableCors({
-        origin: [
-            'http://localhost:3000',
-            'http://localhost:8080',
-            'https://dangdang-walk.vercel.app'
-        ],
-        methods: 'GET,HEAD,PUT,PATCH,POST,DELETE,OPTIONS',
+        origin: ['http://localhost:3000', 'http://localhost:8080', 'https://dangdang-walk.vercel.app'],
+        methods: ['GET', 'HEAD', 'PUT', 'PATCH', 'POST', 'DELETE', 'OPTIONS'],
         allowedHeaders: ['Content-Type', 'Accept', 'Authorization'],
         credentials: true,
     });


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- cors options들 중 `string` 형식을 `string[]` 형식으로 변경
- client에서 뒤로가기할 경우 bfcache가 로딩되어 로그인 상태 관리에 어려움이 있었는데 해당 event가 발생할 때 브라우저를 새로고침함으로써 이 문제를 해결해서 더 이상 server에서 `isLoggedIn`을 보내줄 필요가 없어졌다. `expiresIn` 또한 어차피 고정이기 때문에 보내주지 않는다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
