### PR TITLE
frontend/DANG-659: 산책일지 저장 페이지에서 저장 로직 구현

### DIFF
--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -18,6 +18,7 @@ import DogImages from '@/components/journals/DogImages';
 import ExcrementDisplay from '@/components/journals/ExcrementDisplay';
 import WalkInfo from '@/components/walk/WalkInfo';
 import useToast from '@/hooks/useToast';
+import { useSpinnerStore } from '@/store/spinnerStore';
 import { FormEvent, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
@@ -25,9 +26,13 @@ export default function CreateForm() {
     const navigate = useNavigate();
     const { show: showToast } = useToast();
 
+    const addSpinner = useSpinnerStore((state) => state.spinnerAdd);
+    const removeSpinner = useSpinnerStore((state) => state.spinnerRemove);
+
     const [openModal, setOpenModal] = useState(false);
     const [images, setImages] = useState<Array<Image>>([]);
     const [isUploading, setIsUploading] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
 
     const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -182,7 +187,7 @@ export default function CreateForm() {
                         <textarea name="memo" className="w-full" ref={textAreaRef} />
                     </div>
                 </div>
-                <Button rounded="none" className="w-full h-16" onClick={handleSave}>
+                <Button rounded="none" className="w-full h-16" disabled={isSaving} onClick={handleSave}>
                     <span className="-translate-y-[5px]">저장하기</span>
                 </Button>
             </div>
@@ -202,7 +207,12 @@ export default function CreateForm() {
     );
 
     function handleSave() {
+        setIsSaving(true);
+        addSpinner();
+
         setTimeout(() => {
+            setIsSaving(false);
+            removeSpinner();
             showToast('산책 기록이 저장되었습니다.');
 
             navigate('/');

--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -182,7 +182,7 @@ export default function CreateForm() {
                         <textarea name="memo" className="w-full" ref={textAreaRef} />
                     </div>
                 </div>
-                <Button rounded="none" className="w-full h-16">
+                <Button rounded="none" className="w-full h-16" onClick={handleSave}>
                     <span className="-translate-y-[5px]">저장하기</span>
                 </Button>
             </div>
@@ -200,6 +200,14 @@ export default function CreateForm() {
             </Modal>
         </>
     );
+
+    function handleSave() {
+        setTimeout(() => {
+            showToast('산책 기록이 저장되었습니다.');
+
+            navigate('/');
+        }, 2000);
+    }
 
     function handleCancelSave() {
         showToast('산책 기록이 삭제되었습니다.');


### PR DESCRIPTION
## 작업 내용 (Content)
산책일지 저장 페이지에서 저장 로직 구현

## 링크 (Links)
https://www.notion.so/do0ori/7d93b9d30d574ed18ce59b341b2d7217?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
