### PR TITLE
frontend/DANG-667: 산책일지 저장 페이지를 위한 Heading 컴포넌트

### DIFF
--- a/frontend/src/components/journals/Heading.tsx
+++ b/frontend/src/components/journals/Heading.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/utils/tailwind-class';
+import { VariantProps, cva } from 'class-variance-authority';
+import { HTMLAttributes } from 'react';
+
+const variants = cva('', {
+    variants: {
+        headingNumber: {
+            1: 'text-lg font-bold',
+            2: 'text-base font-semibold',
+            3: 'text-base font-semibold',
+            4: 'text-base font-semibold',
+            5: 'text-base font-semibold',
+            6: 'text-base font-semibold',
+        },
+    },
+});
+export default function Heading({ headingNumber, children, ...props }: Props) {
+    const headings = { 1: 'h1', 2: 'h2', 3: 'h3', 4: 'h4', 5: 'h5', 6: 'h6' } as const;
+    const Tag = headings[headingNumber];
+
+    return (
+        <Tag className={cn(variants({ headingNumber }))} {...props}>
+            {children}
+        </Tag>
+    );
+}
+
+interface Props extends HTMLAttributes<HTMLHeadingElement>, Ensure<VariantProps<typeof variants>> {}
+
+type NonNullableProps<T> = {
+    [P in keyof T]: NonNullable<T[P]>;
+};
+
+type Ensure<T> = T & Required<NonNullableProps<T>>;

--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -16,6 +16,7 @@ import Topbar from '@/components/common/Topbar';
 import AddPhotoButton from '@/components/journals/AddPhotoButton';
 import DogImages from '@/components/journals/DogImages';
 import ExcrementDisplay from '@/components/journals/ExcrementDisplay';
+import Heading from '@/components/journals/Heading';
 import WalkInfo from '@/components/walk/WalkInfo';
 import useToast from '@/hooks/useToast';
 import { useSpinnerStore } from '@/store/spinnerStore';
@@ -148,7 +149,7 @@ export default function CreateForm() {
             <div className="flex flex-col">
                 <Topbar>
                     <Topbar.Center className="text-center text-lg font-bold leading-[27px]">
-                        <h1>5월 2일 산책기록</h1>
+                        <Heading headingNumber={1}>5월 2일 산책기록</Heading>
                     </Topbar.Center>
                     <Topbar.Back className="w-12 flex items-center">
                         <button onClick={() => setOpenModal(true)}>
@@ -161,7 +162,7 @@ export default function CreateForm() {
                     <WalkInfo distance={0} calories={0} duration={0} />
                     <Divider />
                     <div>
-                        <h2>함께한 댕댕이</h2>
+                        <Heading headingNumber={2}>함께한 댕댕이</Heading>
                         <div className="flex flex-col">
                             {FAKE_EXCREMENTS.map((excrement) => (
                                 <div key={excrement.dogId} className="flex justify-between">
@@ -176,14 +177,14 @@ export default function CreateForm() {
                     </div>
                     <Divider />
                     <div>
-                        <h2>사진</h2>
+                        <Heading headingNumber={2}>사진</Heading>
                         <DogImages images={images}>
                             <AddPhotoButton isLoading={isUploading} onChange={handleAddImages} />
                         </DogImages>
                     </div>
                     <Divider />
                     <div>
-                        <h2>메모</h2>
+                        <Heading headingNumber={2}>메모</Heading>
                         <textarea name="memo" className="w-full" ref={textAreaRef} />
                     </div>
                 </div>


### PR DESCRIPTION
## 작업 내용 (Content)
산책일지 저장 페이지를 위한 Heading 컴포넌트

## 링크 (Links)
https://www.notion.so/do0ori/Heading-f38735f6ea6f42d08b9f968cc4892503?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
