### PR TITLE
backend/DANG-678: journals에서 title 삭제, dogs의 profile_photo_url 타입 text->varchar로 복귀

### DIFF
--- a/backend/src/dogs/dogs.entity.ts
+++ b/backend/src/dogs/dogs.entity.ts
@@ -45,7 +45,7 @@ export class Dogs {
     @Column({ name: 'is_neutered' })
     isNeutered: boolean;
 
-    @Column({ name: 'profile_photo_url', type: 'text', nullable: true, default: null })
+    @Column({ name: 'profile_photo_url', type: 'varchar', nullable: true, default: null })
     profilePhotoUrl: string | null;
 
     @Column({ name: 'is_walking', default: false })

--- a/backend/src/journals/dto/journal-update.dto.ts
+++ b/backend/src/journals/dto/journal-update.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsUrl, ValidateNested } from 'class-validator';
+import { IsOptional, IsString, ValidateNested } from 'class-validator';
 
 export class UpdateJournalDto {
     @IsOptional()
@@ -6,6 +6,6 @@ export class UpdateJournalDto {
 
     @IsOptional()
     @ValidateNested()
-    @IsUrl({}, { each: true })
+    @IsString({ each: true })
     photoUrls: string[];
 }

--- a/backend/src/journals/dto/journals-create.dto.ts
+++ b/backend/src/journals/dto/journals-create.dto.ts
@@ -6,7 +6,7 @@ import {
     IsNotEmptyObject,
     IsNumber,
     IsOptional,
-    IsUrl,
+    IsString,
     ValidateNested,
 } from 'class-validator';
 // TODO: 문자열이면서 숫자 범위를 넘지 않는지 확인하는 custom Validator 만들기..?
@@ -47,14 +47,14 @@ export class JournalInfoForCreate {
     duration: number;
 
     @IsNotEmpty()
-    @IsUrl()
+    @IsString()
     routeImageUrl: string;
 
     @IsOptional()
     memo: string;
 
     @IsOptional()
-    @IsUrl({}, { each: true })
+    @IsString({ each: true })
     photoUrls: string[];
 
     static getKeysForJournalTable() {

--- a/backend/src/journals/dto/journals-detail.dto.ts
+++ b/backend/src/journals/dto/journals-detail.dto.ts
@@ -1,9 +1,9 @@
 import { Type } from 'class-transformer';
-import { IsNotEmpty, IsOptional, IsString, IsUrl, ValidateNested } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
 
 export class PhotoUrlDto {
     @IsNotEmpty()
-    @IsUrl()
+    @IsString()
     photoUrl: string;
 
     static getKey() {
@@ -63,14 +63,14 @@ export class JournalInfoForDetail {
     duration: number;
 
     @IsNotEmpty()
-    @IsUrl()
+    @IsString()
     routeImageUrl: string;
 
     @IsNotEmpty()
     memo: string;
 
     @IsNotEmpty()
-    @IsUrl({}, { each: true })
+    @IsString({ each: true })
     photoUrls: string[];
 
     static getKeysForJournalTable() {

--- a/backend/src/journals/journals.entity.ts
+++ b/backend/src/journals/journals.entity.ts
@@ -13,9 +13,6 @@ export class Journals {
     @Column({ name: 'user_id' })
     userId: number;
 
-    @Column({nullable: true})
-    title: string;
-
     @Column()
     distance: number;
 


### PR DESCRIPTION
## 작업 내용 (Content)
1. journals에서 title 삭제
- 사용자가 제목 입력하는 기능이 없다고 해서 삭제했습니다
2. dogs에서 profile_photo_url 컬럼 타입을 text->varchar로 복귀
- presigned URL을 저장하는걸로 잘못 해석해서 길이가 초과됐었는데, presigned URL이 아니라 저장된 파일의 경로를 저장하는거라 varchar로도 충분합니다

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
