### PR TITLE
backend/DANG-589: oauth service에서 axios error 처리 개선

### DIFF
--- a/backend/src/auth/oauth/google.service.ts
+++ b/backend/src/auth/oauth/google.service.ts
@@ -1,6 +1,7 @@
 import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
 import { firstValueFrom } from 'rxjs';
 import { WinstonLoggerService } from 'src/common/logger/winstonLogger.service';
 import { OauthService, RequestTokenRefreshResponse } from './oauth.service.interface';
@@ -59,7 +60,13 @@ export class GoogleService implements OauthService {
 
             return data;
         } catch (error) {
-            this.logger.error('Google: Failed to request token.', error.stack ?? 'No stack');
+            if (axios.isAxiosError(error) && error.response) {
+                this.logger.error(
+                    `Google: Failed to request token. ${JSON.stringify(error.response.data)}`,
+                    error.stack ?? 'No stack'
+                );
+                error = new BadRequestException('Google: Failed to request token.');
+            }
             throw error;
         }
     }
@@ -76,7 +83,13 @@ export class GoogleService implements OauthService {
 
             return data.sub;
         } catch (error) {
-            this.logger.error('Google: Failed to request oauthId.', error.stack ?? 'No stack');
+            if (axios.isAxiosError(error) && error.response) {
+                this.logger.error(
+                    `Google: Failed to request oauthId. ${JSON.stringify(error.response.data)}`,
+                    error.stack ?? 'No stack'
+                );
+                error = new BadRequestException('Google: Failed to request oauthId.');
+            }
             throw error;
         }
     }
@@ -98,7 +111,13 @@ export class GoogleService implements OauthService {
                 )
             );
         } catch (error) {
-            this.logger.error('Google: Failed to request token expiration.', error.stack ?? 'No stack');
+            if (axios.isAxiosError(error) && error.response) {
+                this.logger.error(
+                    `Google: Failed to request token expiration. ${JSON.stringify(error.response.data)}`,
+                    error.stack ?? 'No stack'
+                );
+                error = new BadRequestException('Google: Failed to request token expiration.');
+            }
             throw error;
         }
     }
@@ -116,7 +135,13 @@ export class GoogleService implements OauthService {
 
             return data;
         } catch (error) {
-            this.logger.error('Google: Failed to request token refresh.', error.stack ?? 'No stack');
+            if (axios.isAxiosError(error) && error.response) {
+                this.logger.error(
+                    `Google: Failed to request token refresh. ${JSON.stringify(error.response.data)}`,
+                    error.stack ?? 'No stack'
+                );
+                error = new BadRequestException('Google: Failed to request token refresh.');
+            }
             throw error;
         }
     }

--- a/backend/src/auth/oauth/kakao.service.ts
+++ b/backend/src/auth/oauth/kakao.service.ts
@@ -1,6 +1,7 @@
 import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
 import { firstValueFrom } from 'rxjs';
 import { WinstonLoggerService } from 'src/common/logger/winstonLogger.service';
 import { OauthService } from './oauth.service.interface';
@@ -66,7 +67,13 @@ export class KakaoService implements OauthService {
 
             return data;
         } catch (error) {
-            this.logger.error('Kakao: Failed to request token.', error.stack ?? 'No stack');
+            if (axios.isAxiosError(error) && error.response) {
+                this.logger.error(
+                    `Kakao: Failed to request token. ${JSON.stringify(error.response.data)}`,
+                    error.stack ?? 'No stack'
+                );
+                error = new BadRequestException('Kakao: Failed to request token.');
+            }
             throw error;
         }
     }
@@ -83,7 +90,13 @@ export class KakaoService implements OauthService {
 
             return data.id.toString();
         } catch (error) {
-            this.logger.error('Kakao: Failed to request oauthId.', error.stack ?? 'No stack');
+            if (axios.isAxiosError(error) && error.response) {
+                this.logger.error(
+                    `Kakao: Failed to request oauthId. ${JSON.stringify(error.response.data)}`,
+                    error.stack ?? 'No stack'
+                );
+                error = new BadRequestException('Kakao: Failed to request oauthId.');
+            }
             throw error;
         }
     }
@@ -103,7 +116,13 @@ export class KakaoService implements OauthService {
                 )
             );
         } catch (error) {
-            this.logger.error('Kakao: Failed to request token expiration.', error.stack ?? 'No stack');
+            if (axios.isAxiosError(error) && error.response) {
+                this.logger.error(
+                    `Kakao: Failed to request token expiration. ${JSON.stringify(error.response.data)}`,
+                    error.stack ?? 'No stack'
+                );
+                error = new BadRequestException('Kakao: Failed to request token expiration.');
+            }
             throw error;
         }
     }
@@ -123,7 +142,13 @@ export class KakaoService implements OauthService {
                 )
             );
         } catch (error) {
-            this.logger.error('Kakao: Failed to request unlink.', error.stack ?? 'No stack');
+            if (axios.isAxiosError(error) && error.response) {
+                this.logger.error(
+                    `Kakao: Failed to request unlink. ${JSON.stringify(error.response.data)}`,
+                    error.stack ?? 'No stack'
+                );
+                error = new BadRequestException('Kakao: Failed to request unlink.');
+            }
             throw error;
         }
     }
@@ -149,7 +174,13 @@ export class KakaoService implements OauthService {
 
             return data;
         } catch (error) {
-            this.logger.error('Kakao: Failed to request token refresh.', error.stack ?? 'No stack');
+            if (axios.isAxiosError(error) && error.response) {
+                this.logger.error(
+                    `Kakao: Failed to request token refresh. ${JSON.stringify(error.response.data)}`,
+                    error.stack ?? 'No stack'
+                );
+                error = new BadRequestException('Kakao: Failed to request token refresh.');
+            }
             throw error;
         }
     }

--- a/backend/src/auth/oauth/naver.service.ts
+++ b/backend/src/auth/oauth/naver.service.ts
@@ -1,6 +1,7 @@
 import { HttpService } from '@nestjs/axios';
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
 import { firstValueFrom } from 'rxjs';
 import { WinstonLoggerService } from 'src/common/logger/winstonLogger.service';
 import { OauthService, RequestTokenRefreshResponse } from './oauth.service.interface';
@@ -56,7 +57,13 @@ export class NaverService implements OauthService {
 
             return data;
         } catch (error) {
-            this.logger.error('Naver: Failed to request token.', error.stack ?? 'No stack');
+            if (axios.isAxiosError(error) && error.response) {
+                this.logger.error(
+                    `Naver: Failed to request token. ${JSON.stringify(error.response.data)}`,
+                    error.stack ?? 'No stack'
+                );
+                error = new BadRequestException('Naver: Failed to request token.');
+            }
             throw error;
         }
     }
@@ -73,7 +80,13 @@ export class NaverService implements OauthService {
 
             return data.response.id;
         } catch (error) {
-            this.logger.error('Naver: Failed to request oauthId.', error.stack ?? 'No stack');
+            if (axios.isAxiosError(error) && error.response) {
+                this.logger.error(
+                    `Naver: Failed to request oauthId. ${JSON.stringify(error.response.data)}`,
+                    error.stack ?? 'No stack'
+                );
+                error = new BadRequestException('Naver: Failed to request oauthId.');
+            }
             throw error;
         }
     }
@@ -92,7 +105,13 @@ export class NaverService implements OauthService {
                 })
             );
         } catch (error) {
-            this.logger.error('Naver: Failed to request token expiration.', error.stack ?? 'No stack');
+            if (axios.isAxiosError(error) && error.response) {
+                this.logger.error(
+                    `Naver: Failed to request token expiration. ${JSON.stringify(error.response.data)}`,
+                    error.stack ?? 'No stack'
+                );
+                error = new BadRequestException('Naver: Failed to request token expiration.');
+            }
             throw error;
         }
     }
@@ -112,7 +131,13 @@ export class NaverService implements OauthService {
 
             return data;
         } catch (error) {
-            this.logger.error('Naver: Failed to request token refresh.', error.stack ?? 'No stack');
+            if (axios.isAxiosError(error) && error.response) {
+                this.logger.error(
+                    `Naver: Failed to request token refresh. ${JSON.stringify(error.response.data)}`,
+                    error.stack ?? 'No stack'
+                );
+                error = new BadRequestException('Naver: Failed to request token refresh.');
+            }
             throw error;
         }
     }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
axios error의 `response.data`도 출력하도록 했다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
