### PR TITLE
backend/DANG-729: 산책일지 상세 API 변경

### DIFF
--- a/backend/src/excrements/excrements.entity.ts
+++ b/backend/src/excrements/excrements.entity.ts
@@ -10,10 +10,16 @@ export class Excrements {
 
     @ManyToOne(() => Journals, (WalkJournals) => WalkJournals.id, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'journal_id' })
+    journal: Journals;
+
+    @Column({ name: 'journal_id' })
     journalId: number;
 
     @ManyToOne(() => Dogs, (dog) => dog.id, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'dog_id' })
+    dog: Dogs;
+
+    @Column({ name: 'dog_id' })
     dogId: number;
 
     @Column({ name: 'type', type: 'enum', enum: ExcrementsType })

--- a/backend/src/excrements/excrements.service.ts
+++ b/backend/src/excrements/excrements.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DeleteResult, FindOptionsWhere, UpdateResult } from 'typeorm';
+import { DeleteResult, FindManyOptions, FindOptionsWhere, UpdateResult } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { Excrements } from './excrements.entity';
 import { ExcrementsRepository } from './excrements.repository';
@@ -24,8 +24,8 @@ export class ExcrementsService {
         ]);
     }
 
-    async find(where: FindOptionsWhere<Excrements>): Promise<Excrements[]> {
-        return this.excrementsRepository.find({ where });
+    async find(where: FindManyOptions<Excrements>): Promise<Excrements[]> {
+        return this.excrementsRepository.find(where);
     }
 
     async findOne(where: FindOptionsWhere<Excrements>): Promise<Excrements> {

--- a/backend/src/journals-dogs/journals-dogs.service.ts
+++ b/backend/src/journals-dogs/journals-dogs.service.ts
@@ -25,6 +25,10 @@ export class JournalsDogsService {
         return this.journalsDogsRepository.find(where);
     }
 
+    async getDogIdsByJournalId(journalId: number): Promise<number[]> {
+        const findResult = await this.journalsDogsRepository.find({ where: { journalId } });
+        return findResult.map((cur) => cur.dogId);
+    }
     async getRecentJournalId(dogIds: number[]): Promise<(number | undefined)[]> {
         const result = dogIds.map(async (curDogId) => {
             const journal = await this.journalsDogsRepository.find({

--- a/backend/src/journals/dto/journals-detail.dto.ts
+++ b/backend/src/journals/dto/journals-detail.dto.ts
@@ -1,5 +1,6 @@
 import { Type } from 'class-transformer';
-import { IsNotEmpty, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { Excrements } from 'src/excrements/excrements.entity';
 
 export class PhotoUrlDto {
     @IsNotEmpty()
@@ -22,52 +23,29 @@ export class DogInfoForDetail {
     @IsOptional()
     profilePhotoUrl: string | null;
 
-    @IsNotEmpty()
-    fecesCnt: number;
-
-    @IsNotEmpty()
-    urinesCnt: number;
-
-    // TODO: reflect -metadata 사용하도록 변경
+    // TODO: reflect-metadata 사용하도록 변경
     static getKeysForDogTable() {
         return ['id', 'name', 'profilePhotoUrl'];
     }
 }
 
-export class Companions {
+export class ExcrementsInfoForDetail {
     @IsNotEmpty()
-    id: number;
+    dogId: number;
 
-    @IsNotEmpty()
-    name: string;
+    @IsOptional()
+    @IsNumber()
+    fecesCnt: number;
 
-    profilePhotoUrl: string | null;
-}
-
-export class RouteDto {
-    @IsNotEmpty()
-    x: number;
-
-    @IsNotEmpty()
-    y: number;
+    @IsOptional()
+    @IsNumber()
+    urineCnt: number;
 }
 
 export class JournalInfoForDetail {
     @IsNotEmpty()
-    distance: number;
-
-    @IsNotEmpty()
-    calories: number;
-
-    @IsNotEmpty()
-    startedAt: Date;
-
-    @IsNotEmpty()
-    duration: number;
-
-    @IsNotEmpty()
     @IsString()
-    routeImageUrl: string;
+    routes: Location[];
 
     @IsNotEmpty()
     memo: string;
@@ -77,7 +55,7 @@ export class JournalInfoForDetail {
     photoUrls: string[];
 
     static getKeysForJournalTable() {
-        return ['distance', 'calories', 'startedAt', 'duration', 'routeImageUrl', 'memo'];
+        return ['routes', 'memo'];
     }
     static getKeysForJournalPhotoTable() {
         return ['photoUrls'];
@@ -93,15 +71,16 @@ export class JournalDetailDto {
     @IsNotEmpty()
     @ValidateNested()
     @Type(() => DogInfoForDetail)
-    dog: DogInfoForDetail;
+    dogs: DogInfoForDetail[];
 
-    @IsNotEmpty()
-    @Type(() => Companions)
-    companions: Companions[];
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => Excrements)
+    excrements: ExcrementsInfoForDetail[];
 
-    constructor(journalInfo: JournalInfoForDetail, dogInfo: DogInfoForDetail, companions: Companions[]) {
+    constructor(journalInfo: JournalInfoForDetail, dogInfo: DogInfoForDetail[], excrements: ExcrementsInfoForDetail[]) {
         this.journalInfo = journalInfo;
-        this.dog = dogInfo;
-        this.companions = companions;
+        this.dogs = dogInfo;
+        excrements.length ? (this.excrements = excrements) : excrements;
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
산책일지 상세 API를 변경했습니다.

- excrements 관계형 컬럼과 이름이 같은 일반 컬럼을 추가했습니다. typeorm에서 find시 이렇게 해야 결과가 조회됩니다. 

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
