### PR TITLE
backend/DANG-781: Auth에 Validation 추가

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -11,20 +11,15 @@ import {
     ValidationPipe,
 } from '@nestjs/common';
 import { User } from '../users/decorators/user.decorator';
-import { AuthService, OauthData } from './auth.service';
+import { AuthService } from './auth.service';
 import { OauthCookies } from './decorators/oauth-data.decorator';
 import { SkipAuthGuard } from './decorators/public.decorator';
+import { OAuthAuthorizeDTO } from './dtos/oauth.dto';
 import { OauthDataGuard } from './guards/oauth-data.guard';
 import { RefreshTokenGuard } from './guards/refresh-token.guard';
 import { CookieInterceptor } from './interceptors/cookie.interceptor';
 import { AccessTokenPayload, RefreshTokenPayload } from './token/token.service';
-
-export type OauthProvider = 'google' | 'kakao' | 'naver';
-
-export interface OauthBody {
-    authorizeCode: string;
-    provider: OauthProvider;
-}
+import { OauthData } from './types/auth.type';
 
 @Controller('/auth')
 @UseInterceptors(CookieInterceptor)
@@ -35,8 +30,8 @@ export class AuthController {
     @Post('/login')
     @HttpCode(200)
     @SkipAuthGuard()
-    async login(@Body() oauthBody: OauthBody) {
-        return await this.authService.login(oauthBody);
+    async login(@Body() oAuthAuthorizeDTO: OAuthAuthorizeDTO) {
+        return await this.authService.login(oAuthAuthorizeDTO);
     }
 
     @Post('/signup')

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -14,31 +14,30 @@ import { User } from '../users/decorators/user.decorator';
 import { AuthService } from './auth.service';
 import { OauthCookies } from './decorators/oauth-data.decorator';
 import { SkipAuthGuard } from './decorators/public.decorator';
-import { OAuthAuthorizeDTO } from './dtos/oauth.dto';
+import { OauthAuthorizeDto, OauthDto } from './dtos/oauth.dto';
 import { OauthDataGuard } from './guards/oauth-data.guard';
 import { RefreshTokenGuard } from './guards/refresh-token.guard';
 import { CookieInterceptor } from './interceptors/cookie.interceptor';
 import { AccessTokenPayload, RefreshTokenPayload } from './token/token.service';
-import { OauthData } from './types/auth.type';
 
 @Controller('/auth')
 @UseInterceptors(CookieInterceptor)
-@UsePipes(ValidationPipe)
+@UsePipes(new ValidationPipe({ validateCustomDecorators: true }))
 export class AuthController {
     constructor(private readonly authService: AuthService) {}
 
     @Post('/login')
     @HttpCode(200)
     @SkipAuthGuard()
-    async login(@Body() oAuthAuthorizeDTO: OAuthAuthorizeDTO) {
-        return await this.authService.login(oAuthAuthorizeDTO);
+    async login(@Body() oauthAuthorizeDTO: OauthAuthorizeDto) {
+        return await this.authService.login(oauthAuthorizeDTO);
     }
 
     @Post('/signup')
     @SkipAuthGuard()
     @UseGuards(OauthDataGuard)
-    async signup(@OauthCookies() oauthData: OauthData) {
-        return await this.authService.signup(oauthData);
+    async signup(@OauthCookies() oauthDTO: OauthDto) {
+        return await this.authService.signup(oauthDTO);
     }
 
     @Post('/logout')

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -11,12 +11,11 @@ import { Users } from '../users/users.entity';
 import { UsersRepository } from '../users/users.repository';
 import { UsersService } from '../users/users.service';
 import { AuthService } from './auth.service';
-import { OAuthAuthorizeDTO } from './dtos/oauth.dto';
 import { GoogleService } from './oauth/google.service';
 import { KakaoService } from './oauth/kakao.service';
 import { NaverService } from './oauth/naver.service';
 import { TokenService } from './token/token.service';
-import { OAUTH_PROVIDERS, OauthData } from './types/auth.type';
+import { OAUTH_PROVIDERS, OauthAuthorizeData, OauthData } from './types/auth.type';
 
 const context = describe;
 
@@ -105,7 +104,7 @@ describe('AuthService', () => {
                 it(`${provider} 로그인 후 access token과 refresh token을 반환해야 한다.`, async () => {
                     jest.spyOn(usersService, 'updateAndFindOne').mockResolvedValue({ id: 1 } as Users);
 
-                    const result = await service.login({ authorizeCode, provider } as OAuthAuthorizeDTO);
+                    const result = await service.login({ authorizeCode, provider } as OauthAuthorizeData);
 
                     expect(result).toEqual({
                         accessToken: mockUser.refreshToken,
@@ -121,7 +120,7 @@ describe('AuthService', () => {
                 it(`${provider} 로그인 후 oauth data를 반환해야 한다.`, async () => {
                     jest.spyOn(usersService, 'updateAndFindOne').mockRejectedValue(new NotFoundException());
 
-                    const result = await service.login({ authorizeCode, provider } as OAuthAuthorizeDTO);
+                    const result = await service.login({ authorizeCode, provider } as OauthAuthorizeData);
 
                     expect(result).toEqual({
                         oauthAccessToken: mockUser.oauthAccessToken,

--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -10,12 +10,13 @@ import { mockUser } from '../fixtures/users.fixture';
 import { Users } from '../users/users.entity';
 import { UsersRepository } from '../users/users.repository';
 import { UsersService } from '../users/users.service';
-import { OauthBody } from './auth.controller';
-import { AuthService, OauthData } from './auth.service';
+import { AuthService } from './auth.service';
+import { OAuthAuthorizeDTO } from './dtos/oauth.dto';
 import { GoogleService } from './oauth/google.service';
 import { KakaoService } from './oauth/kakao.service';
 import { NaverService } from './oauth/naver.service';
 import { TokenService } from './token/token.service';
+import { OAUTH_PROVIDERS, OauthData } from './types/auth.type';
 
 const context = describe;
 
@@ -96,16 +97,15 @@ describe('AuthService', () => {
     });
 
     const authorizeCode = 'authorizeCode';
-    const providerList = ['google', 'kakao', 'naver'];
 
     describe('login', () => {
         context('사용자가 존재하면', () => {
             for (let i = 0; i < 3; i++) {
-                const provider = providerList[i];
+                const provider = OAUTH_PROVIDERS[i];
                 it(`${provider} 로그인 후 access token과 refresh token을 반환해야 한다.`, async () => {
                     jest.spyOn(usersService, 'updateAndFindOne').mockResolvedValue({ id: 1 } as Users);
 
-                    const result = await service.login({ authorizeCode, provider } as OauthBody);
+                    const result = await service.login({ authorizeCode, provider } as OAuthAuthorizeDTO);
 
                     expect(result).toEqual({
                         accessToken: mockUser.refreshToken,
@@ -117,11 +117,11 @@ describe('AuthService', () => {
 
         context('사용자가 존재하지 않으면', () => {
             for (let i = 0; i < 3; i++) {
-                const provider = providerList[i];
+                const provider = OAUTH_PROVIDERS[i];
                 it(`${provider} 로그인 후 oauth data를 반환해야 한다.`, async () => {
                     jest.spyOn(usersService, 'updateAndFindOne').mockRejectedValue(new NotFoundException());
 
-                    const result = await service.login({ authorizeCode, provider } as OauthBody);
+                    const result = await service.login({ authorizeCode, provider } as OAuthAuthorizeDTO);
 
                     expect(result).toEqual({
                         oauthAccessToken: mockUser.oauthAccessToken,
@@ -136,7 +136,7 @@ describe('AuthService', () => {
     describe('signup', () => {
         context('사용자가 존재하지 않으면', () => {
             for (let i = 0; i < 3; i++) {
-                const provider = providerList[i];
+                const provider = OAUTH_PROVIDERS[i];
                 it(`${provider} 회원가입 후 access token과 refresh token을 반환해야 한다.`, async () => {
                     jest.spyOn(usersService, 'createIfNotExists').mockResolvedValue({ id: 1 } as Users);
 

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -6,12 +6,11 @@ import { S3Service } from 'src/s3/s3.service';
 import { Transactional } from 'typeorm-transactional';
 import { Users } from '../users/users.entity';
 import { UsersService } from '../users/users.service';
-import { OAuthAuthorizeDTO } from './dtos/oauth.dto';
 import { GoogleService } from './oauth/google.service';
 import { KakaoService } from './oauth/kakao.service';
 import { NaverService } from './oauth/naver.service';
 import { AccessTokenPayload, RefreshTokenPayload, TokenService } from './token/token.service';
-import { AuthData, OauthData } from './types/auth.type';
+import { AuthData, OauthAuthorizeData, OauthData } from './types/auth.type';
 
 @Injectable()
 export class AuthService {
@@ -29,7 +28,7 @@ export class AuthService {
 
     private readonly redirectURI = this.configService.get<string>('CORS_ORIGIN') + '/callback';
 
-    async login({ authorizeCode, provider }: OAuthAuthorizeDTO): Promise<AuthData | OauthData | undefined> {
+    async login({ authorizeCode, provider }: OauthAuthorizeData): Promise<AuthData | OauthData | undefined> {
         const { access_token: oauthAccessToken, refresh_token: oauthRefreshToken } = await this[
             `${provider}Service`
         ].requestToken(authorizeCode, this.redirectURI);

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -6,22 +6,12 @@ import { S3Service } from 'src/s3/s3.service';
 import { Transactional } from 'typeorm-transactional';
 import { Users } from '../users/users.entity';
 import { UsersService } from '../users/users.service';
-import { OauthBody, OauthProvider } from './auth.controller';
+import { OAuthAuthorizeDTO } from './dtos/oauth.dto';
 import { GoogleService } from './oauth/google.service';
 import { KakaoService } from './oauth/kakao.service';
 import { NaverService } from './oauth/naver.service';
 import { AccessTokenPayload, RefreshTokenPayload, TokenService } from './token/token.service';
-
-export interface AuthData {
-    accessToken: string;
-    refreshToken: string;
-}
-
-export interface OauthData {
-    oauthAccessToken: string;
-    oauthRefreshToken: string;
-    provider: OauthProvider;
-}
+import { AuthData, OauthData } from './types/auth.type';
 
 @Injectable()
 export class AuthService {
@@ -39,7 +29,7 @@ export class AuthService {
 
     private readonly redirectURI = this.configService.get<string>('CORS_ORIGIN') + '/callback';
 
-    async login({ authorizeCode, provider }: OauthBody): Promise<AuthData | OauthData | undefined> {
+    async login({ authorizeCode, provider }: OAuthAuthorizeDTO): Promise<AuthData | OauthData | undefined> {
         const { access_token: oauthAccessToken, refresh_token: oauthRefreshToken } = await this[
             `${provider}Service`
         ].requestToken(authorizeCode, this.redirectURI);

--- a/backend/src/auth/decorators/oauth-data.decorator.ts
+++ b/backend/src/auth/decorators/oauth-data.decorator.ts
@@ -1,5 +1,5 @@
 import { ExecutionContext, createParamDecorator } from '@nestjs/common';
-import { OauthData } from '../auth.service';
+import { OauthData } from '../types/auth.type';
 
 export const OauthCookies = createParamDecorator((data: never, context: ExecutionContext): OauthData => {
     const request = context.switchToHttp().getRequest();

--- a/backend/src/auth/dtos/oauth.dto.ts
+++ b/backend/src/auth/dtos/oauth.dto.ts
@@ -1,0 +1,13 @@
+import { IsIn, IsNotEmpty, IsString } from 'class-validator';
+import { OAUTH_PROVIDERS, OauthProvider } from '../types/auth.type';
+
+export class OAuthAuthorizeDTO {
+    @IsString()
+    @IsNotEmpty()
+    authorizeCode: string;
+
+    @IsString()
+    @IsIn(OAUTH_PROVIDERS)
+    @IsNotEmpty()
+    provider: OauthProvider;
+}

--- a/backend/src/auth/dtos/oauth.dto.ts
+++ b/backend/src/auth/dtos/oauth.dto.ts
@@ -1,10 +1,25 @@
 import { IsIn, IsNotEmpty, IsString } from 'class-validator';
 import { OAUTH_PROVIDERS, OauthProvider } from '../types/auth.type';
 
-export class OAuthAuthorizeDTO {
+export class OauthAuthorizeDto {
     @IsString()
     @IsNotEmpty()
     authorizeCode: string;
+
+    @IsString()
+    @IsIn(OAUTH_PROVIDERS)
+    @IsNotEmpty()
+    provider: OauthProvider;
+}
+
+export class OauthDto {
+    @IsString()
+    @IsNotEmpty()
+    oauthAccessToken: string;
+
+    @IsString()
+    @IsNotEmpty()
+    oauthRefreshToken: string;
 
     @IsString()
     @IsIn(OAUTH_PROVIDERS)

--- a/backend/src/auth/interceptors/cookie.interceptor.ts
+++ b/backend/src/auth/interceptors/cookie.interceptor.ts
@@ -3,8 +3,8 @@ import { ConfigService } from '@nestjs/config';
 import { CookieOptions, Response } from 'express';
 import { Observable, map } from 'rxjs';
 import { WinstonLoggerService } from 'src/common/logger/winstonLogger.service';
-import { AuthData, OauthData } from '../auth.service';
 import { TOKEN_LIFETIME_MAP } from '../token/token.service';
+import { AuthData, OauthData } from '../types/auth.type';
 
 @Injectable()
 export class CookieInterceptor implements NestInterceptor {

--- a/backend/src/auth/token/token.service.ts
+++ b/backend/src/auth/token/token.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { parse } from '../../utils/ms.utils';
-import { OauthProvider } from '../auth.controller';
+import { OauthProvider } from '../types/auth.type';
 
 export interface AccessTokenPayload {
     userId: number;

--- a/backend/src/auth/types/auth.type.ts
+++ b/backend/src/auth/types/auth.type.ts
@@ -2,6 +2,11 @@ export const OAUTH_PROVIDERS = ['google', 'kakao', 'naver'] as const;
 
 export type OauthProvider = (typeof OAUTH_PROVIDERS)[number];
 
+export interface OauthAuthorizeData {
+    authorizeCode: string;
+    provider: OauthProvider;
+}
+
 export interface AuthData {
     accessToken: string;
     refreshToken: string;

--- a/backend/src/auth/types/auth.type.ts
+++ b/backend/src/auth/types/auth.type.ts
@@ -1,0 +1,14 @@
+export const OAUTH_PROVIDERS = ['google', 'kakao', 'naver'] as const;
+
+export type OauthProvider = (typeof OAUTH_PROVIDERS)[number];
+
+export interface AuthData {
+    accessToken: string;
+    refreshToken: string;
+}
+
+export interface OauthData {
+    oauthAccessToken: string;
+    oauthRefreshToken: string;
+    provider: OauthProvider;
+}

--- a/backend/src/users/users.service.ts
+++ b/backend/src/users/users.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { OauthProvider } from 'src/auth/auth.controller';
 import { AccessTokenPayload } from 'src/auth/token/token.service';
+import { OauthProvider } from 'src/auth/types/auth.type';
 import { S3Service } from 'src/s3/s3.service';
 import { FindOptionsWhere } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
`ValidationPipe`에 `validateCustomDecorators` option을 사용해 OauthCookies custom decorator에서 반환하는 값에도 class validation을 적용했다.
DTO는 client와 server 간에 주고 받는 데이터 전송 객체이기 때문에 validation에만 사용하고 그 외에는 type에서 정의한 객체를 사용해 역할을 분리했다.

## 링크 (Links)
https://www.notion.so/do0ori/Auth-Validation-7409ea05c3e14297933092ccd21f2f93

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
