### PR TITLE
frontend/DANG-815: 산책일지 상세 페이지에서 상단 바의 외관 구현

### DIFF
--- a/frontend/src/assets/icons/ic-meatball.svg
+++ b/frontend/src/assets/icons/ic-meatball.svg
@@ -1,0 +1,7 @@
+<svg width="17" height="3" viewBox="0 0 17 3" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g id="Group 1697">
+<circle id="Ellipse 121" cx="1.5" cy="1.5" r="1.5" fill="#222222"/>
+<circle id="Ellipse 122" cx="8.5" cy="1.5" r="1.5" fill="#222222"/>
+<circle id="Ellipse 123" cx="15.5" cy="1.5" r="1.5" fill="#222222"/>
+</g>
+</svg>

--- a/frontend/src/components/journals/Heading.tsx
+++ b/frontend/src/components/journals/Heading.tsx
@@ -14,12 +14,12 @@ const variants = cva('my-[10px]', {
         },
     },
 });
-export default function Heading({ headingNumber, children, ...props }: Props) {
+export default function Heading({ headingNumber, className, children, ...props }: Props) {
     const headings = { 1: 'h1', 2: 'h2', 3: 'h3', 4: 'h4', 5: 'h5', 6: 'h6' } as const;
     const Tag = headings[headingNumber];
 
     return (
-        <Tag className={cn(variants({ headingNumber }))} {...props}>
+        <Tag className={cn(variants({ headingNumber }), className)} {...props}>
             {children}
         </Tag>
     );

--- a/frontend/src/pages/Journals/Detail.tsx
+++ b/frontend/src/pages/Journals/Detail.tsx
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { JournalDetail, update as updateJournal } from '@/api/journals';
 import { deleteImages, getUploadUrl, uploadImage } from '@/api/upload';
-import Cancel from '@/assets/icons/ic-top-cancel.svg';
+import { ReactComponent as Arrow } from '@/assets/icons/ic-arrow.svg';
+import { ReactComponent as Meatball } from '@/assets/icons/ic-meatball.svg';
 import { Button } from '@/components/common/Button';
 import { Divider } from '@/components/common/Divider';
 import {
@@ -92,12 +93,15 @@ export default function Detail() {
     return (
         <>
             <div className="flex flex-col">
-                <div className="flex justify-between items-center h-12 pl-5 pr-2">
-                    <Heading headingNumber={1}>
+                <div className="flex justify-between items-center h-12 px-5">
+                    <button className="w-12 h-12 flex justify-center items-center">
+                        <Arrow className="rotate-180" />
+                    </button>
+                    <Heading headingNumber={1} className="-translate-x-[15px]">
                         {dogName}의 {journalCount}번째 산책
                     </Heading>
-                    <button onClick={() => setOpenModal(true)}>
-                        <img src={Cancel} alt="cancel" />
+                    <button className="w-12 h-12 flex justify-center items-center" onClick={() => setOpenModal(true)}>
+                        <Meatball />
                     </button>
                 </div>
                 <div className={`h-[calc(100dvh-3rem-4rem)] overflow-y-auto`}>


### PR DESCRIPTION
## 작업 내용 (Content)
산책일지 상세 페이지에서 상단 바의 외관 구현

## 링크 (Links)
https://www.notion.so/do0ori/ea5abe1ba6d84409a379338fd8f62e87?pvs=4

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
