### PR TITLE
frontend/DANG-764: 산책일지 저장 페이지에서 타입과 변수 이름 변경

### DIFF
--- a/frontend/src/components/journals/DogImages.tsx
+++ b/frontend/src/components/journals/DogImages.tsx
@@ -1,4 +1,4 @@
-import { ImageUrl } from '@/pages/Journals/CreateForm';
+import { ImageFileName } from '@/pages/Journals/CreateForm';
 import { makeFileUrl } from '@/utils/url';
 import { ReactNode } from 'react';
 
@@ -20,6 +20,6 @@ export default function DogImages({ imageUrls, children }: Props) {
 }
 
 interface Props {
-    imageUrls: Array<ImageUrl>;
+    imageUrls: Array<ImageFileName>;
     children: ReactNode;
 }

--- a/frontend/src/components/journals/DogImages.tsx
+++ b/frontend/src/components/journals/DogImages.tsx
@@ -2,10 +2,10 @@ import { ImageFileName } from '@/pages/Journals/CreateForm';
 import { makeFileUrl } from '@/utils/url';
 import { ReactNode } from 'react';
 
-export default function DogImages({ imageUrls, children }: Props) {
+export default function DogImages({ imageFileNames, children }: Props) {
     return (
         <div className="flex flex-row gap-1 py-2 overflow-x-auto">
-            {imageUrls.map((imageUrl) => (
+            {imageFileNames.map((imageUrl) => (
                 <span key={imageUrl} className="inline-flex items-center h-[104px]">
                     <img
                         src={makeFileUrl(imageUrl)}
@@ -20,6 +20,6 @@ export default function DogImages({ imageUrls, children }: Props) {
 }
 
 interface Props {
-    imageUrls: Array<ImageFileName>;
+    imageFileNames: Array<ImageFileName>;
     children: ReactNode;
 }

--- a/frontend/src/components/journals/DogImages.tsx
+++ b/frontend/src/components/journals/DogImages.tsx
@@ -19,7 +19,7 @@ export default function DogImages({ imageFileNames, children }: Props) {
     );
 }
 
-interface Props {
+export interface Props {
     imageFileNames: Array<ImageFileName>;
     children: ReactNode;
 }

--- a/frontend/src/components/journals/Photos.tsx
+++ b/frontend/src/components/journals/Photos.tsx
@@ -6,7 +6,7 @@ export default function Photos({ imageUrls, isLoading, onChange }: Props) {
     return (
         <div className="px-5 py-[10px]">
             <Heading headingNumber={2}>사진</Heading>
-            <DogImages imageUrls={imageUrls}>
+            <DogImages imageFileNames={imageUrls}>
                 <AddPhotoButton isLoading={isLoading} onChange={onChange} />
             </DogImages>
         </div>

--- a/frontend/src/components/journals/Photos.tsx
+++ b/frontend/src/components/journals/Photos.tsx
@@ -1,18 +1,16 @@
 import AddPhotoButton, { Props as AddPhotoButtonProps } from '@/components/journals/AddPhotoButton';
-import DogImages from '@/components/journals/DogImages';
+import DogImages, { Props as DogImagesProps } from '@/components/journals/DogImages';
 import Heading from '@/components/journals/Heading';
 
-export default function Photos({ imageUrls, isLoading, onChange }: Props) {
+export default function Photos({ imageFileNames, isLoading, onChange }: Props3) {
     return (
         <div className="px-5 py-[10px]">
             <Heading headingNumber={2}>사진</Heading>
-            <DogImages imageFileNames={imageUrls}>
+            <DogImages imageFileNames={imageFileNames}>
                 <AddPhotoButton isLoading={isLoading} onChange={onChange} />
             </DogImages>
         </div>
     );
 }
 
-interface Props extends AddPhotoButtonProps {
-    imageUrls: Array<string>;
-}
+interface Props3 extends AddPhotoButtonProps, Pick<DogImagesProps, 'imageFileNames'> {}

--- a/frontend/src/components/journals/Photos.tsx
+++ b/frontend/src/components/journals/Photos.tsx
@@ -2,7 +2,7 @@ import AddPhotoButton, { Props as AddPhotoButtonProps } from '@/components/journ
 import DogImages, { Props as DogImagesProps } from '@/components/journals/DogImages';
 import Heading from '@/components/journals/Heading';
 
-export default function Photos({ imageFileNames, isLoading, onChange }: Props3) {
+export default function Photos({ imageFileNames, isLoading, onChange }: Props) {
     return (
         <div className="px-5 py-[10px]">
             <Heading headingNumber={2}>사진</Heading>
@@ -13,4 +13,4 @@ export default function Photos({ imageFileNames, isLoading, onChange }: Props3) 
     );
 }
 
-interface Props3 extends AddPhotoButtonProps, Pick<DogImagesProps, 'imageFileNames'> {}
+interface Props extends AddPhotoButtonProps, Pick<DogImagesProps, 'imageFileNames'> {}

--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -36,7 +36,7 @@ export default function CreateForm() {
     const removeSpinner = useSpinnerStore((state) => state.spinnerRemove);
 
     const [openModal, setOpenModal] = useState(false);
-    const [images, setImages] = useState<Array<ImageFileName>>([]);
+    const [imageFileNames, setImageFileNames] = useState<Array<ImageFileName>>([]);
     const [isUploading, setIsUploading] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
 
@@ -53,7 +53,7 @@ export default function CreateForm() {
             dog.profilePhotoUrl = getFileName(dog.profilePhotoUrl);
         });
 
-        setImages(photoUrls);
+        setImageFileNames(photoUrls);
     }, [location]);
 
     return (
@@ -78,7 +78,7 @@ export default function CreateForm() {
                     <Divider />
                     <CompanionDogs dogs={dogs} />
                     <Divider />
-                    <Photos imageUrls={images} isLoading={isUploading} onChange={handleAddImages} />
+                    <Photos imageUrls={imageFileNames} isLoading={isUploading} onChange={handleAddImages} />
                     <Divider />
                     <Memo textAreaRef={textAreaRef} />
                 </div>
@@ -171,7 +171,7 @@ export default function CreateForm() {
         await Promise.allSettled(uploadImagePromises);
 
         const filenames = uploadUrlResponses.map((uploadUrlResponse) => uploadUrlResponse.filename);
-        setImages((prevImages) => [...prevImages, ...filenames]);
+        setImageFileNames((prevImageFileNames) => [...prevImageFileNames, ...filenames]);
         setIsUploading(false);
     }
 }

--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -44,7 +44,15 @@ export default function CreateForm() {
 
     const receivedState = location.state as ReceivedState;
 
-    const { dogs, distance, calories, duration, startedAt: serializedStartedAt, photoUrls, routes } = receivedState;
+    const {
+        dogs,
+        distance,
+        calories,
+        duration,
+        startedAt: serializedStartedAt,
+        photoUrls: photoFileNames,
+        routes,
+    } = receivedState;
     const startedAt = new Date(serializedStartedAt);
 
     useEffect(() => {
@@ -53,7 +61,7 @@ export default function CreateForm() {
             dog.profilePhotoUrl = getFileName(dog.profilePhotoUrl);
         });
 
-        setImageFileNames(photoUrls);
+        setImageFileNames(photoFileNames);
     }, [location]);
 
     return (
@@ -112,7 +120,7 @@ export default function CreateForm() {
             startedAt: startedAt.toJSON(),
             duration,
             routes,
-            photoUrls: photoUrls ?? [],
+            photoUrls: photoFileNames ?? [],
             memo: textAreaRef.current?.value ?? '',
         };
         const excrements = dogs.map((dog) => {

--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -86,7 +86,7 @@ export default function CreateForm() {
                     <Divider />
                     <CompanionDogs dogs={dogs} />
                     <Divider />
-                    <Photos imageUrls={imageFileNames} isLoading={isUploading} onChange={handleAddImages} />
+                    <Photos imageFileNames={imageFileNames} isLoading={isUploading} onChange={handleAddImages} />
                     <Divider />
                     <Memo textAreaRef={textAreaRef} />
                 </div>

--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -36,7 +36,7 @@ export default function CreateForm() {
     const removeSpinner = useSpinnerStore((state) => state.spinnerRemove);
 
     const [openModal, setOpenModal] = useState(false);
-    const [images, setImages] = useState<Array<ImageUrl>>([]);
+    const [images, setImages] = useState<Array<ImageFileName>>([]);
     const [isUploading, setIsUploading] = useState(false);
     const [isSaving, setIsSaving] = useState(false);
 
@@ -186,4 +186,4 @@ interface ReceivedState {
     photoUrls: string[];
 }
 
-export type ImageUrl = string;
+export type ImageFileName = string;


### PR DESCRIPTION
## 작업 내용 (Content)
산책일지 저장 페이지에서 타입과 변수 이름 변경
- 타입: `ImageUrl` → `ImageFileName`
- 상태: `images` → `imageFileNames`
- 변수: `photoUrls` → `photoFileNames`
- 프롭: `imageUrls` → `imageFileNames`

## 링크 (Links)
https://www.notion.so/do0ori/4bde9c26354740b3aed0a3a6474b6e05?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
