### PR TITLE
backend/DANG-719: 회원탈퇴시 S3에서 해당 유저의 데이터(폴더) 삭제

### DIFF
--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -5,6 +5,7 @@ import { JwtService } from '@nestjs/jwt';
 import { Test, TestingModule } from '@nestjs/testing';
 import { WinstonLoggerService } from 'src/common/logger/winstonLogger.service';
 import { DogsService } from 'src/dogs/dogs.service';
+import { S3Service } from 'src/s3/s3.service';
 import { mockUser } from '../fixtures/users.fixture';
 import { Users } from '../users/users.entity';
 import { UsersRepository } from '../users/users.repository';
@@ -32,6 +33,10 @@ describe('AuthService', () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 AuthService,
+                {
+                    provide: S3Service,
+                    useValue: { deleteObjectFolder: jest.fn() },
+                },
                 {
                     provide: UsersService,
                     useValue: { updateAndFindOne: jest.fn(), createIfNotExists: jest.fn(), findOne: jest.fn() },

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -2,6 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { WinstonLoggerService } from 'src/common/logger/winstonLogger.service';
 import { DogsService } from 'src/dogs/dogs.service';
+import { S3Service } from 'src/s3/s3.service';
 import { Transactional } from 'typeorm-transactional';
 import { Users } from '../users/users.entity';
 import { UsersService } from '../users/users.service';
@@ -32,6 +33,7 @@ export class AuthService {
         private readonly kakaoService: KakaoService,
         private readonly naverService: NaverService,
         private readonly configService: ConfigService,
+        private readonly s3Service: S3Service,
         private readonly logger: WinstonLoggerService
     ) {}
 
@@ -136,6 +138,7 @@ export class AuthService {
         });
 
         await this.usersService.delete({ id: userId });
+        await this.s3Service.deleteObjectFolder(userId);
     }
 
     async validateAccessToken(userId: number): Promise<boolean> {

--- a/backend/src/s3/s3.service.ts
+++ b/backend/src/s3/s3.service.ts
@@ -85,4 +85,20 @@ export class S3Service {
             this.logger.error(`Can't delete ${filename} from S3 bucket ${BUCKET_NAME}`, error ?? error.stack);
         }
     }
+
+    async deleteObjectFolder(userId: number) {
+        const filename = `${userId.toString()}/`;
+
+        const command = new DeleteObjectCommand({
+            Bucket: BUCKET_NAME,
+            Key: filename,
+        });
+
+        try {
+            await this.s3Client.send(command);
+            this.logger.log(`Successfuly deleted ${filename}`);
+        } catch (error) {
+            this.logger.error(`Can't delete ${filename} from S3 bucket ${BUCKET_NAME}`, error ?? error.stack);
+        }
+    }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
회원탈퇴 시 S3에서 회원의 폴더를 삭제하도록 추가

## 링크 (Links)
https://www.notion.so/do0ori/S3-6b447b03ca9540c69ba1216aa0ad6094

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
