### PR TITLE
backend/DANG-695: 회원탈퇴(삭제)시 연관된 row들까지 삭제하도록 업데이트

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -40,15 +40,15 @@ export class AuthController {
         return await this.authService.logout(user);
     }
 
-    @Delete('deactivate')
-    async deactivate(@User() user: AccessTokenPayload) {
-        return await this.authService.deactivate(user);
-    }
-
     @Get('token')
     @SkipAuthGuard()
     @UseGuards(RefreshTokenGuard)
     async token(@User() user: RefreshTokenPayload) {
         return await this.authService.reissueTokens(user);
+    }
+
+    @Delete('deactivate')
+    async deactivate(@User() user: AccessTokenPayload) {
+        return await this.authService.deactivate(user);
     }
 }

--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { APP_GUARD } from '@nestjs/core';
 import { JwtModule } from '@nestjs/jwt';
-import { UsersModule } from '../users/users.module';
+import { DogsModule } from 'src/dogs/dogs.module';
 import { AuthController } from './auth.controller';
 import { AuthService } from './auth.service';
 import { AuthGuard } from './guards/auth.guard';
@@ -17,7 +17,7 @@ import { TokenService } from './token/token.service';
                 secret: config.get('JWT_SECRET'),
             }),
         }),
-        UsersModule,
+        DogsModule,
         OauthModule,
     ],
     controllers: [AuthController],

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { WinstonLoggerService } from 'src/common/logger/winstonLogger.service';
+import { DogsService } from 'src/dogs/dogs.service';
 import { mockUser } from '../fixtures/users.fixture';
 import { Users } from '../users/users.entity';
 import { UsersRepository } from '../users/users.repository';
@@ -20,6 +21,7 @@ const context = describe;
 describe('AuthService', () => {
     let service: AuthService;
     let usersService: UsersService;
+    let dogsService: DogsService;
     let tokenService: TokenService;
     let googleService: GoogleService;
     let kakaoService: KakaoService;
@@ -33,6 +35,10 @@ describe('AuthService', () => {
                 {
                     provide: UsersService,
                     useValue: { updateAndFindOne: jest.fn(), createIfNotExists: jest.fn(), findOne: jest.fn() },
+                },
+                {
+                    provide: DogsService,
+                    useValue: { deleteDogFromUser: jest.fn() },
                 },
                 { provide: UsersRepository, useValue: {} },
                 TokenService,
@@ -48,6 +54,7 @@ describe('AuthService', () => {
 
         service = module.get<AuthService>(AuthService);
         usersService = module.get<UsersService>(UsersService);
+        dogsService = module.get<DogsService>(DogsService);
         tokenService = module.get<TokenService>(TokenService);
         googleService = module.get<GoogleService>(GoogleService);
         kakaoService = module.get<KakaoService>(KakaoService);

--- a/backend/src/journals/journals.entity.ts
+++ b/backend/src/journals/journals.entity.ts
@@ -6,7 +6,7 @@ export class Journals {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @ManyToOne(() => Users, (users) => users.id)
+    @ManyToOne(() => Users, (users) => users.id, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'user_id' })
     user: Users;
 

--- a/backend/src/users-dogs/users-dogs.entity.ts
+++ b/backend/src/users-dogs/users-dogs.entity.ts
@@ -5,7 +5,7 @@ import { Users } from '../users/users.entity';
 @Entity('users_dogs')
 export class UsersDogs {
     @PrimaryColumn({ name: 'user_id' })
-    @ManyToOne(() => Users, (users) => users.id)
+    @ManyToOne(() => Users, (users) => users.id, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'user_id' })
     userId: number;
 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- `UsersDogs` 및 `Journals`의 userId FK에 `onDelete: 'CASCADE'` 추가
- Table들의 연관관계가 업데이트되면서 단순히 userId에 해당하는 user를 삭제할 수 없게 되었다. (FK Constraints Error 발생)
연관된 row들까지 삭제하는 순서는 다음과 같다.
  1. UsersDogs에서 사용자가 소유하고 있는 강아지의 id를 모두 찾아 해당 강아지들을 삭제
  2. Users에서 사용자 삭제

  `onDelete: 'CASCADE'` option에 의해 연관된 나머지 row들은 자동으로 삭제된다.

## 링크 (Links)
https://www.notion.so/do0ori/row-c7fd34272af549cb93a015cfa9dd016f

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
