### PR TITLE
frontend/DANG-703: 산책일지 저장 페이지에서 잘못된 사진 Url

### DIFF
--- a/frontend/src/components/journals/DogImages.tsx
+++ b/frontend/src/components/journals/DogImages.tsx
@@ -1,4 +1,5 @@
 import { ImageUrl } from '@/pages/Journals/CreateForm';
+import { makeFileUrl } from '@/utils/url';
 import { ReactNode } from 'react';
 
 export default function DogImages({ imageUrls, children }: Props) {
@@ -6,7 +7,11 @@ export default function DogImages({ imageUrls, children }: Props) {
         <div className="flex flex-row gap-1 overflow-x-auto">
             {imageUrls.map((imageUrl) => (
                 <span key={imageUrl} className="inline-flex items-center h-[104px]">
-                    <img src={imageUrl} alt="강아진 산책 사진" className="inline-block max-h-[104px] bg-slate-300" />
+                    <img
+                        src={makeFileUrl(imageUrl)}
+                        alt="강아진 산책 사진"
+                        className="inline-block max-h-[104px] bg-slate-300"
+                    />
                 </span>
             ))}
             {children}

--- a/frontend/src/utils/url.ts
+++ b/frontend/src/utils/url.ts
@@ -1,0 +1,7 @@
+const { REACT_APP_BASE_IMAGE_URL = '' } = window._ENV ?? process.env;
+
+function makeFileUrl(fileName: string) {
+    return `${REACT_APP_BASE_IMAGE_URL}/${fileName}`;
+}
+
+export { makeFileUrl };


### PR DESCRIPTION
## 작업 내용 (Content)
산책일지 저장 페이지에서 잘못된 사진 Url

## 링크 (Links)
https://www.notion.so/do0ori/Url-69f696f21dc94d5695088a555a1e603f?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
