### PR TITLE
backend/DANG-887: custom pipe에서 value가 없을 경우 error 발생시키도록 코드 추가

### DIFF
--- a/backend/src/statistics/pipes/date-validation.pipe.ts
+++ b/backend/src/statistics/pipes/date-validation.pipe.ts
@@ -3,6 +3,10 @@ import { BadRequestException, Injectable, PipeTransform } from '@nestjs/common';
 @Injectable()
 export class DateValidationPipe implements PipeTransform<string, string> {
     transform(value: string): string {
+        if (!value) {
+            throw new BadRequestException('date query parameter is missing.');
+        }
+
         const dateFormat = /^\d{4}-\d{2}-\d{2}$/;
 
         if (!value.match(dateFormat)) {

--- a/backend/src/statistics/pipes/period-validation.pipe.ts
+++ b/backend/src/statistics/pipes/period-validation.pipe.ts
@@ -8,6 +8,10 @@ export class PeriodValidationPipe implements PipeTransform<Period, Period> {
     readonly allowedPeriods = allowedPeriods;
 
     transform(value: Period): Period {
+        if (!value) {
+            throw new BadRequestException('period query parameter is missing.');
+        }
+
         if (!this.allowedPeriods.includes(value)) {
             throw new BadRequestException(
                 `Invalid period: ${value}. Allowed periods are: ${this.allowedPeriods.join(', ')}`


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
따로 DTO를 이용한 validation 대신 각 parameter마다 custom pipe를 적용하고 있기 때문에 value가 없는 경우에 대해서도 처리해주었다.

## 링크 (Links)
https://www.notion.so/do0ori/Statistics-pipe-validation-b49aabc54cf24412b0aa284d324aba81

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
