### PR TITLE
frontend/DANG-458: Checkbox2 컴포넌트에서 함수의 이름 변경

### DIFF
--- a/frontend/src/components/common/Checkbox2.tsx
+++ b/frontend/src/components/common/Checkbox2.tsx
@@ -6,7 +6,7 @@ import { ComponentPropsWithoutRef, ElementRef, forwardRef, useRef } from 'react'
 
 const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Props>(
     ({ checked, labelText, className, children, ...props }, ref) => {
-        const idRef = useRef<string | undefined>(labelText ? newID() : undefined);
+        const idRef = useRef<string | undefined>(labelText ? generateId() : undefined);
 
         return (
             <div className={cn('flex items-center gap-3 h-9', className)}>
@@ -29,7 +29,7 @@ const Checkbox = forwardRef<ElementRef<typeof CheckboxPrimitive.Root>, Props>(
 );
 Checkbox.displayName = CheckboxPrimitive.Root.displayName;
 
-function newID() {
+function generateId() {
     return Math.random().toString(36).slice(2);
 }
 


### PR DESCRIPTION
## 작업 내용 (Content)
Checkbox2 컴포넌트에서 함수의 이름 변경

## 링크 (Links)
https://www.notion.so/do0ori/84da6a9ecbc1491a908a59854e486631?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
