### PR TITLE
backend/DANG-728: 회원 정보 조회 API 구현

### DIFF
--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -74,7 +74,12 @@ describe('AuthService', () => {
 
         for (const oauthService of oauthServiceList) {
             jest.spyOn(oauthService, 'requestToken').mockResolvedValue(mockTokenResponse);
-            jest.spyOn(oauthService, 'requestUserId').mockResolvedValue(mockUser.oauthId);
+            jest.spyOn(oauthService, 'requestUserInfo').mockResolvedValue({
+                oauthId: mockUser.oauthId,
+                oauthNickname: 'test',
+                email: 'test@mail.com',
+                profileImage: 'test.jpg',
+            });
             jest.spyOn(oauthService, 'requestTokenExpiration').mockResolvedValue();
             jest.spyOn(oauthService, 'requestTokenRefresh').mockResolvedValue(mockTokenResponse);
         }
@@ -116,7 +121,6 @@ describe('AuthService', () => {
                     expect(result).toEqual({
                         oauthAccessToken: mockUser.oauthAccessToken,
                         oauthRefreshToken: mockUser.oauthRefreshToken,
-                        oauthId: mockUser.oauthId,
                         provider,
                     });
                 });

--- a/backend/src/auth/guards/oauthData.guard.ts
+++ b/backend/src/auth/guards/oauthData.guard.ts
@@ -8,14 +8,12 @@ export class OauthDataGuard implements CanActivate {
         const request = context.switchToHttp().getRequest();
         const oauthAccessToken = request.cookies['oauthAccessToken'];
         const oauthRefreshToken = request.cookies['oauthRefreshToken'];
-        const oauthId = request.cookies['oauthId'];
         const provider = request.cookies['provider'];
 
-        if (!oauthAccessToken || !oauthRefreshToken || !oauthId || !provider) {
+        if (!oauthAccessToken || !oauthRefreshToken || !provider) {
             const missingFields = [
                 !oauthAccessToken && 'oauthAccessToken',
                 !oauthRefreshToken && 'oauthRefreshToken',
-                !oauthId && 'oauthId',
                 !provider && 'provider',
             ]
                 .filter(Boolean)
@@ -25,7 +23,7 @@ export class OauthDataGuard implements CanActivate {
             this.logger.error(`OAuthDataGuard failed: missing ${missingFields}.`, error.stack ?? 'No stack');
             throw error;
         }
-        request.oauthData = { oauthAccessToken, oauthRefreshToken, oauthId, provider };
+        request.oauthData = { oauthAccessToken, oauthRefreshToken, provider };
 
         return true;
     }

--- a/backend/src/auth/interceptors/cookie.interceptor.ts
+++ b/backend/src/auth/interceptors/cookie.interceptor.ts
@@ -40,12 +40,7 @@ export class CookieInterceptor implements NestInterceptor {
                     this.setAuthCookies(response, data);
                     this.clearOauthCookies(response);
                     return { accessToken: data.accessToken };
-                } else if (
-                    'oauthAccessToken' in data &&
-                    'oauthRefreshToken' in data &&
-                    'oauthId' in data &&
-                    'provider' in data
-                ) {
+                } else if ('oauthAccessToken' in data && 'oauthRefreshToken' in data && 'provider' in data) {
                     this.setOauthCookies(response, data);
 
                     const error = new NotFoundException('No matching user found. Please sign up for an account.');
@@ -60,13 +55,9 @@ export class CookieInterceptor implements NestInterceptor {
         response.cookie('refreshToken', refreshToken, this.refreshCookieOptions);
     }
 
-    private setOauthCookies(
-        response: Response,
-        { oauthAccessToken, oauthRefreshToken, oauthId, provider }: OauthData
-    ): void {
+    private setOauthCookies(response: Response, { oauthAccessToken, oauthRefreshToken, provider }: OauthData): void {
         response.cookie('oauthAccessToken', oauthAccessToken, this.sessionCookieOptions);
         response.cookie('oauthRefreshToken', oauthRefreshToken, this.sessionCookieOptions);
-        response.cookie('oauthId', oauthId, this.sessionCookieOptions);
         response.cookie('provider', provider, this.sessionCookieOptions);
     }
 
@@ -77,7 +68,6 @@ export class CookieInterceptor implements NestInterceptor {
     private clearOauthCookies(response: Response): void {
         response.clearCookie('oauthAccessToken', this.sessionCookieOptions);
         response.clearCookie('oauthRefreshToken', this.sessionCookieOptions);
-        response.clearCookie('oauthId', this.sessionCookieOptions);
         response.clearCookie('provider', this.sessionCookieOptions);
     }
 }

--- a/backend/src/auth/oauth/oauth.service.interface.ts
+++ b/backend/src/auth/oauth/oauth.service.interface.ts
@@ -1,21 +1,28 @@
-interface RequestToken {
+export interface RequestToken {
     access_token: string;
     refresh_token: string;
     [key: string]: any;
 }
 
-export interface RequestTokenRefreshResponse extends Omit<RequestToken, 'refresh_token'> {
+export interface RequestTokenRefresh extends Omit<RequestToken, 'refresh_token'> {
     refresh_token?: string;
+}
+
+export interface RequestUserInfo {
+    oauthId: string;
+    oauthNickname: string;
+    email: string;
+    profileImage: string;
 }
 
 export interface OauthService {
     requestToken(authorizeCode: string, redirectURI?: string): Promise<RequestToken>;
 
-    requestUserId(accessToken: string): Promise<string>;
+    requestUserInfo(accessToken: string): Promise<RequestUserInfo>;
 
     requestTokenExpiration(accessToken: string): Promise<void>;
 
     requestUnlink?(accessToken: string): Promise<void>;
 
-    requestTokenRefresh(refreshToken: string): Promise<RequestTokenRefreshResponse>;
+    requestTokenRefresh(refreshToken: string): Promise<RequestTokenRefresh>;
 }

--- a/backend/src/users/dto/createUser.dto.ts
+++ b/backend/src/users/dto/createUser.dto.ts
@@ -1,0 +1,24 @@
+import { IsString } from 'class-validator';
+
+export class CreateUserDto {
+    @IsString()
+    oauthNickname: string;
+
+    @IsString()
+    email: string;
+
+    @IsString()
+    profileImage: string;
+
+    @IsString()
+    oauthId: string;
+
+    @IsString()
+    oauthAccessToken: string;
+
+    @IsString()
+    oauthRefreshToken: string;
+
+    @IsString()
+    refreshToken: string;
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get } from '@nestjs/common';
+import { AccessTokenPayload } from 'src/auth/token/token.service';
+import { User } from '../users/decorators/user.decorator';
+import { UsersService } from './users.service';
+
+@Controller('users')
+export class UsersController {
+    constructor(private readonly usersService: UsersService) {}
+
+    @Get('me')
+    async getUserProfile(@User() user: AccessTokenPayload) {
+        return await this.usersService.getUserProfile(user);
+    }
+}

--- a/backend/src/users/users.entity.ts
+++ b/backend/src/users/users.entity.ts
@@ -10,6 +10,12 @@ export class Users {
     @Column({ unique: true })
     nickname: string;
 
+    @Column()
+    email: string;
+
+    @Column({ name: 'profile_image' })
+    profileImage: string;
+
     @Column({
         type: 'enum',
         enum: Role,

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -2,12 +2,14 @@ import { Module } from '@nestjs/common';
 import { DatabaseModule } from '../common/database/database.module';
 import { UsersDogs } from '../users-dogs/users-dogs.entity';
 import { UsersDogsModule } from '../users-dogs/users-dogs.module';
+import { UsersController } from './users.controller';
 import { Users } from './users.entity';
 import { UsersRepository } from './users.repository';
 import { UsersService } from './users.service';
 
 @Module({
     imports: [DatabaseModule.forFeature([Users, UsersDogs]), UsersDogsModule],
+    controllers: [UsersController],
     providers: [UsersService, UsersRepository],
     exports: [UsersService, UsersDogsModule],
 })

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@nestjs/common';
+import { OauthProvider } from 'src/auth/auth.controller';
+import { AccessTokenPayload } from 'src/auth/token/token.service';
 import { FindOptionsWhere } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { UsersDogsService } from '../users-dogs/users-dogs.service';
@@ -9,6 +11,13 @@ import { CreateUser } from './types/user-types';
 import { Role } from './user-roles.enum';
 import { Users } from './users.entity';
 import { UsersRepository } from './users.repository';
+
+export interface UserProfile {
+    nickname: string;
+    email: string;
+    profileImage: string;
+    provider: OauthProvider;
+}
 
 @Injectable()
 export class UsersService {
@@ -79,5 +88,10 @@ export class UsersService {
 
         const result = checkIfExistsInArr(myDogIds, dogId);
         return result;
+    }
+
+    async getUserProfile({ userId, provider }: AccessTokenPayload): Promise<UserProfile> {
+        const { nickname, email, profileImage } = await this.usersRepository.findOne({ id: userId });
+        return { nickname, email, profileImage, provider };
     }
 }

--- a/frontend/src/utils/oauth.ts
+++ b/frontend/src/utils/oauth.ts
@@ -9,7 +9,7 @@ const getAuthorizeCodeCallbackUrl = (provider: string) => {
     let url = '';
     switch (provider) {
         case 'google':
-            url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${BASE_URL}/callback&response_type=code&access_type=offline&scope=https://www.googleapis.com/auth/userinfo.email&prompt=select_account`;
+            url = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${BASE_URL}/callback&response_type=code&access_type=offline&scope=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile&prompt=select_account`;
             break;
         case 'kakao':
             url = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${KAKAO_CLIENT_ID}&redirect_uri=${BASE_URL}/callback&prompt=select_account`;


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- Users table에 email, profileImage column 추가
- 회원가입 시 다시 oauthAccesToken으로 userInfo를 요청하기 때문에 oauthId를 cookie에 저장할 필요가 없어서 삭제
- google 인가 코드 요청 url에 userinfo.profile scope 추가

## 링크 (Links)
https://www.notion.so/do0ori/API-d824f5bb23b14f0e94d6a8417fd02efe

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
