### PR TITLE
infra/DANG-611: "error"라는 단어가 포함된 페이지에서 script가 중단되는 현상 해결

### DIFF
--- a/.github/workflows/link_pr_to_ticket.yaml
+++ b/.github/workflows/link_pr_to_ticket.yaml
@@ -14,13 +14,6 @@ jobs:
           DATABASE_ID: 35e838520c274894b2206eb34a198575
           NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
         run: |
-          check_error() {
-            echo $1 | jq .
-            if [[ $1 == *"error"* ]]; then
-              exit 1
-            fi
-          }
-
           branch_name="${{ github.event.pull_request.head.ref }}"
 
           if [[ $branch_name =~ DANG-([0-9]+)$ ]]; then
@@ -51,7 +44,7 @@ jobs:
             --data "$JSON_DATA"
           )
 
-          check_error "$response"
+          echo "$response" | jq .
 
           PAGE_ID=$(echo $response | jq -r ".results[0].id")
 
@@ -84,4 +77,4 @@ jobs:
             --data "$JSON_DATA"
           )
 
-          check_error "$response"
+          echo "$response" | jq .


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
`check_error`라는 함수에서 "error"라는 단어가 응답에 존재하면 exit 1을 하게 되는데 찾은 페이지에서 "error"라는 단어를 제목이나 본문에서 사용하고 있으면 이 조건을 충족해 exit 1이 되어버려 script가 중단되는 것이었다. error message에 대해 처리를 하려고 만든 함수였지만 의도치 않은 현상이 생겨 삭제했다.

## 링크 (Links)
https://www.notion.so/do0ori/link-pr-to-notion-script-page-patch-api-0cee86ee743a4074bc2440bf6a18dbeb

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
