### PR TITLE
frontend/DANG-779: 산책기록 상세 페이지에서 데이터 바인딩과 수정 구현

### DIFF
--- a/frontend/src/api/journals.ts
+++ b/frontend/src/api/journals.ts
@@ -13,6 +13,10 @@ export const create = async (form: JournalCreateForm) => {
     await httpClient.post('/journals', form);
 };
 
+export const update = async (journalId: number, form: JournalUpdateForm) => {
+    await httpClient.patch(`/journals/${journalId}`, form);
+};
+
 export const fetchJournal = async (journalId: number) => {
     const { data } = await httpClient.get<JournalDetail>(`/journals/${journalId}`);
 
@@ -65,4 +69,9 @@ interface ExcrementCounts {
     dogId: number;
     fecesCnt: number;
     urineCnt: number;
+}
+
+interface JournalUpdateForm {
+    memo?: string;
+    photoUrls?: Array<string>;
 }

--- a/frontend/src/api/journals.ts
+++ b/frontend/src/api/journals.ts
@@ -1,6 +1,6 @@
 import { httpClient } from '@/api/http';
 import { Journal } from '@/models/journals';
-import { Position as NumberPosition } from '@/models/location.model';
+import { Position as NumberPosition, Position } from '@/models/location.model';
 import { formDate } from '@/utils/date';
 
 export const fetchJournals = async (dogId: number, date: string = formDate(new Date())): Promise<Journal[]> => {
@@ -11,6 +11,12 @@ export const fetchJournals = async (dogId: number, date: string = formDate(new D
 
 export const create = async (form: JournalCreateForm) => {
     await httpClient.post('/journals', form);
+};
+
+export const fetchJournal = async (journalId: number) => {
+    const { data } = await httpClient.get<JournalDetail>(`/journals/${journalId}`);
+
+    return data;
 };
 
 interface JournalCreateForm {
@@ -36,4 +42,27 @@ interface Excrement {
 interface StringPosition {
     lat: string;
     lng: string;
+}
+
+export interface JournalDetail {
+    journalInfo: {
+        id: number;
+        routes: Array<Position>;
+        memo: string;
+        photoUrls: Array<string>;
+    };
+    dogs: Array<Dog>;
+    excrements?: Array<ExcrementCounts>;
+}
+
+interface Dog {
+    id: number;
+    name: string;
+    profilePhotoUrl: string;
+}
+
+interface ExcrementCounts {
+    dogId: number;
+    fecesCnt: number;
+    urineCnt: number;
 }

--- a/frontend/src/components/common/Avatar.tsx
+++ b/frontend/src/components/common/Avatar.tsx
@@ -19,12 +19,16 @@ const imgSize = (size: string) => {
     }
 };
 
+const { REACT_APP_BASE_IMAGE_URL = '' } = window._ENV ?? process.env;
+
 export default function Avatar({ url, name, size = 'small', onClick, className }: AvatarProps) {
+    const convertedUrl = convertUrl(url);
+
     return (
         <div className={`justify-start items-center gap-2 inline-flex ${className}`} onClick={onClick}>
             <div className={`flex justify-center items-center rounded-full border overflow-hidden border-neutral-200`}>
-                {url ? (
-                    <img src={url} alt={name} width={imgSize(size)} height={imgSize(size)} />
+                {convertedUrl ? (
+                    <img src={convertedUrl} alt={name} width={imgSize(size)} height={imgSize(size)} />
                 ) : (
                     <DefaultProfileImage />
                 )}
@@ -32,4 +36,10 @@ export default function Avatar({ url, name, size = 'small', onClick, className }
             {name && <div className="text-neutral-800 text-sm font-bold leading-[21px]">{name ? name : ''}</div>}
         </div>
     );
+}
+
+function convertUrl(url?: string): string | undefined {
+    if (url === undefined) return undefined;
+    if (url.startsWith('http') || url.startsWith('/static')) return url;
+    return `${REACT_APP_BASE_IMAGE_URL}/${url}`;
 }

--- a/frontend/src/components/journals/CompanionDogSection2.tsx
+++ b/frontend/src/components/journals/CompanionDogSection2.tsx
@@ -1,0 +1,31 @@
+import Avatar from '@/components/common/Avatar';
+import ExcrementDisplay from '@/components/journals/ExcrementDisplay';
+import Heading from '@/components/journals/Heading';
+
+export default function CompanionDogSection({ dogs }: Props) {
+    return (
+        <div className="px-5 py-[10px]">
+            <Heading headingNumber={2}>함께한 댕댕이</Heading>
+            <div className="flex flex-col">
+                {dogs.map((dog) => (
+                    <div key={dog.id} className="flex justify-between h-[52px]">
+                        <Avatar url={dog.profilePhotoUrl} name={dog.name} />
+                        <ExcrementDisplay fecesCount={dog.fecesCount} urineCount={dog.urineCount} />
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+interface Props {
+    dogs: Array<Dog>;
+}
+
+export interface Dog {
+    id: number;
+    name: string;
+    profilePhotoUrl: string;
+    fecesCount: number;
+    urineCount: number;
+}

--- a/frontend/src/components/journals/JournalCard.tsx
+++ b/frontend/src/components/journals/JournalCard.tsx
@@ -19,7 +19,7 @@ const getStartToEnd = (start: string, seconds: number) => {
 export default function JournalCard({ journal, dog }: { journal: Journal; dog: Dog | undefined }) {
     const navigate = useNavigate();
     const goToDetail = (id: number) => {
-        navigate(`/journals/detail/${id}`);
+        navigate(`/journals/${id}`);
     };
     if (!dog) return <></>;
     return (

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -6,6 +6,7 @@ import Home from '@/pages/Home';
 import Join from '@/pages/Join';
 import JournalCreateForm from '@/pages/Journals/CreateForm';
 import Detail from '@/pages/Journals/Detail';
+import Journals from '@/pages/Journals/Journals';
 import OauthCallback from '@/pages/OauthCallback';
 import Profile from '@/pages/Profile';
 import Walk from '@/pages/Walk';
@@ -58,6 +59,10 @@ const router = createBrowserRouter([
             {
                 path: '/journals/create',
                 element: <JournalCreateForm />,
+            },
+            {
+                path: '/journals',
+                element: <Journals />,
             },
             {
                 path: '/journals/:journalId',

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,9 +1,11 @@
+import { fetchJournal } from '@/api/journals';
 import queryClient from '@/api/queryClient';
 import Camera from '@/pages/Camera';
 import Health from '@/pages/Health';
 import Home from '@/pages/Home';
 import Join from '@/pages/Join';
 import JournalCreateForm from '@/pages/Journals/CreateForm';
+import Detail from '@/pages/Journals/Detail';
 import OauthCallback from '@/pages/OauthCallback';
 import Profile from '@/pages/Profile';
 import Walk from '@/pages/Walk';
@@ -15,7 +17,6 @@ import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import App from './App';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
-import Journals from '@/pages/Journals/Journals';
 const router = createBrowserRouter([
     {
         path: '/',
@@ -59,8 +60,12 @@ const router = createBrowserRouter([
                 element: <JournalCreateForm />,
             },
             {
-                path: '/journals',
-                element: <Journals />,
+                path: '/journals/:journalId',
+                element: <Detail />,
+                loader: async ({ params }) => {
+                    const journalId = Number(params.journalId);
+                    return await fetchJournal(journalId);
+                },
             },
         ],
     },

--- a/frontend/src/pages/Journals/Detail.tsx
+++ b/frontend/src/pages/Journals/Detail.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { JournalDetail } from '@/api/journals';
+import { JournalDetail, update as updateJournal } from '@/api/journals';
 import { deleteImages, getUploadUrl, uploadImage } from '@/api/upload';
 import Cancel from '@/assets/icons/ic-top-cancel.svg';
 import { Button } from '@/components/common/Button';
@@ -30,7 +30,7 @@ export default function Detail() {
     const journalDetail = useLoaderData() as JournalDetail;
     console.log(journalDetail);
     const { journalInfo, dogs: dogsFromAPI, excrements = [] } = journalDetail;
-    const { routes, memo, photoUrls: photoFileNames } = journalInfo;
+    const { id: journalId, routes, memo, photoUrls: photoFileNames } = journalInfo;
 
     const navigate = useNavigate();
     const location = useLocation();
@@ -116,7 +116,7 @@ export default function Detail() {
                     <Divider />
                     <MemoSection textAreaRef={textAreaRef} />
                 </div>
-                <Button rounded="none" className="w-full h-16" disabled={isSaving}>
+                <Button rounded="none" className="w-full h-16" disabled={isSaving} onClick={handleSave}>
                     <span className="-translate-y-[5px]">저장하기</span>
                 </Button>
             </div>
@@ -135,53 +135,20 @@ export default function Detail() {
         </>
     );
 
-    // async function handleSave() {
-    //     setIsSaving(true);
-    //     addSpinner();
+    async function handleSave() {
+        setIsSaving(true);
+        addSpinner();
 
-    //     const dogIds = dogs.map((dog) => dog.id);
-    //     const journalInfo = {
-    //         distance,
-    //         calories,
-    //         startedAt: startedAt.toJSON(),
-    //         duration,
-    //         routes,
-    //         photoUrls: photoFileNames ?? [],
-    //         memo: textAreaRef.current?.value ?? '',
-    //     };
-    //     const excrements = dogs.map((dog) => {
-    //         const stringFecesLocations = dog.fecesLocations.map((position) => {
-    //             return {
-    //                 lat: String(position.lat),
-    //                 lng: String(position.lng),
-    //             };
-    //         });
-    //         const stringUrineLocations = dog.fecesLocations.map((position) => {
-    //             return {
-    //                 lat: String(position.lat),
-    //                 lng: String(position.lng),
-    //             };
-    //         });
+        const memo = textAreaRef.current?.value ?? '';
+        const photoUrls = imageFileNames;
+        await updateJournal(journalId, { memo, photoUrls });
 
-    //         return {
-    //             dogId: dog.id,
-    //             fecesLocations: stringFecesLocations,
-    //             urineLocations: stringUrineLocations,
-    //         };
-    //     });
+        setIsSaving(false);
+        removeSpinner();
+        showToast('산책 기록이 저장되었습니다.');
 
-    //     await createJournal({
-    //         dogs: dogIds,
-    //         journalInfo,
-    //         excrements: excrements ?? [],
-    //     });
-
-    //     setIsSaving(false);
-    //     removeSpinner();
-    //     showToast('산책 기록이 저장되었습니다.');
-
-    //     navigate('/');
-    // }
+        navigate('/');
+    }
 
     function handleCancelSave() {
         showToast('산책 기록이 삭제되었습니다.');

--- a/frontend/src/pages/Journals/Detail.tsx
+++ b/frontend/src/pages/Journals/Detail.tsx
@@ -1,0 +1,231 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { JournalDetail } from '@/api/journals';
+import { deleteImages, getUploadUrl, uploadImage } from '@/api/upload';
+import Cancel from '@/assets/icons/ic-top-cancel.svg';
+import { Button } from '@/components/common/Button';
+import { Divider } from '@/components/common/Divider';
+import {
+    Modal,
+    ModalAction,
+    ModalCancel,
+    ModalContent,
+    ModalDescription,
+    ModalFooter,
+    ModalHeader,
+    ModalTitle,
+} from '@/components/common/Modal';
+import CompanionDogSection, { Dog } from '@/components/journals/CompanionDogSection2';
+import Heading from '@/components/journals/Heading';
+import MemoSection from '@/components/journals/MemoSection';
+import PhotoSection from '@/components/journals/PhotoSection';
+import Map from '@/components/walk/Map';
+import WalkInfo from '@/components/walk/WalkInfo';
+import useToast from '@/hooks/useToast';
+import { useSpinnerStore } from '@/store/spinnerStore';
+import { getFileName } from '@/utils/url';
+import { FormEvent, useEffect, useRef, useState } from 'react';
+import { useLoaderData, useLocation, useNavigate } from 'react-router-dom';
+
+export default function Detail() {
+    const journalDetail = useLoaderData() as JournalDetail;
+    console.log(journalDetail);
+    const { journalInfo, dogs: dogsFromAPI, excrements = [] } = journalDetail;
+    const { routes, memo, photoUrls: photoFileNames } = journalInfo;
+
+    const navigate = useNavigate();
+    const location = useLocation();
+    const { show: showToast } = useToast();
+
+    const addSpinner = useSpinnerStore((state) => state.spinnerAdd);
+    const removeSpinner = useSpinnerStore((state) => state.spinnerRemove);
+
+    const [openModal, setOpenModal] = useState(false);
+    const [imageFileNames, setImageFileNames] = useState<Array<ImageFileName>>([]);
+    const [isUploading, setIsUploading] = useState(false);
+    const [isSaving, setIsSaving] = useState(false);
+
+    const textAreaRef = useRef<HTMLTextAreaElement>(null);
+
+    const receivedState =
+        (location.state as ReceivedState) ??
+        ({
+            dogName: '골댕이',
+            startedAt: '1718-03-30 12:32:08',
+            journalCnt: 1,
+            calories: 20,
+            distance: 30,
+            duration: 131,
+        } as ReceivedState);
+
+    const {
+        dogName,
+        journalCnt: journalCount,
+        startedAt: serializedStartedAt,
+        calories,
+        duration,
+        distance,
+    } = receivedState;
+    const startedAt = new Date(serializedStartedAt);
+
+    const dogs: Array<Dog> = dogsFromAPI.map((dog) => {
+        const foundExcrement = excrements.find((excrement) => excrement.dogId === dog.id);
+        const fecesCount = foundExcrement?.fecesCnt ?? 0;
+        const urineCount = foundExcrement?.urineCnt ?? 0;
+
+        return { ...dog, fecesCount, urineCount };
+    });
+
+    useEffect(() => {
+        dogs.forEach((dog) => {
+            if (dog.profilePhotoUrl === undefined) return;
+            dog.profilePhotoUrl = getFileName(dog.profilePhotoUrl);
+        });
+
+        setImageFileNames(photoFileNames);
+    }, [location]);
+
+    return (
+        <>
+            <div className="flex flex-col">
+                <div className="flex justify-between items-center h-12 pl-5 pr-2">
+                    <Heading headingNumber={1}>
+                        {dogName}의 {journalCount}번째 산책
+                    </Heading>
+                    <button onClick={() => setOpenModal(true)}>
+                        <img src={Cancel} alt="cancel" />
+                    </button>
+                </div>
+                <div className={`h-[calc(100dvh-3rem-4rem)] overflow-y-auto`}>
+                    <Map
+                        startPosition={routes[0]}
+                        path={routes}
+                        className="rounded-lg overflow-hidden"
+                        height="216px"
+                    />
+                    <WalkInfo distance={distance} calories={calories} duration={duration} />
+                    <Divider />
+                    <CompanionDogSection dogs={dogs} />
+                    <Divider />
+                    <PhotoSection
+                        imageFileNames={imageFileNames}
+                        isLoading={isUploading}
+                        isModifying
+                        onChange={handleAddImages}
+                        onDeleteImage={handleDeleteImage}
+                    />
+                    <Divider />
+                    <MemoSection textAreaRef={textAreaRef} />
+                </div>
+                <Button rounded="none" className="w-full h-16" disabled={isSaving}>
+                    <span className="-translate-y-[5px]">저장하기</span>
+                </Button>
+            </div>
+            <Modal open={openModal}>
+                <ModalContent>
+                    <ModalHeader>
+                        <ModalTitle>산책기록삭제</ModalTitle>
+                        <ModalDescription>오늘한 산책을 기록에서 삭제할까요?</ModalDescription>
+                    </ModalHeader>
+                    <ModalFooter>
+                        <ModalCancel onClick={() => setOpenModal(false)}>취소</ModalCancel>
+                        <ModalAction onClick={handleCancelSave}>삭제하기</ModalAction>
+                    </ModalFooter>
+                </ModalContent>
+            </Modal>
+        </>
+    );
+
+    // async function handleSave() {
+    //     setIsSaving(true);
+    //     addSpinner();
+
+    //     const dogIds = dogs.map((dog) => dog.id);
+    //     const journalInfo = {
+    //         distance,
+    //         calories,
+    //         startedAt: startedAt.toJSON(),
+    //         duration,
+    //         routes,
+    //         photoUrls: photoFileNames ?? [],
+    //         memo: textAreaRef.current?.value ?? '',
+    //     };
+    //     const excrements = dogs.map((dog) => {
+    //         const stringFecesLocations = dog.fecesLocations.map((position) => {
+    //             return {
+    //                 lat: String(position.lat),
+    //                 lng: String(position.lng),
+    //             };
+    //         });
+    //         const stringUrineLocations = dog.fecesLocations.map((position) => {
+    //             return {
+    //                 lat: String(position.lat),
+    //                 lng: String(position.lng),
+    //             };
+    //         });
+
+    //         return {
+    //             dogId: dog.id,
+    //             fecesLocations: stringFecesLocations,
+    //             urineLocations: stringUrineLocations,
+    //         };
+    //     });
+
+    //     await createJournal({
+    //         dogs: dogIds,
+    //         journalInfo,
+    //         excrements: excrements ?? [],
+    //     });
+
+    //     setIsSaving(false);
+    //     removeSpinner();
+    //     showToast('산책 기록이 저장되었습니다.');
+
+    //     navigate('/');
+    // }
+
+    function handleCancelSave() {
+        showToast('산책 기록이 삭제되었습니다.');
+
+        navigate('/');
+    }
+
+    async function handleAddImages(e: FormEvent<HTMLInputElement>) {
+        const files = e.currentTarget.files;
+
+        if (files === null) return;
+        setIsUploading(true);
+
+        const fileTypes = Array.from(files).map((file) => file.type);
+        const uploadUrlResponses = await getUploadUrl(fileTypes);
+        const uploadUrls = uploadUrlResponses.map((uploadUrlResponse) => uploadUrlResponse.url);
+
+        const uploadImagePromises = uploadUrls.map((uploadUrl, index) => {
+            return uploadImage(files[index]!, uploadUrl);
+        });
+        await Promise.allSettled(uploadImagePromises);
+
+        const filenames = uploadUrlResponses.map((uploadUrlResponse) => uploadUrlResponse.filename);
+        setImageFileNames((prevImageFileNames) => [...prevImageFileNames, ...filenames]);
+        setIsUploading(false);
+    }
+
+    async function handleDeleteImage(imageFileName: ImageFileName) {
+        await deleteImages([imageFileName]);
+
+        setImageFileNames((prevImageFileNames) =>
+            prevImageFileNames.filter((prevImageFileName) => prevImageFileName !== imageFileName)
+        );
+        showToast('사진이 삭제되었습니다.');
+    }
+}
+
+interface ReceivedState {
+    dogName: string;
+    journalCnt: number;
+    startedAt: string;
+    calories: number;
+    duration: number;
+    distance: number;
+}
+
+export type ImageFileName = string;

--- a/frontend/src/pages/Journals/Detail.tsx
+++ b/frontend/src/pages/Journals/Detail.tsx
@@ -84,6 +84,11 @@ export default function Detail() {
         setImageFileNames(photoFileNames);
     }, [location]);
 
+    useEffect(() => {
+        if (textAreaRef.current === null) return;
+        textAreaRef.current.value = memo;
+    }, []);
+
     return (
         <>
             <div className="flex flex-col">


### PR DESCRIPTION
## 작업 내용 (Content)
산책기록 상세 페이지에서 데이터 바인딩과 수정 구현

## 링크 (Links)
https://www.notion.so/do0ori/511bb4b4e67f479992008442b6526b4e?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
