### PR TITLE
backend/DANG-773: 강아지의 최근 한달 간 산책 통계 API 구현

### DIFF
--- a/backend/src/statistics/statistics.controller.ts
+++ b/backend/src/statistics/statistics.controller.ts
@@ -10,15 +10,25 @@ import { StatisticsService } from './statistics.service';
 export class StatisticsController {
     constructor(private readonly statisticsService: StatisticsService) {}
 
-    @Get('/:id(\\d+)/statistics')
+    @Get('/:id(\\d+)/statistics/recent')
     @UseGuards(AuthDogGuard)
     async getDogStatistics(
+        @User() { userId }: AccessTokenPayload,
+        @Param('id', ParseIntPipe) dogId: number,
+        @Query('period', PeriodValidationPipe) period: Period
+    ) {
+        return await this.statisticsService.getDogStatistics(userId, dogId, period);
+    }
+
+    @Get('/:id(\\d+)/statistics')
+    @UseGuards(AuthDogGuard)
+    async getDogWalkCnt(
         @User() { userId }: AccessTokenPayload,
         @Param('id', ParseIntPipe) dogId: number,
         @Query('date', DateValidationPipe) date: string,
         @Query('period', PeriodValidationPipe) period: Period
     ) {
-        return await this.statisticsService.getDogStatistics(userId, dogId, date, period);
+        return await this.statisticsService.getDogWalkCnt(userId, dogId, date, period);
     }
 
     @Get('/statistics')

--- a/backend/src/statistics/statistics.service.ts
+++ b/backend/src/statistics/statistics.service.ts
@@ -3,7 +3,7 @@ import { DogSummary } from 'src/dogs/dogs.controller';
 import { DogsService } from 'src/dogs/dogs.service';
 import { DogStatisticDto } from 'src/dogs/dto/dog-statistic.dto';
 import { JournalsService } from 'src/journals/journals.service';
-import { getStartAndEndOfMonth, getStartAndEndOfWeek } from 'src/utils/date.utils';
+import { getOneMonthAgo, getStartAndEndOfMonth, getStartAndEndOfWeek } from 'src/utils/date.utils';
 import { In } from 'typeorm';
 import { BreedService } from '../breed/breed.service';
 import { WinstonLoggerService } from '../common/logger/winstonLogger.service';
@@ -44,7 +44,18 @@ export class StatisticsService {
         return result;
     }
 
-    async getDogStatistics(userId: number, dogId: number, date: string, period: Period) {
+    async getDogStatistics(userId: number, dogId: number, period: Period) {
+        let startDate: Date, endDate: Date;
+        startDate = endDate = new Date();
+
+        if (period === 'month') {
+            startDate = getOneMonthAgo(new Date());
+        }
+
+        return this.journalsService.findJournalsAndGetTotal(userId, dogId, startDate, endDate);
+    }
+
+    async getDogWalkCnt(userId: number, dogId: number, date: string, period: Period) {
         let startDate: Date, endDate: Date;
         startDate = endDate = new Date();
 
@@ -54,7 +65,7 @@ export class StatisticsService {
             ({ startDate, endDate } = getStartAndEndOfWeek(new Date(date)));
         }
 
-        return this.journalsService.findJournalsAndAggregate(userId, dogId, startDate, endDate);
+        return this.journalsService.findJournalsAndAggregateByDay(userId, dogId, startDate, endDate);
     }
 
     async getDogsStatistics(userId: number): Promise<DogStatisticDto[]> {

--- a/backend/src/utils/date.utils.ts
+++ b/backend/src/utils/date.utils.ts
@@ -40,6 +40,12 @@ export function getStartAndEndOfDay(date: Date): { startDate: Date; endDate: Dat
     return { startDate, endDate };
 }
 
+export function getOneMonthAgo(date: Date): Date {
+    const oneMonthAgo = new Date(date);
+    oneMonthAgo.setMonth(date.getMonth() - 1);
+    return oneMonthAgo;
+}
+
 export function formatDate(date: Date): string {
     const year = date.getFullYear();
     const month = String(date.getMonth() + 1).padStart(2, '0');


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- 한달 전 날짜를 구하는 util 함수 추가
- 한달의 기준은 단순히 (월 - 1)
  ex. 2024-05-21 → 2024-04-21
- [강아지의 최근 한달 간 산책 통계 API ](https://www.notion.so/do0ori/71574bd772e64614923ba0a2087f24b4)구현

## 링크 (Links)
https://www.notion.so/do0ori/API-330def6b74d346519fd27961047eb41c

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
