### PR TITLE
backend/DANG-677: journalId를 찾을 수 없다는 버그 수정

### DIFF
--- a/backend/src/journals-dogs/journals-dogs.service.ts
+++ b/backend/src/journals-dogs/journals-dogs.service.ts
@@ -32,7 +32,7 @@ export class JournalsDogsService {
                 order: { journalId: 'DESC' },
                 take: 1,
             });
-            return journal ? journal[0].journalId : undefined;
+            return journal.length ? journal[0].journalId : undefined;
         });
         return Promise.all(result);
     }


### PR DESCRIPTION
## 작업 내용 (Content)
- 최근 산책일지를 찾는 로직에서, 산책일지가 없을 때를 !result로 체크했는데, 산책일지가 없어도 빈 배열을 리턴해서 체크를 통과해버려서 빈 배열 안에 있는 joruanlId에 접근해서 생긴 문제.
- 체크 로직을 !result.length로 변경해서 해결했다

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
