### PR TITLE
frontend/DANG-799: Avatar 컴포넌트의 이미지 경로 문제

### DIFF
--- a/frontend/src/components/common/Avatar.tsx
+++ b/frontend/src/components/common/Avatar.tsx
@@ -24,7 +24,7 @@ const { REACT_APP_BASE_IMAGE_URL = '' } = window._ENV ?? process.env;
 
 export default function Avatar({ url, name, size = 'small', onClick, className }: AvatarProps) {
     const convertedUrl = convertUrl(url);
-    console.log(url);
+
     return (
         <div className={`justify-start items-center gap-2 inline-flex ${className}`} onClick={onClick}>
             <div className={`flex justify-center items-center rounded-full border overflow-hidden border-neutral-200`}>

--- a/frontend/src/components/common/Avatar.tsx
+++ b/frontend/src/components/common/Avatar.tsx
@@ -1,4 +1,5 @@
 import DefaultProfileImage from '@/components/common/DefaultProfileImage';
+import { isImageFileName } from '@/utils/url';
 import { MouseEvent } from 'react';
 
 interface AvatarProps {
@@ -39,8 +40,7 @@ export default function Avatar({ url, name, size = 'small', onClick, className }
     );
 }
 
-function convertUrl(url?: string | null): string | undefined {
-    if (!url) return undefined;
-    if (url.startsWith('http') || url.startsWith('/static')) return url;
-    return `${REACT_APP_BASE_IMAGE_URL}/${url}`;
+function convertUrl(url: undefined | null | string): undefined | null | string {
+    if (typeof url === 'string' && isImageFileName(url)) return `${REACT_APP_BASE_IMAGE_URL}/${url}`;
+    return url;
 }

--- a/frontend/src/utils/url.test.ts
+++ b/frontend/src/utils/url.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from 'vitest';
+import { isImageFileName } from './url';
+
+describe('유틸 함수 isImageFileName은', () => {
+    test('S3에 업로드된 이미지의 fileName 형식에 대해 true를 반환한다.', () => {
+        expect(isImageFileName('1/8bd7fb6e-351d-4224-bf8a-1e855c018de9.png')).toBe(true);
+    });
+    test('S3에 업로드된 이미지의 fileName 형식이 처음에 있지 않은 것에 대해 false를 반환한다.', () => {
+        expect(isImageFileName('/static/media/1/8bd7fb6e-351d-4224-bf8a-1e855c018de9.png')).toBe(false);
+        expect(isImageFileName('data:image/png;base64,1/8bd7fb6e-351d-4224-bf8a-1e855c018de9.png')).toBe(false);
+    });
+    test('정적 자산 형식에 대해 false를 반환한다.', () => {
+        expect(isImageFileName('/static/media/frame-5058.bb2c5fbbf292bff8ee8face288e54913.svg')).toBe(false);
+    });
+    test('base64 형식에 대해 false를 반환한다.', () => {
+        expect(isImageFileName('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAoAAAANSUhEUoAAAANSUhEU')).toBe(false);
+    });
+});

--- a/frontend/src/utils/url.ts
+++ b/frontend/src/utils/url.ts
@@ -8,4 +8,10 @@ function getFileName(fileUrl: string) {
     return fileUrl.replaceAll(`${REACT_APP_BASE_IMAGE_URL}/`, '');
 }
 
-export { getFileName, makeFileUrl };
+function isImageFileName(url: string): boolean {
+    const regexp = /^\d+\//;
+
+    return regexp.test(url);
+}
+
+export { getFileName, isImageFileName, makeFileUrl };


### PR DESCRIPTION
## 작업 내용 (Content)
Avatar 컴포넌트의 이미지 경로 문제

## 링크 (Links)
https://www.notion.so/do0ori/Avatar-db658f1ecf6540688feac4ca6ef3a7f8?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
