### PR TITLE
backend/DANG-759: excrements 엔티티 primary 컬럼 추가하고 컴포지트 키 삭제

### DIFF
--- a/backend/src/excrements/excrements.entity.ts
+++ b/backend/src/excrements/excrements.entity.ts
@@ -1,21 +1,22 @@
-import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
 import { Dogs } from '../dogs/dogs.entity';
 import { Journals } from '../journals/journals.entity';
 import { ExcrementsType } from './types/excrements.enum';
 
 @Entity('excrements')
 export class Excrements {
-    @PrimaryColumn({ name: 'journal_id' })
+    @PrimaryGeneratedColumn()
+    id: number;
+
     @ManyToOne(() => Journals, (WalkJournals) => WalkJournals.id, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'journal_id' })
     journalId: number;
 
-    @PrimaryColumn({ name: 'dog_id' })
     @ManyToOne(() => Dogs, (dog) => dog.id, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'dog_id' })
     dogId: number;
 
-    @PrimaryColumn({ name: 'type', type: 'enum', enum: ExcrementsType })
+    @Column({ name: 'type', type: 'enum', enum: ExcrementsType })
     type: ExcrementsType;
 
     @Column({ type: 'point', spatialFeatureType: 'Point', srid: 4326 })


### PR DESCRIPTION
## 작업 내용 (Content)
excrement는 한 산책일지, 같은 강아지, 같은 타입 내에서도 중복될 수 있어
컴포지트 키를 삭제하고 pk를 추가했습니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
