### PR TITLE
backend/DANG-699: getProfile method에서 breed field의 koreanName을 사용하도록 수정

### DIFF
--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -102,11 +102,11 @@ export class DogsService {
         return dogIds;
     }
 
-    private makeProfile(dogInfo: Dogs, breed: string): DogProfile {
+    private makeProfile(dogInfo: Dogs): DogProfile {
         return {
             id: dogInfo.id,
             name: dogInfo.name,
-            breed: breed,
+            breed: dogInfo.breed.koreanName,
             gender: dogInfo.gender as Gender,
             isNeutered: dogInfo.isNeutered,
             birth: dogInfo.birth,
@@ -125,8 +125,7 @@ export class DogsService {
 
     async getProfile(dogId: number): Promise<DogProfile> {
         const dogInfo = await this.dogsRepository.findOne({ id: dogId });
-        const breed = await this.breedService.findOne(dogInfo.breed);
-        return this.makeProfile(dogInfo, breed.koreanName);
+        return this.makeProfile(dogInfo);
     }
 
     async getRelatedTableIdList(


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
현재 `Dogs.breed` column에 option으로 `eager: true`가 설정되어 있기 때문에 Dogs entity를 가져올 때 breedId에 해당하는 Breed entity도 함께 가져오게 된다. 그래서 따로 breedId에 해당하는 Breed 객체를 찾지 않아도 된다.

## 링크 (Links)
https://www.notion.so/do0ori/getProfile-method-eager-option-f629ea7d253e4fbea0b093b8b35eaf43

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
