### PR TITLE
backend/DANG-601: 월별 강아지 산책 조회 API 1차

### DIFF
--- a/backend/src/breed/breed.controller.ts
+++ b/backend/src/breed/breed.controller.ts
@@ -3,8 +3,8 @@ import { SkipAuthGuard } from 'src/auth/decorators/public.decorator';
 
 @Controller('breeds')
 export class BreedController {
-    @SkipAuthGuard()
     @Get('/')
+    @SkipAuthGuard()
     async getBreedData() {
         //TODO : 데이터 확정 후에는 DB에서 가져오는걸로 바꾸기..
         return [

--- a/backend/src/dogs/dogs.controller.ts
+++ b/backend/src/dogs/dogs.controller.ts
@@ -39,7 +39,7 @@ export class DogsController {
     @HttpCode(204)
     @UseGuards(AuthDogGuard)
     async delete(@Param('id', ParseIntPipe) dogId: number) {
-        await this.dogsService.deleteDogFromUser({ id: dogId });
+        await this.dogsService.deleteDogFromUser(dogId);
         return true;
     }
 

--- a/backend/src/dogs/dogs.controller.ts
+++ b/backend/src/dogs/dogs.controller.ts
@@ -1,9 +1,22 @@
-import { Body, Controller, Delete, Get, HttpCode, Param, ParseIntPipe, Patch, Post, UseGuards } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    HttpCode,
+    Param,
+    ParseIntPipe,
+    Patch,
+    Post,
+    Query,
+    UseGuards,
+} from '@nestjs/common';
 import { AccessTokenPayload } from '../auth/token/token.service';
 import { User } from '../users/decorators/user.decorator';
 import { DogsService } from './dogs.service';
 import { DogDto } from './dto/dog.dto';
 import { AuthDogGuard } from './guards/authDog.guard';
+import { DateValidationPipe } from './pipes/dateValidation.pipe';
 
 export type DogProfile = {
     id: number;
@@ -44,9 +57,14 @@ export class DogsController {
         return this.dogsService.getProfile(dogId);
     }
 
-    @Get('/walk-available')
-    async getAvailableDogs(@User() { userId }: AccessTokenPayload): Promise<DogProfile[]> {
-        return await this.dogsService.getAvailableDogs(userId);
+    @Get('/:id(\\d+)/statistics')
+    @UseGuards(AuthDogGuard)
+    async getDogStatistics(
+        @User() { userId }: AccessTokenPayload,
+        @Param('id', ParseIntPipe) dogId: number,
+        @Query('date', DateValidationPipe) date: string
+    ) {
+        return await this.dogsService.getDogStatistics(userId, dogId, date);
     }
 
     @Get('/statistics')
@@ -54,4 +72,8 @@ export class DogsController {
         return await this.dogsService.getDogsStatistics(userId);
     }
 
+    @Get('/walk-available')
+    async getAvailableDogs(@User() { userId }: AccessTokenPayload): Promise<DogProfile[]> {
+        return await this.dogsService.getAvailableDogs(userId);
+    }
 }

--- a/backend/src/dogs/dogs.entity.ts
+++ b/backend/src/dogs/dogs.entity.ts
@@ -26,7 +26,7 @@ export class Dogs {
     @Column()
     name: string;
 
-    @ManyToOne(() => Breed, { nullable: false })
+    @ManyToOne(() => Breed, { nullable: false, eager: true })
     @JoinColumn({ name: 'breed_id' })
     breed: Breed;
 

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -50,8 +50,8 @@ export class DogsService {
         }
     }
 
-    async deleteDogFromUser(where: FindOptionsWhere<Dogs>) {
-        const dog = await this.findOne(where);
+    async deleteDogFromUser(dogId: number) {
+        const dog = await this.findOne({ id: dogId });
 
         await this.dogWalkDayService.delete({ id: dog.walkDayId });
         await this.dailyWalkTimeService.delete({ id: dog.dailyWalkTimeId });
@@ -146,6 +146,13 @@ export class DogsService {
             });
         }
         return result;
+    }
+
+    async getDogStatistics(userId: number, dogId: number, date: string) {
+        const dog = await this.findOne({ id: dogId });
+        // this.journalsService.getDogMonthlyJournals(userId, dogId, date);
+
+        return { recommendedWalkAmount: dog.breed.recommendedWalkAmount };
     }
 
     async getDogsStatistics(userId: number): Promise<DogStatisticDto[]> {

--- a/backend/src/dogs/pipes/dateValidation.pipe.ts
+++ b/backend/src/dogs/pipes/dateValidation.pipe.ts
@@ -1,0 +1,33 @@
+import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
+
+@Injectable()
+export class DateValidationPipe implements PipeTransform<string, string> {
+    transform(value: string): string {
+        const dateFormat = /^\d{4}-\d{2}-\d{2}$/;
+
+        if (!value.match(dateFormat)) {
+            throw new BadRequestException('Invalid date format. Please provide date in YYYY-MM-DD format.');
+        }
+
+        const [year, month, day] = value.split('-').map(Number);
+
+        if (month < 1 || month > 12) {
+            throw new BadRequestException(`Invalid month: ${month}. Month must be between 1 and 12.`);
+        }
+
+        const lastDayOfMonth = new Date(year, month, 0).getDate();
+
+        if (day < 1 || day > lastDayOfMonth) {
+            throw new BadRequestException(`Invalid day: ${day}. Day must be between 1 and ${lastDayOfMonth}.`);
+        }
+
+        const currentDate = new Date();
+        const requestedDate = new Date(value);
+
+        if (requestedDate > currentDate) {
+            throw new BadRequestException('Date cannot be in the future.');
+        }
+
+        return value;
+    }
+}


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- data query string을 위한 validation pipe 추가
  - `YYYY-MM-DD` 형식인지
  - month와 day의 숫자가 유효한지
  - 현재 또는 과거의 날짜인지
- dogs controller에 `param.id`에는 `ParseIntPipe`를, `query.date`에는 앞서 정의한 custom `DateValidationPipe`를 사용한다.
- delete api refactoring
- dogs entity에서 breed의 option을 `eager: true`로 설정하여 dog data를 가져올 때 breedId에 해당하는 Breed 정보도 가져오도록 했다.

## 링크 (Links)
https://www.notion.so/do0ori/API-1-c921013ff2a94552b932d3b41d144bd8

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
