### PR TITLE
backend/DANG-744: 회원 정보 수정 API 구현

### DIFF
--- a/backend/src/dogs/dogs.module.ts
+++ b/backend/src/dogs/dogs.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { JournalsDogsModule } from 'src/journals-dogs/journals-dogs.module';
-import { S3Module } from 'src/s3/s3.module';
 import { Breed } from '../breed/breed.entity';
 import { BreedModule } from '../breed/breed.module';
 import { DatabaseModule } from '../common/database/database.module';
@@ -22,18 +21,9 @@ import { DogsService } from './dogs.service';
         DailyWalkTimeModule,
         DogWalkDayModule,
         JournalsDogsModule,
-        S3Module,
     ],
     controllers: [DogsController],
     providers: [DogsService, DogsRepository],
-    exports: [
-        DogsService,
-        UsersModule,
-        JournalsDogsModule,
-        BreedModule,
-        DailyWalkTimeModule,
-        DogWalkDayModule,
-        S3Module,
-    ],
+    exports: [DogsService, UsersModule, JournalsDogsModule, BreedModule, DailyWalkTimeModule, DogWalkDayModule],
 })
 export class DogsModule {}

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -86,7 +86,7 @@ export class DogsService {
         if (profilePhotoUrl) {
             const curDogInfo = await this.findOne({ id: dogId });
             if (curDogInfo && curDogInfo.profilePhotoUrl) {
-                this.s3Service.deleteSingleObject(userId, curDogInfo.profilePhotoUrl);
+                await this.s3Service.deleteSingleObject(userId, curDogInfo.profilePhotoUrl);
             }
         }
         const updateData = breedName ? { breed, profilePhotoUrl, ...otherAttributes } : otherAttributes;

--- a/backend/src/users/dto/updateUser.dto.ts
+++ b/backend/src/users/dto/updateUser.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UpdateUserDto {
+    @IsString()
+    @IsOptional()
+    nickname: string;
+
+    @IsString()
+    @IsOptional()
+    profileImage: string;
+}

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get } from '@nestjs/common';
+import { Body, Controller, Get, Patch } from '@nestjs/common';
 import { AccessTokenPayload } from 'src/auth/token/token.service';
 import { User } from '../users/decorators/user.decorator';
+import { UpdateUserDto } from './dto/updateUser.dto';
 import { UsersService } from './users.service';
 
 @Controller('users')
@@ -10,5 +11,10 @@ export class UsersController {
     @Get('me')
     async getUserProfile(@User() user: AccessTokenPayload) {
         return await this.usersService.getUserProfile(user);
+    }
+
+    @Patch('me')
+    async updateUserProfile(@User() { userId }: AccessTokenPayload, @Body() userInfo: UpdateUserDto) {
+        return await this.usersService.updateUserProfile(userId, userInfo);
     }
 }

--- a/backend/src/users/users.module.ts
+++ b/backend/src/users/users.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { S3Module } from 'src/s3/s3.module';
 import { DatabaseModule } from '../common/database/database.module';
 import { UsersDogs } from '../users-dogs/users-dogs.entity';
 import { UsersDogsModule } from '../users-dogs/users-dogs.module';
@@ -8,9 +9,9 @@ import { UsersRepository } from './users.repository';
 import { UsersService } from './users.service';
 
 @Module({
-    imports: [DatabaseModule.forFeature([Users, UsersDogs]), UsersDogsModule],
+    imports: [DatabaseModule.forFeature([Users, UsersDogs]), UsersDogsModule, S3Module],
     controllers: [UsersController],
     providers: [UsersService, UsersRepository],
-    exports: [UsersService, UsersDogsModule],
+    exports: [UsersService, UsersDogsModule, S3Module],
 })
 export class UsersModule {}

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -1,6 +1,7 @@
 import { ConflictException, NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
+import { S3Service } from 'src/s3/s3.service';
 import { EntityManager, Repository, UpdateResult } from 'typeorm';
 import { WinstonLoggerService } from '../common/logger/winstonLogger.service';
 import { mockUser } from '../fixtures/users.fixture';
@@ -27,6 +28,10 @@ describe('UsersService', () => {
                 UsersDogsService,
                 UsersDogsRepository,
                 EntityManager,
+                {
+                    provide: S3Service,
+                    useValue: { deleteSingleObject: jest.fn() },
+                },
                 {
                     provide: getRepositoryToken(Users),
                     useClass: Repository,
@@ -132,12 +137,15 @@ describe('UsersService', () => {
 
             it('ConflictException 예외를 던져야 한다.', async () => {
                 await expect(
-                    service.createIfNotExists(
-                        mockUser.oauthId,
-                        mockUser.oauthAccessToken,
-                        mockUser.oauthRefreshToken,
-                        mockUser.refreshToken
-                    )
+                    service.createIfNotExists({
+                        oauthNickname: 'modifyTest',
+                        email: 'test@mail.com',
+                        profileImage: 'test.jpg',
+                        oauthId: mockUser.oauthId,
+                        oauthAccessToken: mockUser.oauthAccessToken,
+                        oauthRefreshToken: mockUser.oauthRefreshToken,
+                        refreshToken: mockUser.refreshToken,
+                    })
                 ).rejects.toThrow(ConflictException);
             });
         });

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -7,6 +7,7 @@ import { UsersDogsService } from '../users-dogs/users-dogs.service';
 import { generateUuid } from '../utils/hash.utils';
 import { checkIfExistsInArr } from '../utils/manipulate.util';
 import { CreateUserDto } from './dto/createUser.dto';
+import { UpdateUserDto } from './dto/updateUser.dto';
 import { CreateUser } from './types/user-types';
 import { Role } from './user-roles.enum';
 import { Users } from './users.entity';
@@ -93,5 +94,13 @@ export class UsersService {
     async getUserProfile({ userId, provider }: AccessTokenPayload): Promise<UserProfile> {
         const { nickname, email, profileImage } = await this.usersRepository.findOne({ id: userId });
         return { nickname, email, profileImage, provider };
+    }
+
+    async updateUserProfile(userId: number, userInfo: UpdateUserDto) {
+        if ('nickname' in userInfo) {
+            const nickname = await this.generateUniqueNickname(userInfo.nickname);
+            userInfo.nickname = nickname;
+        }
+        await this.usersRepository.update({ id: userId }, userInfo);
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 회원 정보 수정 API는 nickname과 profileImage를 받음 (nickname은 # 앞부분에 해당하는 문자열)
- profileImage update 시 기존 profileImage는 S3에서 삭제

## 링크 (Links)
https://www.notion.so/do0ori/API-6861b6db6be94df091a9f178818c2cf0

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
