### PR TITLE
backend/DANG-733: Journals 엔티티에 routeImageUrl -> routes로 변경, 산책일지 생성시 routes 경로 저장

### DIFF
--- a/backend/src/journals/dto/journals-create.dto.ts
+++ b/backend/src/journals/dto/journals-create.dto.ts
@@ -46,9 +46,10 @@ export class JournalInfoForCreate {
     @IsNotEmpty()
     duration: number;
 
-    @IsNotEmpty()
-    @IsString()
-    routeImageUrl: string;
+    @IsArray()
+    @ValidateNested()
+    @Type(() => Location)
+    routes: Location[];
 
     @IsOptional()
     memo: string;
@@ -58,7 +59,7 @@ export class JournalInfoForCreate {
     photoUrls: string[];
 
     static getKeysForJournalTable() {
-        return ['distance', 'calories', 'startedAt', 'duration', 'routeImageUrl', 'memo'];
+        return ['distance', 'calories', 'startedAt', 'duration', 'routes', 'memo'];
     }
     static getKeysForJournalPhotoTable() {
         return ['photoUrls'];

--- a/backend/src/journals/journals.entity.ts
+++ b/backend/src/journals/journals.entity.ts
@@ -28,9 +28,6 @@ export class Journals {
     @Column({ type: 'mediumtext' })
     routes: string;
 
-    @Column({ name: 'route_image_url' })
-    routeImageUrl: string;
-
     @Column({ nullable: true })
     memo: string;
 

--- a/backend/src/journals/journals.entity.ts
+++ b/backend/src/journals/journals.entity.ts
@@ -25,6 +25,9 @@ export class Journals {
     @Column()
     duration: number;
 
+    @Column({ type: 'mediumtext' })
+    routes: string;
+
     @Column({ name: 'route_image_url' })
     routeImageUrl: string;
 

--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -212,6 +212,7 @@ export class JournalsService {
             JournalInfoForCreate.getKeysForJournalTable()
         );
         journalData.userId = userId;
+        journalData.routes = JSON.stringify(journalData.routes);
 
         return journalData;
     }
@@ -228,7 +229,6 @@ export class JournalsService {
     async createJournal(userId: number, createJournalData: CreateJournalDto) {
         const dogs = createJournalData.dogs;
         const journalData = this.makeJournalData(userId, createJournalData);
-
         const createJournalResult = await this.createNewJournal(userId, journalData);
         await this.createNewJournalDogs(createJournalResult.id, dogs);
 

--- a/backend/src/journals/types/journal-types.ts
+++ b/backend/src/journals/types/journal-types.ts
@@ -5,6 +5,6 @@ export interface CreateJournalData {
     calories: number;
     startedAt: Date;
     duration: number;
-    routeImageUrl: string;
+    routes: string;
     memo?: string;
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- Journals 엔티티  routeImageUrl -> routes로 변경했습니다
- 산책일지 생성시 이미지 url 대신 routes 경로 데이터를 저장하도록 변경했습니다

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
