### PR TITLE
backend/DANG-722: 산책 목록 API 구현

### DIFF
--- a/backend/src/common/database/abstract.repository.ts
+++ b/backend/src/common/database/abstract.repository.ts
@@ -65,6 +65,10 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         return this.entityRepository.find(where);
     }
 
+    async findAndCountBy(where: FindOptionsWhere<T>): Promise<[T[], number]> {
+        return this.entityRepository.findAndCountBy(where);
+    }
+
     async update(where: FindOptionsWhere<T>, partialEntity: QueryDeepPartialEntity<T>): Promise<UpdateResult> {
         const updateResult = await this.entityRepository.update(where, partialEntity);
 

--- a/backend/src/common/database/abstract.repository.ts
+++ b/backend/src/common/database/abstract.repository.ts
@@ -65,10 +65,6 @@ export abstract class AbstractRepository<T extends ObjectLiteral> {
         return this.entityRepository.find(where);
     }
 
-    async findAndCountBy(where: FindOptionsWhere<T>): Promise<[T[], number]> {
-        return this.entityRepository.findAndCountBy(where);
-    }
-
     async update(where: FindOptionsWhere<T>, partialEntity: QueryDeepPartialEntity<T>): Promise<UpdateResult> {
         const updateResult = await this.entityRepository.update(where, partialEntity);
 

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -120,7 +120,8 @@ export class DogsService {
     }
 
     private makeDogsSummaryList(dogs: Dogs[]): DogSummary[] {
-        return makeSubObjectsArray(dogs, ['id', 'name', 'profilePhotoUrl']);
+        //TODO: key를 리턴하는 함수 만들어 인자로 넣기
+        return makeSubObjectsArray(dogs, ['id', 'name', 'profilePhotoUrl'], ['id', 'name', 'profilePhotoUrl']);
     }
 
     async getDogsSummaryList(where: FindOptionsWhere<Dogs>): Promise<DogSummary[]> {

--- a/backend/src/journals-dogs/journals-dogs.service.ts
+++ b/backend/src/journals-dogs/journals-dogs.service.ts
@@ -25,10 +25,6 @@ export class JournalsDogsService {
         return this.journalsDogsRepository.find(where);
     }
 
-    async findAndCountBy(where: FindOptionsWhere<JournalsDogs>) {
-        return this.journalsDogsRepository.findAndCountBy(where);
-    }
-
     async getRecentJournalId(dogIds: number[]): Promise<(number | undefined)[]> {
         const result = dogIds.map(async (curDogId) => {
             const journal = await this.journalsDogsRepository.find({

--- a/backend/src/journals-dogs/journals-dogs.service.ts
+++ b/backend/src/journals-dogs/journals-dogs.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { FindOptionsWhere } from 'typeorm';
+import { FindManyOptions, FindOptionsWhere } from 'typeorm';
 import { JournalsDogs } from './journals-dogs.entity';
 import { JournalsDogsRepository } from './journals-dogs.repository';
 
@@ -21,8 +21,12 @@ export class JournalsDogsService {
         return this.journalsDogsRepository.findOne(where);
     }
 
-    async find(where: FindOptionsWhere<JournalsDogs>): Promise<JournalsDogs[]> {
-        return this.journalsDogsRepository.find({ where });
+    async find(where: FindManyOptions<JournalsDogs>): Promise<JournalsDogs[]> {
+        return this.journalsDogsRepository.find(where);
+    }
+
+    async findAndCountBy(where: FindOptionsWhere<JournalsDogs>) {
+        return this.journalsDogsRepository.findAndCountBy(where);
     }
 
     async getRecentJournalId(dogIds: number[]): Promise<(number | undefined)[]> {

--- a/backend/src/journals/dto/journal-list.dto.ts
+++ b/backend/src/journals/dto/journal-list.dto.ts
@@ -1,0 +1,29 @@
+import { IsDate, IsInt, IsNumber } from 'class-validator';
+
+export class JournalInfoForList {
+    @IsNumber()
+    journalId: number;
+
+    @IsInt()
+    journalCnt: number;
+
+    @IsDate()
+    startedAt: Date;
+
+    @IsNumber()
+    distance: number;
+
+    @IsNumber()
+    calories: number;
+
+    @IsNumber()
+    duration: number;
+
+    static getAttributesForJournalTable() {
+        return ['journalId', 'startedAt', 'distance', 'calories', 'duration'];
+    }
+
+    static getKeysForJournalTable() {
+        return ['id', 'startedAt', 'distance', 'calories', 'duration'];
+    }
+}

--- a/backend/src/journals/journals.controller.ts
+++ b/backend/src/journals/journals.controller.ts
@@ -1,6 +1,8 @@
 import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, Query, UseGuards } from '@nestjs/common';
 import { AccessTokenPayload } from 'src/auth/token/token.service';
+import { DateValidationPipe } from 'src/statistics/pipes/dateValidation.pipe';
 import { User } from 'src/users/decorators/user.decorator';
+import { JournalInfoForList } from './dto/journal-list.dto';
 import { UpdateJournalDto } from './dto/journal-update.dto';
 import { CreateJournalDto } from './dto/journals-create.dto';
 import { AuthJournalGuard } from './guards/authJournal.guard';
@@ -14,6 +16,14 @@ export class JournalsController {
     @UseGuards(AuthJournalGuard)
     getJournalDetail(@Param('id', ParseIntPipe) journalId: number, @Query('dogId', ParseIntPipe) dogId: number) {
         return this.journalsService.getJournalDetail(journalId, dogId);
+    }
+
+    @Get('/')
+    async getJournalList(
+        @Query('dogId', ParseIntPipe) dogId: number,
+        @Query('date', DateValidationPipe) date: string
+    ): Promise<JournalInfoForList[]> {
+        return await this.journalsService.getJournalList(dogId, date);
     }
 
     @Post('/')

--- a/backend/src/utils/manipulate.util.ts
+++ b/backend/src/utils/manipulate.util.ts
@@ -20,36 +20,45 @@ export function checkIfExistsInArr<T>(targetArr: T[], toFind: T | T[]): boolean 
 }
 
 /**
- * 주어진 대상 배열에서 특정 속성을 선택하여 객체 배열을 생성합니다.
+ * 주어진 배열의 각 요소에서 특정 속성을 선택하여 새로운 객체를 만듭니다.
+ * 이때, 새로운 객체의 키로는 `targetAttributes` 배열의 값들이 사용되고,
+ * 값으로는 `srcAttributes` 배열의 값들이 사용됩니다.
+ * 생성된 객체들은 최종 결과 배열에 추가됩니다.
  *
- * 이 함수는 `targetArr`를 반복하고 각 요소에 대해 새 객체를 생성합니다.
- *  결과 객체는 새 배열로 수집되어 반환됩니다.
- *
- * @param targetArr - 속성을 추출할 원본 배열입니다.
- * @param attributes - `targetArr`의 각 객체에서 선택할 속성입니다.
- *   이 매개변수는 문자열(속성 이름) 또는 문자열 배열이 될 수 있습니다.
- *   `attributes`가 배열인 경우, 이 배열에 속한 모든 속성을 포함합니다.
- *   `attributes`가 문자열인 경우, 주어진 이름의 속성 하나를 선택합니다.
- * @returns `targetArr`의 각 객체에서 지정된 속성만 포함하는 객체의 배열을 반환합니다.
+ * @param {any[]} targetArr - 속성을 추출할 소스 배열입니다.
+ * @param {(string|string[])} targetAttributes - 결과 객체의 키로 사용할 속성 이름입니다.
+ * 단일 문자열 또는 속성 이름의 배열을 받을 수 있습니다.
+ * @param {(string|string[])} srcAttributes - 소스 배열의 각 요소에서 속성을 추출할 속성 이름입니다.
+ * 단일 문자열 또는 속성 이름의 배열을 받을 수 있습니다.
+ * @returns {any[]} 결과 객체들의 배열입니다.
  *
  * @example
- * const targetArray = [
- *   { id: 1, name: 'Alice', age: 30 },
- *   { id: 2, name: 'Bob', age: 25 }
+ * const data = [
+ *     { id: 1, name: 'Alice', age: 30 },
+ *     { id: 2, name: 'Bob', age: 25 }
  * ];
- * const attributes = ['id', 'name'];
- * const result = makeSubObjectsArray(targetArray, attributes);
+ * const targetAttrs = ['name'];
+ * const srcAttrs = ['age'];
+ * const result = makeSubObjectsArray(data, targetAttrs, srcAttrs);
  * console.log(result);
- * // 출력: [{ id: 1, name: 'Alice' }, { id: 2, name: 'Bob' }]
+ * // 출력:
+ * // [
+ * //     { name: 30 },
+ * //     { name: 25 }
+ * // ]
  */
-export function makeSubObjectsArray(targetArr: any[], attributes: string | string[]): any[] {
+export function makeSubObjectsArray(
+    targetArr: any[],
+    targetAttributes: string | string[],
+    srcAttributes: string | string[]
+): any[] {
     const resArr: any[] = [];
-    if (Array.isArray(attributes)) {
+    if (Array.isArray(srcAttributes)) {
         targetArr.map((cur) => {
             {
                 const obj: { [key: string]: any } = {};
-                for (let i = 0; i < attributes.length; i++) {
-                    obj[`${attributes[i]}`] = cur[`${attributes[i]}`];
+                for (let i = 0; i < srcAttributes.length; i++) {
+                    obj[`${targetAttributes[i]}`] = cur[`${srcAttributes[i]}`];
                 }
                 resArr.push(obj);
             }
@@ -57,7 +66,7 @@ export function makeSubObjectsArray(targetArr: any[], attributes: string | strin
     } else {
         targetArr.map((cur) => {
             const obj: { [key: string]: any } = {};
-            obj[`${attributes}`] = cur[`${attributes}`];
+            obj[`${targetAttributes}`] = cur[`${srcAttributes}`];
             resArr.push(obj);
         });
     }


### PR DESCRIPTION
## 작업 내용 (Content)
산책 목록 API를 구현했습니다.

- makeSubObjectArray 함수의 Attributes 인자를 targetAttributes, srcAttributes로 분리했습니다.
만들 대상이 되는 배열과, 재료(?)배열의 속성명이 다를 수 있어 바꾸었습니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
