### PR TITLE
frontend/DANG-770: 산책일지 저장 페이지에서 사진 삭제 기능 구현

### DIFF
--- a/frontend/src/api/upload.ts
+++ b/frontend/src/api/upload.ts
@@ -1,4 +1,5 @@
 import { createClient, httpClient } from '@/api/http';
+import { ImageFileName } from '@/pages/Journals/CreateForm';
 
 interface UploadUrlResponse {
     url: string;
@@ -24,4 +25,8 @@ export const uploadImage = async (file: File, url: string | undefined): Promise<
     if (!url || !file) return;
     const { data } = await uploadClient.put(url, file, { headers: { 'Content-Type': file.type } });
     return data;
+};
+
+export const deleteImages = async (imageFileNames: Array<ImageFileName>) => {
+    await httpClient.delete('/api/delete', { data: imageFileNames });
 };

--- a/frontend/src/components/journals/DogImages.tsx
+++ b/frontend/src/components/journals/DogImages.tsx
@@ -11,7 +11,7 @@ export default function DogImages({ imageFileNames, children, isModifying = fals
                     <span className="relative">
                         <img
                             src={makeFileUrl(imageFileName)}
-                            alt="강아진 산책 사진"
+                            alt="강아지 산책 사진"
                             className="inline-block max-h-[104px] max-w-none rounded-lg"
                         />
                         {isModifying && (

--- a/frontend/src/components/journals/DogImages.tsx
+++ b/frontend/src/components/journals/DogImages.tsx
@@ -1,3 +1,4 @@
+import { ReactComponent as Delete } from '@/assets/icons/btn-delete.svg';
 import { ImageFileName } from '@/pages/Journals/CreateForm';
 import { makeFileUrl } from '@/utils/url';
 import { ReactNode } from 'react';
@@ -7,11 +8,16 @@ export default function DogImages({ imageFileNames, children }: Props) {
         <div className="flex flex-row gap-1 py-2 overflow-x-auto">
             {imageFileNames.map((imageUrl) => (
                 <span key={imageUrl} className="inline-flex items-center h-[104px]">
-                    <img
-                        src={makeFileUrl(imageUrl)}
-                        alt="강아진 산책 사진"
-                        className="inline-block max-h-[104px] max-w-none rounded-lg"
-                    />
+                    <span className="relative">
+                        <img
+                            src={makeFileUrl(imageUrl)}
+                            alt="강아진 산책 사진"
+                            className="inline-block max-h-[104px] max-w-none rounded-lg"
+                        />
+                        <button className="absolute right-1 top-1">
+                            <Delete />
+                        </button>
+                    </span>
                 </span>
             ))}
             {children}

--- a/frontend/src/components/journals/DogImages.tsx
+++ b/frontend/src/components/journals/DogImages.tsx
@@ -3,7 +3,7 @@ import { ImageFileName } from '@/pages/Journals/CreateForm';
 import { makeFileUrl } from '@/utils/url';
 import { ReactNode } from 'react';
 
-export default function DogImages({ imageFileNames, children }: Props) {
+export default function DogImages({ imageFileNames, children, isModifying = false }: Props) {
     return (
         <div className="flex flex-row gap-1 py-2 overflow-x-auto">
             {imageFileNames.map((imageUrl) => (
@@ -14,9 +14,11 @@ export default function DogImages({ imageFileNames, children }: Props) {
                             alt="강아진 산책 사진"
                             className="inline-block max-h-[104px] max-w-none rounded-lg"
                         />
-                        <button className="absolute right-1 top-1">
-                            <Delete />
-                        </button>
+                        {isModifying && (
+                            <button className="absolute right-1 top-1">
+                                <Delete />
+                            </button>
+                        )}
                     </span>
                 </span>
             ))}
@@ -28,4 +30,5 @@ export default function DogImages({ imageFileNames, children }: Props) {
 export interface Props {
     imageFileNames: Array<ImageFileName>;
     children: ReactNode;
+    isModifying?: boolean;
 }

--- a/frontend/src/components/journals/DogImages.tsx
+++ b/frontend/src/components/journals/DogImages.tsx
@@ -3,7 +3,7 @@ import { ImageFileName } from '@/pages/Journals/CreateForm';
 import { makeFileUrl } from '@/utils/url';
 import { ReactNode } from 'react';
 
-export default function DogImages({ imageFileNames, children, isModifying = false }: Props) {
+export default function DogImages({ imageFileNames, children, onDeleteImage, isModifying = false }: Props) {
     return (
         <div className="flex flex-row gap-1 py-2 overflow-x-auto">
             {imageFileNames.map((imageFileName) => (
@@ -15,7 +15,7 @@ export default function DogImages({ imageFileNames, children, isModifying = fals
                             className="inline-block max-h-[104px] max-w-none rounded-lg"
                         />
                         {isModifying && (
-                            <button className="absolute right-1 top-1">
+                            <button className="absolute right-1 top-1" onClick={() => onDeleteImage(imageFileName)}>
                                 <Delete />
                             </button>
                         )}
@@ -30,5 +30,6 @@ export default function DogImages({ imageFileNames, children, isModifying = fals
 export interface Props {
     imageFileNames: Array<ImageFileName>;
     children: ReactNode;
+    onDeleteImage: (imageFileName: ImageFileName) => Promise<void>;
     isModifying?: boolean;
 }

--- a/frontend/src/components/journals/DogImages.tsx
+++ b/frontend/src/components/journals/DogImages.tsx
@@ -6,11 +6,11 @@ import { ReactNode } from 'react';
 export default function DogImages({ imageFileNames, children, isModifying = false }: Props) {
     return (
         <div className="flex flex-row gap-1 py-2 overflow-x-auto">
-            {imageFileNames.map((imageUrl) => (
-                <span key={imageUrl} className="inline-flex items-center h-[104px]">
+            {imageFileNames.map((imageFileName) => (
+                <span key={imageFileName} className="inline-flex items-center h-[104px]">
                     <span className="relative">
                         <img
-                            src={makeFileUrl(imageUrl)}
+                            src={makeFileUrl(imageFileName)}
                             alt="강아진 산책 사진"
                             className="inline-block max-h-[104px] max-w-none rounded-lg"
                         />

--- a/frontend/src/components/journals/Photos.tsx
+++ b/frontend/src/components/journals/Photos.tsx
@@ -2,15 +2,15 @@ import AddPhotoButton, { Props as AddPhotoButtonProps } from '@/components/journ
 import DogImages, { Props as DogImagesProps } from '@/components/journals/DogImages';
 import Heading from '@/components/journals/Heading';
 
-export default function Photos({ imageFileNames, isLoading, onChange }: Props) {
+export default function Photos({ imageFileNames, isLoading, isModifying, onChange }: Props) {
     return (
         <div className="px-5 py-[10px]">
             <Heading headingNumber={2}>사진</Heading>
-            <DogImages imageFileNames={imageFileNames}>
+            <DogImages imageFileNames={imageFileNames} isModifying={isModifying}>
                 <AddPhotoButton isLoading={isLoading} onChange={onChange} />
             </DogImages>
         </div>
     );
 }
 
-interface Props extends AddPhotoButtonProps, Pick<DogImagesProps, 'imageFileNames'> {}
+interface Props extends AddPhotoButtonProps, Pick<DogImagesProps, 'imageFileNames' | 'isModifying'> {}

--- a/frontend/src/components/journals/Photos.tsx
+++ b/frontend/src/components/journals/Photos.tsx
@@ -2,15 +2,15 @@ import AddPhotoButton, { Props as AddPhotoButtonProps } from '@/components/journ
 import DogImages, { Props as DogImagesProps } from '@/components/journals/DogImages';
 import Heading from '@/components/journals/Heading';
 
-export default function Photos({ imageFileNames, isLoading, isModifying, onChange }: Props) {
+export default function Photos({ imageFileNames, isLoading, isModifying, onChange, onDeleteImage }: Props) {
     return (
         <div className="px-5 py-[10px]">
             <Heading headingNumber={2}>사진</Heading>
-            <DogImages imageFileNames={imageFileNames} isModifying={isModifying}>
+            <DogImages imageFileNames={imageFileNames} isModifying={isModifying} onDeleteImage={onDeleteImage}>
                 <AddPhotoButton isLoading={isLoading} onChange={onChange} />
             </DogImages>
         </div>
     );
 }
 
-interface Props extends AddPhotoButtonProps, Pick<DogImagesProps, 'imageFileNames' | 'isModifying'> {}
+interface Props extends AddPhotoButtonProps, Pick<DogImagesProps, 'imageFileNames' | 'isModifying' | 'onDeleteImage'> {}

--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -86,7 +86,12 @@ export default function CreateForm() {
                     <Divider />
                     <CompanionDogs dogs={dogs} />
                     <Divider />
-                    <Photos imageFileNames={imageFileNames} isLoading={isUploading} onChange={handleAddImages} />
+                    <Photos
+                        imageFileNames={imageFileNames}
+                        isLoading={isUploading}
+                        isModifying
+                        onChange={handleAddImages}
+                    />
                     <Divider />
                     <Memo textAreaRef={textAreaRef} />
                 </div>

--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -195,6 +195,7 @@ export default function CreateForm() {
         setImageFileNames((prevImageFileNames) =>
             prevImageFileNames.filter((prevImageFileName) => prevImageFileName !== imageFileName)
         );
+        showToast('사진이 삭제되었습니다.');
     }
 }
 

--- a/frontend/src/pages/Journals/CreateForm.tsx
+++ b/frontend/src/pages/Journals/CreateForm.tsx
@@ -1,5 +1,5 @@
 import { create as createJournal } from '@/api/journals';
-import { getUploadUrl, uploadImage } from '@/api/upload';
+import { deleteImages, getUploadUrl, uploadImage } from '@/api/upload';
 import Cancel from '@/assets/icons/ic-top-cancel.svg';
 import { Button } from '@/components/common/Button';
 import { Divider } from '@/components/common/Divider';
@@ -91,6 +91,7 @@ export default function CreateForm() {
                         isLoading={isUploading}
                         isModifying
                         onChange={handleAddImages}
+                        onDeleteImage={handleDeleteImage}
                     />
                     <Divider />
                     <Memo textAreaRef={textAreaRef} />
@@ -186,6 +187,14 @@ export default function CreateForm() {
         const filenames = uploadUrlResponses.map((uploadUrlResponse) => uploadUrlResponse.filename);
         setImageFileNames((prevImageFileNames) => [...prevImageFileNames, ...filenames]);
         setIsUploading(false);
+    }
+
+    async function handleDeleteImage(imageFileName: ImageFileName) {
+        await deleteImages([imageFileName]);
+
+        setImageFileNames((prevImageFileNames) =>
+            prevImageFileNames.filter((prevImageFileName) => prevImageFileName !== imageFileName)
+        );
     }
 }
 


### PR DESCRIPTION
## 작업 내용 (Content)
산책일지 저장 페이지에서 사진 삭제 기능 구현

## 링크 (Links)
https://www.notion.so/do0ori/0aedcf4d45d34bae89cf7c9762ebbd30?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
