### PR TITLE
backend/DANG-849: makeSubobjectsArray 함수 개선

### DIFF
--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -121,7 +121,7 @@ export class DogsService {
 
     private makeDogsSummaryList(dogs: Dogs[]): DogSummary[] {
         //TODO: key를 리턴하는 함수 만들어 인자로 넣기
-        return makeSubObjectsArray(dogs, ['id', 'name', 'profilePhotoUrl'], ['id', 'name', 'profilePhotoUrl']);
+        return makeSubObjectsArray(dogs, ['id', 'name', 'profilePhotoUrl']);
     }
 
     async getDogsSummaryList(where: FindOptionsWhere<Dogs>): Promise<DogSummary[]> {

--- a/backend/src/utils/manipulate.util.ts
+++ b/backend/src/utils/manipulate.util.ts
@@ -47,35 +47,26 @@ export function checkIfExistsInArr<T>(targetArr: T[], toFind: T | T[]): boolean 
  * //     { name: 25 }
  * // ]
  */
+
 export function makeSubObjectsArray(
     targetArr: any[],
     srcAttributes: string | string[],
-    targetAttributes: string | string[]
+    targetAttributes?: string | string[]
 ): any[] {
     const resArr: any[] = [];
-    if (!targetAttributes) {
-        targetAttributes = srcAttributes;
+    targetAttributes = targetAttributes ?? srcAttributes;
+    Array.isArray(srcAttributes) ? srcAttributes : [srcAttributes];
+    Array.isArray(targetAttributes) ? targetAttributes : [targetAttributes];
+    if (srcAttributes.length != targetAttributes.length) {
+        throw new Error('srcAttributes and targetAttributes must have same length');
     }
-    if (Array.isArray(srcAttributes) && Array.isArray(targetAttributes)) {
-        targetArr.map((cur) => {
-            {
-                const obj: { [key: string]: any } = {};
-                for (let i = 0; i < srcAttributes.length; i++) {
-                    obj[`${targetAttributes[i]}`] = cur[`${srcAttributes[i]}`];
-                }
-                resArr.push(obj);
-            }
-        });
-    } else if (typeof srcAttributes === 'string' && typeof targetAttributes === 'string') {
-        targetArr.map((cur) => {
-            const obj: { [key: string]: any } = {};
-            obj[`${targetAttributes}`] = cur[`${srcAttributes}`];
-            resArr.push(obj);
-        });
-    } else {
-        //TODO: 에러를 던지는게 적절한지 고민
-        throw new Error('srcAttributes and targetAttributes must be of the same type');
-    }
+    targetArr.map((cur) => {
+        const obj: { [key: string]: any } = {};
+        for (let i = 0; i < srcAttributes.length; i++) {
+            obj[`${targetAttributes[i]}`] = cur[`${srcAttributes[i]}`];
+        }
+        resArr.push(obj);
+    });
     return resArr;
 }
 

--- a/backend/src/utils/manipulate.util.ts
+++ b/backend/src/utils/manipulate.util.ts
@@ -49,11 +49,14 @@ export function checkIfExistsInArr<T>(targetArr: T[], toFind: T | T[]): boolean 
  */
 export function makeSubObjectsArray(
     targetArr: any[],
-    targetAttributes: string | string[],
-    srcAttributes: string | string[]
+    srcAttributes: string | string[],
+    targetAttributes: string | string[]
 ): any[] {
     const resArr: any[] = [];
-    if (Array.isArray(srcAttributes)) {
+    if (!targetAttributes) {
+        targetAttributes = srcAttributes;
+    }
+    if (Array.isArray(srcAttributes) && Array.isArray(targetAttributes)) {
         targetArr.map((cur) => {
             {
                 const obj: { [key: string]: any } = {};
@@ -63,12 +66,15 @@ export function makeSubObjectsArray(
                 resArr.push(obj);
             }
         });
-    } else {
+    } else if (typeof srcAttributes === 'string' && typeof targetAttributes === 'string') {
         targetArr.map((cur) => {
             const obj: { [key: string]: any } = {};
             obj[`${targetAttributes}`] = cur[`${srcAttributes}`];
             resArr.push(obj);
         });
+    } else {
+        //TODO: 에러를 던지는게 적절한지 고민
+        throw new Error('srcAttributes and targetAttributes must be of the same type');
     }
     return resArr;
 }


### PR DESCRIPTION
## 작업 내용 (Content)
- targetAttributes를 옵셔널로 받도록 변경
- 인자가 문자열로 들어와도 배열로 바꾸어 동일한 로직 사용하도록 변경
## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
