### PR TITLE
backend/DANG-805: photoUrl 없을 시 빈배열 리턴

### DIFF
--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -79,6 +79,9 @@ export class JournalsService {
 
     async getJournalPhotos(journalId: number): Promise<string[]> {
         const photoUrlsRaw = await this.journalPhotosService.find({ journalId });
+        if (photoUrlsRaw.length === 1 && photoUrlsRaw[0].photoUrl === "") {
+            return[];
+        }
 
         const photoUrls = photoUrlsRaw.map((cur) => {
             return cur.photoUrl;


### PR DESCRIPTION
## 작업 내용 (Content)
산책일지 생성시,photoURL을 보내지 않은 경우에도 journal-photos에 새 행을 만들도록 변경했습니다.
이에 따라 산책일시 상세 조회시 photoUrl에 있는 빈 문자열이 그대로 보내지는 문제가 있어서,
photoUrl의 값이 하나이고, 빈 문자열이면 빈 배열을 리턴하도록 변경했습니다.

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
