### PR TITLE
backend/DANG-640: getDogsStatistics에서 breedIds가 중복되는 경우 recommendedWalkAmount 배열 길이가 맞지 않는 오류 해결 

### DIFF
--- a/backend/src/breed/breed.service.ts
+++ b/backend/src/breed/breed.service.ts
@@ -15,13 +15,23 @@ export class BreedService {
         return this.breedRepository.findOne(where);
     }
 
-    async getRecommendedWalkAmountList(ownDogs: number[]): Promise<number[]> {
-        const breeds = await this.breedRepository.find({ id: In(ownDogs) });
+    async getRecommendedWalkAmountList(breedIds: number[]): Promise<number[]> {
+        const breeds = await this.breedRepository.find({ id: In(breedIds) });
+
         if (!breeds.length) {
             throw new NotFoundException();
         }
-        return breeds.map((breed: Breed) => {
-            return breed.recommendedWalkAmount;
+
+        const breedMap = new Map(breeds.map((breed: Breed) => [breed.id, breed.recommendedWalkAmount]));
+
+        return breedIds.map((breedId: number) => {
+            const recommendedWalkAmount = breedMap.get(breedId);
+
+            if (!recommendedWalkAmount) {
+                throw new NotFoundException(`Recommended walk amount not found for breedId: ${breedId}.`);
+            }
+
+            return recommendedWalkAmount;
         });
     }
 }

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -167,16 +167,18 @@ export class DogsService {
         const weeklyWalks = await this.dogWalkDayService.getWalkDayList(dogWalkDayIds);
 
         const length = ownDogIds.length;
-        if (
-            dogProfiles.length !== length ||
-            recommendedWalkAmount.length !== length ||
-            todayWalkAmount.length !== length ||
-            weeklyWalks.length !== length
-        ) {
-            const error = new NotFoundException(
-                `Data not matched - Check dogs / breed / dog_walk_day / daily_walk_time table for dogId: ${ownDogIds}.`
+        const mismatchedLengths = [
+            dogProfiles.length !== length && `dogProfiles.length = ${dogProfiles.length}`,
+            recommendedWalkAmount.length !== length && `recommendedWalkAmount.length = ${recommendedWalkAmount.length}`,
+            todayWalkAmount.length !== length && `todayWalkAmount.length = ${todayWalkAmount.length}`,
+            weeklyWalks.length !== length && `weeklyWalks.length = ${weeklyWalks.length}`,
+        ].filter(Boolean);
+        if (mismatchedLengths.length > 0) {
+            const error = new NotFoundException(`Data missing or mismatched for dogId: ${ownDogIds}.`);
+            this.logger.error(
+                `Data missing or mismatched for dogId: ${ownDogIds}. Expected length: ${length}. Mismatched data: ${mismatchedLengths.join(', ')}`,
+                error.stack ?? 'No stack'
             );
-            this.logger.error(`Data not matched for dogId-${ownDogIds}.`, error.stack ?? 'No stack');
             throw error;
         }
 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- `getDogsStatistics` method에서 어떤 data의 길이가 맞지 않는지까지 error message에 넣어주도록 수정했다.
- IN operator로 breeds 값을 가져오다보니 중복된 breedIds가 존재하는 경우 결과 배열의 길이가 breedIds 배열의 길이보다 짧아지게 된다. 따라서 breed id와 recommendedWalkAmount 값을 쌍으로하는 Map 객체를 만들어 breedId마다 recommendedWalkAmount 값을 mapping해주었다.

## 링크 (Links)
https://www.notion.so/do0ori/getDogsStatistics-breedId-66e5d238ad9e4766bad36dfaca0e7a7a

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
