### PR TITLE
backend/DANG-693: seeding 시 console.log를 winstonLogger로 대체하기

### DIFF
--- a/backend/src/common/database/database.module.ts
+++ b/backend/src/common/database/database.module.ts
@@ -6,6 +6,7 @@ import { color } from 'src/utils/ansi.utils';
 import { DataSource } from 'typeorm';
 import { runSeeders } from 'typeorm-extension';
 import { addTransactionalDataSource } from 'typeorm-transactional';
+import { WinstonLoggerService } from '../logger/winstonLogger.service';
 import BreedSeeder from './seeds/breed.seeder';
 
 @Module({
@@ -35,11 +36,14 @@ import BreedSeeder from './seeds/breed.seeder';
     ],
 })
 export class DatabaseModule {
-    constructor(@Inject(getDataSourceToken()) private readonly dataSource: DataSource) {}
+    constructor(
+        @Inject(getDataSourceToken()) private readonly dataSource: DataSource,
+        private readonly logger: WinstonLoggerService
+    ) {}
 
     async onModuleInit() {
         await runSeeders(this.dataSource, { seeds: [BreedSeeder] });
-        console.log(color('Seed data applied successfully.', 'Cyan'));
+        this.logger.log(color('Seed data applied successfully.', 'Yellow'));
     }
 
     static forFeature(models: EntityClassOrSchema[]): DynamicModule {

--- a/backend/src/common/database/seeds/breed.seeder.ts
+++ b/backend/src/common/database/seeds/breed.seeder.ts
@@ -1,5 +1,6 @@
 import * as fs from 'node:fs';
 import { Breed } from 'src/breed/breed.entity';
+import { WinstonLoggerService } from 'src/common/logger/winstonLogger.service';
 import { color } from 'src/utils/ansi.utils';
 import { DataSource } from 'typeorm';
 import { Seeder } from 'typeorm-extension';
@@ -16,6 +17,7 @@ export default class BreedSeeder implements Seeder {
         await repository.query('SET FOREIGN_KEY_CHECKS = 1;');
         await repository.insert(breeds);
 
-        console.log(`${color(breeds.length, 'Yellow')} rows inserted into breed table.`);
+        const logger = new WinstonLoggerService();
+        logger.log(`${color(breeds.length, 'Yellow')} rows inserted into breed table.`);
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- `DatabaseModule`에는 `WinstonLoggerService` 주입
- `BreedSeeder`는 주입이 안되는 관계로 직접 instance를 생성해 사용

## 링크 (Links)
https://www.notion.so/do0ori/seeding-console-log-winstonLogger-841f565105af45cbb3255f5e1aac1b09

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
