### PR TITLE
backend/DANG-791: 홈 화면 조회시 today_walk_time 마지막 업데이트일이 오늘 이전인지 확인해서 리셋

### DIFF
--- a/backend/src/dog-walk-day/dog-walk-day.service.ts
+++ b/backend/src/dog-walk-day/dog-walk-day.service.ts
@@ -32,11 +32,11 @@ export class DogWalkDayService {
         return this.dogWalkDayRepository.update(where, partialEntity);
     }
 
-    private getDayCntOnly(walkDay: any): number[] {
+    private getDayCntOnly(walkDay: DogWalkDay): number[] {
         const dayCntArr = [];
         for (const key in walkDay) {
             if (key !== 'id' && key !== 'updatedAt') {
-                dayCntArr.push(walkDay[key]);
+                dayCntArr.push(walkDay[key] as number);
             }
         }
         return dayCntArr;

--- a/backend/src/today-walk-time/today-walk-time.service.ts
+++ b/backend/src/today-walk-time/today-walk-time.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { WinstonLoggerService } from 'src/common/logger/winstonLogger.service';
+import { getStartOfToday } from 'src/utils/date.util';
 import { FindManyOptions, FindOptionsWhere, In, UpdateResult } from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { TodayWalkTime } from './today-walk-time.entity';
 import { TodayWalkTimeRepository } from './today-walk-time.repository';
-import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 
 @Injectable()
 export class TodayWalkTimeService {
@@ -20,10 +21,6 @@ export class TodayWalkTimeService {
         return this.todayWalkTimeRepository.findOne(where);
     }
 
-    async delete(where: FindOptionsWhere<TodayWalkTime>) {
-        return this.todayWalkTimeRepository.delete(where);
-    }
-
     async update(
         where: FindOptionsWhere<TodayWalkTime>,
         partialEntity: QueryDeepPartialEntity<TodayWalkTime>
@@ -31,13 +28,30 @@ export class TodayWalkTimeService {
         return this.todayWalkTimeRepository.update(where, partialEntity);
     }
 
+    async delete(where: FindOptionsWhere<TodayWalkTime>) {
+        return this.todayWalkTimeRepository.delete(where);
+    }
+
+    async checkDayPassed(walkTimeId: number, updatedAt: Date) {
+        const startOfToday = getStartOfToday();
+        if (updatedAt < startOfToday) {
+            await this.update({ id: walkTimeId }, { duration: 0 });
+        }
+    }
+
     async getWalkTimeList(walkTimeIds: number[]) {
-        const walkTimeList = await this.todayWalkTimeRepository.find({ where: { id: In(walkTimeIds) } });
-        if (!walkTimeList.length) {
+        const walkTimeListBeforeCheck = await this.todayWalkTimeRepository.find({ where: { id: In(walkTimeIds) } });
+        if (!walkTimeListBeforeCheck.length) {
             const error = new NotFoundException(`No walkTime found for the provided IDs: ${walkTimeIds}.`);
             this.logger.error(`No walkTime found for the provided IDs: ${walkTimeIds}.`, error.stack ?? 'No stack');
             throw error;
         }
+
+        for (const curWalkTime of walkTimeListBeforeCheck) {
+            await this.checkDayPassed(curWalkTime.id, curWalkTime.updatedAt);
+        }
+
+        const walkTimeList = await this.todayWalkTimeRepository.find({ where: { id: In(walkTimeIds) } });
         return walkTimeList.map((cur) => {
             return cur.duration;
         });

--- a/backend/src/utils/date.util.ts
+++ b/backend/src/utils/date.util.ts
@@ -68,3 +68,8 @@ export function getLastSunday() {
 
     return lastSunday;
 }
+
+export function getStartOfToday(): Date {
+    const now = new Date();
+    return new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
+}


### PR DESCRIPTION
## 작업 내용 (Content)
홈 화면 조회시 today_walk_time 마지막 업데이트일이 오늘 이전인지 확인해서 리셋하는 로직을 추가했습니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
