### PR TITLE
backend/DANG-688: 사용자가 소유한 모든 강아지의 profile을 가져오는 API 추가

### DIFF
--- a/backend/src/dogs/dogs.controller.ts
+++ b/backend/src/dogs/dogs.controller.ts
@@ -26,6 +26,11 @@ export type DogSummary = {
 export class DogsController {
     constructor(private readonly dogsService: DogsService) {}
 
+    @Get()
+    async getProfileList(@User() { userId }: AccessTokenPayload) {
+        return this.dogsService.getProfileList(userId);
+    }
+
     @Post()
     async register(@User() { userId }: AccessTokenPayload, @Body() dogDto: DogDto) {
         await this.dogsService.createDogToUser(userId, dogDto);
@@ -50,7 +55,7 @@ export class DogsController {
 
     @Get('/:id(\\d+)')
     @UseGuards(AuthDogGuard)
-    async getOneProfile(@Param('id', ParseIntPipe) dogId: number) {
+    async getProfile(@Param('id', ParseIntPipe) dogId: number) {
         return this.dogsService.getProfile(dogId);
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
`UserDogs`에서 사용자가 소유한 모든 강아지의 id를 가져오고 순회하며 profile을 작성할 수도 있지만 비효율적인 것 같아 `QueryBuilder`로 해결했다. 보내줄 field는 확정은 아니라서 일단 강아지 프로필 조회 API와 동일하게 보낸다.
생일 timezone도 아직 처리가 안되어 있다.

## 링크 (Links)
https://www.notion.so/do0ori/API-c5160d28653449cf8e2b363e2de2390a

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
