### PR TITLE
backend/DANG-652:  추상 리포지토리 find 함수를 typeorm의 find 함수 쓰도록 변경, 인자 타입 findManyOptions로 변경

### DIFF
--- a/backend/src/breed/breed.service.ts
+++ b/backend/src/breed/breed.service.ts
@@ -8,7 +8,7 @@ export class BreedService {
     constructor(private readonly breedRepository: BreedRepository) {}
 
     async find(where: FindOptionsWhere<Breed>): Promise<Breed[]> {
-        return this.breedRepository.find(where);
+        return this.breedRepository.find({ where });
     }
 
     async findOne(where: FindOptionsWhere<Breed>): Promise<Breed> {
@@ -16,7 +16,7 @@ export class BreedService {
     }
 
     async getRecommendedWalkAmountList(breedIds: number[]): Promise<number[]> {
-        const breeds = await this.breedRepository.find({ id: In(breedIds) });
+        const breeds = await this.breedRepository.find({ where: { id: In(breedIds) } });
 
         if (!breeds.length) {
             throw new NotFoundException();

--- a/backend/src/common/database/abstract.repository.ts
+++ b/backend/src/common/database/abstract.repository.ts
@@ -1,5 +1,13 @@
 import { ConflictException, NotFoundException } from '@nestjs/common';
-import { DeleteResult, EntityManager, FindOptionsWhere, ObjectLiteral, Repository, UpdateResult } from 'typeorm';
+import {
+    DeleteResult,
+    EntityManager,
+    FindManyOptions,
+    FindOptionsWhere,
+    ObjectLiteral,
+    Repository,
+    UpdateResult,
+} from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 
 export abstract class AbstractRepository<T extends ObjectLiteral> {
@@ -53,8 +61,8 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         return entity;
     }
 
-    async find(where: FindOptionsWhere<T>): Promise<T[]> {
-        return this.entityRepository.findBy(where);
+    async find(where: FindManyOptions<T>): Promise<T[]> {
+        return this.entityRepository.find(where);
     }
 
     async update(where: FindOptionsWhere<T>, partialEntity: QueryDeepPartialEntity<T>): Promise<UpdateResult> {

--- a/backend/src/daily-walk-time/daily-walk-time.service.ts
+++ b/backend/src/daily-walk-time/daily-walk-time.service.ts
@@ -12,7 +12,7 @@ export class DailyWalkTimeService {
     ) {}
 
     async find(where: FindOptionsWhere<TodayWalkTime>): Promise<TodayWalkTime[]> {
-        return this.dailyWalkTimeRepository.find(where);
+        return this.dailyWalkTimeRepository.find({ where });
     }
 
     async delete(where: FindOptionsWhere<TodayWalkTime>) {
@@ -20,7 +20,7 @@ export class DailyWalkTimeService {
     }
 
     async getWalkTimeList(walkTimeIds: number[]) {
-        const walkTimeList = await this.dailyWalkTimeRepository.find({ id: In(walkTimeIds) });
+        const walkTimeList = await this.dailyWalkTimeRepository.find({ where: { id: In(walkTimeIds) } });
         if (!walkTimeList.length) {
             const error = new NotFoundException(`No walkTime found for the provided IDs: ${walkTimeIds}.`);
             this.logger.error(`No walkTime found for the provided IDs: ${walkTimeIds}.`, error.stack ?? 'No stack');

--- a/backend/src/dog-walk-day/dog-walk-day.service.ts
+++ b/backend/src/dog-walk-day/dog-walk-day.service.ts
@@ -8,7 +8,7 @@ export class DogWalkDayService {
     constructor(private readonly dogWalkDayRepository: DogWalkDayRepository) {}
 
     async find(where: FindOptionsWhere<DogWalkDay>): Promise<DogWalkDay[]> {
-        return this.dogWalkDayRepository.find(where);
+        return this.dogWalkDayRepository.find({where});
     }
 
     async delete(where: FindOptionsWhere<DogWalkDay>) {
@@ -29,7 +29,7 @@ export class DogWalkDayService {
     }
 
     async getWalkDayList(walkDayIds: number[]): Promise<number[][]> {
-        const foundDays = await this.dogWalkDayRepository.find({ id: In(walkDayIds) });
+        const foundDays = await this.dogWalkDayRepository.find({where:{ id: In(walkDayIds) }});
         if (!foundDays.length) {
             throw new NotFoundException();
         }

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -107,7 +107,7 @@ export class DogsService {
     }
 
     async getProfileList(where: FindOptionsWhere<Dogs>): Promise<DogProfile[]> {
-        const dogInfos = await this.dogsRepository.find(where);
+        const dogInfos = await this.dogsRepository.find({ where });
         return this.makeProfileList(dogInfos);
     }
 
@@ -120,14 +120,14 @@ export class DogsService {
         ownDogIds: number[],
         attributeName: 'walkDayId' | 'todayWalkTimeId' | 'breedId'
     ): Promise<number[]> {
-        const ownDogList = await this.dogsRepository.find({ id: In(ownDogIds) });
+        const ownDogList = await this.dogsRepository.find({ where: { id: In(ownDogIds) } });
         return ownDogList.map((cur) => {
             return cur[attributeName];
         });
     }
 
     async getAvailableDogProfileList(ownDogIds: number[]): Promise<DogProfile[]> {
-        const availableDogList = await this.dogsRepository.find({ id: In(ownDogIds), isWalking: false });
+        const availableDogList = await this.dogsRepository.find({ where: { id: In(ownDogIds), isWalking: false } });
         const availableDogProfileList = this.makeProfileList(availableDogList);
         return availableDogProfileList;
     }

--- a/backend/src/excrements/excrements.service.ts
+++ b/backend/src/excrements/excrements.service.ts
@@ -25,7 +25,7 @@ export class ExcrementsService {
     }
 
     async find(where: FindOptionsWhere<Excrements>): Promise<Excrements[]> {
-        return this.excrementsRepository.find(where);
+        return this.excrementsRepository.find({ where });
     }
 
     async findOne(where: FindOptionsWhere<Excrements>): Promise<Excrements> {

--- a/backend/src/journal-photos/journal-photos.service.ts
+++ b/backend/src/journal-photos/journal-photos.service.ts
@@ -23,7 +23,7 @@ export class JournalPhotosService {
     }
 
     async find(where: FindOptionsWhere<JournalPhotos>): Promise<JournalPhotos[]> {
-        return this.journalPhotosRepository.find(where);
+        return this.journalPhotosRepository.find({ where });
     }
 
     async update(

--- a/backend/src/journals-dogs/journals-dogs.service.ts
+++ b/backend/src/journals-dogs/journals-dogs.service.ts
@@ -22,6 +22,6 @@ export class JournalsDogsService {
     }
 
     async find(where: FindOptionsWhere<JournalsDogs>): Promise<JournalsDogs[]> {
-        return this.journalsDogsRepository.find(where);
+        return this.journalsDogsRepository.find({ where });
     }
 }

--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -33,7 +33,7 @@ export class JournalsService {
     }
 
     async find(where: FindOptionsWhere<Journals>) {
-        return this.journalsRepository.find(where);
+        return this.journalsRepository.find({ where });
     }
 
     async findOne(where: FindOptionsWhere<Journals>): Promise<Journals> {
@@ -60,11 +60,11 @@ export class JournalsService {
     }
 
     async getOwnJournals(userId: number): Promise<Journals[]> {
-        return this.journalsRepository.find({ id: userId });
+        return this.journalsRepository.find({ where: { id: userId } });
     }
 
     async getOwnJournalIds(userId: number): Promise<number[]> {
-        const ownJournals = await this.journalsRepository.find({ id: userId });
+        const ownJournals = await this.journalsRepository.find({ where: { id: userId } });
 
         return ownJournals.map((cur) => cur.id);
     }

--- a/backend/src/users-dogs/users-dogs.service.ts
+++ b/backend/src/users-dogs/users-dogs.service.ts
@@ -14,7 +14,7 @@ export class UsersDogsService {
     }
 
     async find(where: FindOptionsWhere<UsersDogs>) {
-        return this.usersDogsRepository.find(where);
+        return this.usersDogsRepository.find({ where });
     }
 
     async findOne(where: FindOptionsWhere<UsersDogs>) {

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -22,7 +22,7 @@ export class UsersService {
     }
 
     async find(where: FindOptionsWhere<Users>) {
-        return this.usersRepository.find(where);
+        return this.usersRepository.find({ where });
     }
 
     async findOne(where: FindOptionsWhere<Users>) {


### PR DESCRIPTION
## 작업 내용 (Content)
- 추상 리포지토리 find 함수를 typeorm의 find 함수 쓰도록 변경
- 인자 타입을 findMayOptions 로 변경해 더 많은 옵션을 넣을 수 있도록 변경

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
