### PR TITLE
backend/DANG-812: 산책일지 수정 API 버그 수정

### DIFF
--- a/backend/src/journal-photos/journal-photos.service.ts
+++ b/backend/src/journal-photos/journal-photos.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { DeleteResult, FindOptionsWhere, UpdateResult } from 'typeorm';
+import { DeleteResult, FindManyOptions, FindOptionsWhere, UpdateResult } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { JournalPhotos } from './journal-photos.entity';
 import { JournalPhotosRepository } from './journal-photos.repository';
@@ -22,8 +22,8 @@ export class JournalPhotosService {
         return this.journalPhotosRepository.findOne(where);
     }
 
-    async find(where: FindOptionsWhere<JournalPhotos>): Promise<JournalPhotos[]> {
-        return this.journalPhotosRepository.find({ where });
+    async find(where: FindManyOptions<JournalPhotos>): Promise<JournalPhotos[]> {
+        return this.journalPhotosRepository.find(where);
     }
 
     async update(


### PR DESCRIPTION
## 작업 내용 (Content)
- 산책일지 사진 삭제 시, 레코드를 먼저 찾고 없을 때만 삭제하도록 변경
- 산책일지 생성시 빈 문자열로 journals-photos에 레코드 생성하는 로직 삭제
  - 빈 문자열 -> 빈 배열로 변경하는 로직도 삭제

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
