### PR TITLE
frontend/DANG-769: Memo 컴포넌트에 readonly 기능 구현

### DIFF
--- a/frontend/src/components/journals/Memo.tsx
+++ b/frontend/src/components/journals/Memo.tsx
@@ -1,7 +1,7 @@
 import Heading from '@/components/journals/Heading';
 import { RefObject } from 'react';
 
-export default function Memo({ textAreaRef }: Props) {
+export default function Memo({ textAreaRef, readonly = false }: Props) {
     return (
         <div className="px-5 py-[10px]">
             <Heading headingNumber={2}>메모</Heading>
@@ -9,6 +9,7 @@ export default function Memo({ textAreaRef }: Props) {
                 name="memo"
                 className="w-full h-[100px] my-2 px-4 py-3 rounded-lg border border-[#E4E4E4] text-xs placeholder:text-[#BABABA]"
                 placeholder="오늘 산책에 대해서 자유롭게 메모해보세요."
+                readOnly={readonly}
                 ref={textAreaRef}
             />
         </div>
@@ -17,4 +18,5 @@ export default function Memo({ textAreaRef }: Props) {
 
 interface Props {
     textAreaRef: RefObject<HTMLTextAreaElement>;
+    readonly?: boolean;
 }


### PR DESCRIPTION
## 작업 내용 (Content)
Memo 컴포넌트에 readonly 기능 구현

## 링크 (Links)
https://www.notion.so/do0ori/Memo-readonly-5a05006061ca47f7bc710a2a8905b5aa?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
