### PR TITLE
frontend/DANG-651: 산책일지 저장 페이지에서 상태에 저장된 경로를 이용해 이미지를 표시

### DIFF
--- a/frontend/src/components/journals/DogImages.tsx
+++ b/frontend/src/components/journals/DogImages.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+
+export default function DogImages({ children }: Props) {
+    return (
+        <div className="flex flex-row gap-1 overflow-x-auto">
+            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
+            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
+            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
+            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
+            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
+            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
+            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
+            {children}
+        </div>
+    );
+}
+
+interface Props {
+    children: ReactNode;
+}

--- a/frontend/src/components/journals/DogImages.tsx
+++ b/frontend/src/components/journals/DogImages.tsx
@@ -5,8 +5,8 @@ export default function DogImages({ images, children }: Props) {
     return (
         <div className="flex flex-row gap-1 overflow-x-auto">
             {images.map((image) => (
-                <span key={image.url} className="inline-block min-w-[104px] h-[104px] bg-slate-300">
-                    강아지 이미지
+                <span key={image.url} className="inline-flex items-center h-[104px]">
+                    <img src={image.url} alt={image.name} className="inline-block max-h-[104px] bg-slate-300" />
                 </span>
             ))}
             {children}

--- a/frontend/src/components/journals/DogImages.tsx
+++ b/frontend/src/components/journals/DogImages.tsx
@@ -1,20 +1,20 @@
+import { Image } from '@/pages/Journals/CreateForm';
 import { ReactNode } from 'react';
 
-export default function DogImages({ children }: Props) {
+export default function DogImages({ images, children }: Props) {
     return (
         <div className="flex flex-row gap-1 overflow-x-auto">
-            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
-            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
-            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
-            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
-            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
-            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
-            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
+            {images.map((image) => (
+                <span key={image.url} className="inline-block min-w-[104px] h-[104px] bg-slate-300">
+                    강아지 이미지
+                </span>
+            ))}
             {children}
         </div>
     );
 }
 
 interface Props {
+    images: Array<Image>;
     children: ReactNode;
 }

--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -26,7 +26,6 @@ export default function CreateForm() {
     const { show: showToast } = useToast();
 
     const [openModal, setOpenModal] = useState(false);
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [images, setImages] = useState<Array<Image>>([]);
     const [isUploading, setIsUploading] = useState(false);
 
@@ -173,7 +172,7 @@ export default function CreateForm() {
                     <Divider />
                     <div>
                         <h2>사진</h2>
-                        <DogImages>
+                        <DogImages images={images}>
                             <AddPhotoButton isLoading={isUploading} onChange={handleAddImages} />
                         </DogImages>
                     </div>
@@ -239,7 +238,7 @@ interface Excrement {
     urineLocations: Array<Location>;
 }
 
-interface Image {
+export interface Image {
     url: string;
     name: string;
 }

--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/components/common/Modal';
 import Topbar from '@/components/common/Topbar';
 import AddPhotoButton from '@/components/journals/AddPhotoButton';
+import DogImages from '@/components/journals/DogImages';
 import ExcrementDisplay from '@/components/journals/ExcrementDisplay';
 import WalkInfo from '@/components/walk/WalkInfo';
 import useToast from '@/hooks/useToast';
@@ -172,16 +173,9 @@ export default function CreateForm() {
                     <Divider />
                     <div>
                         <h2>사진</h2>
-                        <div className="flex flex-row gap-1 overflow-x-auto">
-                            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
-                            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
-                            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
-                            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
-                            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
-                            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
-                            <span className="inline-block min-w-[104px] h-[104px] bg-slate-300">강아지 이미지</span>
+                        <DogImages>
                             <AddPhotoButton isLoading={isUploading} onChange={handleAddImages} />
-                        </div>
+                        </DogImages>
                     </div>
                     <Divider />
                     <div>


### PR DESCRIPTION
## 작업 내용 (Content)
산책일지 저장 페이지에서 상태에 저장된 경로를 이용해 이미지를 표시

## 링크 (Links)
https://www.notion.so/do0ori/2ed3234462f2443f92e700145a4f88ce?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
