### PR TITLE
backend/DANG-765: 간헐적인 DataSource with name 'default' has already added. 에러 해결하기

### DIFF
--- a/backend/src/common/database/database.module.ts
+++ b/backend/src/common/database/database.module.ts
@@ -5,7 +5,7 @@ import { EntityClassOrSchema } from '@nestjs/typeorm/dist/interfaces/entity-clas
 import { color } from 'src/utils/ansi.utils';
 import { DataSource } from 'typeorm';
 import { runSeeders } from 'typeorm-extension';
-import { addTransactionalDataSource } from 'typeorm-transactional';
+import { addTransactionalDataSource, getDataSourceByName } from 'typeorm-transactional';
 import { WinstonLoggerService } from '../logger/winstonLogger.service';
 import BreedSeeder from './seeds/breed.seeder';
 
@@ -31,7 +31,7 @@ import BreedSeeder from './seeds/breed.seeder';
                     throw new Error('Invalid options passed');
                 }
 
-                return addTransactionalDataSource(new DataSource(options));
+                return getDataSourceByName('default') || addTransactionalDataSource(new DataSource(options));
             },
         }),
     ],

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -109,7 +109,6 @@ export class DogsService {
     }
 
     private makeProfile(dogInfo: Dogs): DogProfile {
-        console.log(dogInfo.updatedAt);
         return {
             id: dogInfo.id,
             name: dogInfo.name,


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- DataSource with name 'default' has already added 에러 방지 코드 추가
- DatabaseModule에서 이름이 'default'인 DataSource를 가져오거나 없으면 새로 생성하도록 함

## 링크 (Links)
https://www.notion.so/do0ori/DataSource-with-name-default-has-already-added-d395e4d352c74dd1b6785bbed17d16dc

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
