### PR TITLE
backend/DANG-863: WinstonLogger의 log를 json 형식으로 변환 & log 형식 개선

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -38,7 +38,7 @@ export class AuthService {
         const { oauthId } = await this[`${provider}Service`].requestUserInfo(oauthAccessToken);
 
         const refreshToken = this.tokenService.signRefreshToken(oauthId, provider);
-        this.logger.debug(`login - signRefreshToken: ${refreshToken}`);
+        this.logger.debug('login - signRefreshToken', { refreshToken });
 
         try {
             const { id: userId } = await this.usersService.updateAndFindOne(
@@ -47,7 +47,7 @@ export class AuthService {
             );
 
             const accessToken = this.tokenService.signAccessToken(userId, provider);
-            this.logger.debug(`login - signAccessToken: ${accessToken}`);
+            this.logger.debug('login - signAccessToken', { accessToken });
 
             return { accessToken, refreshToken };
         } catch (error) {
@@ -64,7 +64,7 @@ export class AuthService {
             await this[`${provider}Service`].requestUserInfo(oauthAccessToken);
 
         const refreshToken = this.tokenService.signRefreshToken(oauthId, provider);
-        this.logger.debug(`signup - signRefreshToken: ${refreshToken}`);
+        this.logger.debug('signup - signRefreshToken', { refreshToken });
 
         const { id: userId } = await this.usersService.createIfNotExists({
             oauthNickname,
@@ -77,14 +77,14 @@ export class AuthService {
         });
 
         const accessToken = this.tokenService.signAccessToken(userId, provider);
-        this.logger.debug(`signup - signAccessToken: ${accessToken}`);
+        this.logger.debug('signup - signAccessToken', { accessToken });
 
         return { accessToken, refreshToken };
     }
 
     async logout({ userId, provider }: AccessTokenPayload): Promise<void> {
         const { oauthAccessToken } = await this.usersService.findOne({ id: userId });
-        this.logger.debug(`logout - oauthAccessToken: ${oauthAccessToken}`);
+        this.logger.debug('logout - oauthAccessToken', { oauthAccessToken });
 
         if (provider === 'kakao') {
             await this.kakaoService.requestTokenExpiration(oauthAccessToken);
@@ -135,7 +135,7 @@ export class AuthService {
     async validateAccessToken(userId: number): Promise<boolean> {
         try {
             const result = await this.usersService.findOne({ id: userId });
-            this.logger.debug(`validateAccessToken - find User result:\n${JSON.stringify(result, null, 2)}`);
+            this.logger.debug('validateAccessToken - find User result', { ...result });
 
             return true;
         } catch {

--- a/backend/src/auth/guards/auth.guard.ts
+++ b/backend/src/auth/guards/auth.guard.ts
@@ -36,7 +36,7 @@ export class AuthGuard implements CanActivate {
 
         try {
             const payload = this.tokenService.verify(token) as AccessTokenPayload;
-            this.logger.log(`Payload: ${JSON.stringify(payload)}`);
+            this.logger.log('Payload', payload);
 
             const isValid = await this.authService.validateAccessToken(payload.userId);
 

--- a/backend/src/auth/guards/refresh-token.guard.ts
+++ b/backend/src/auth/guards/refresh-token.guard.ts
@@ -18,7 +18,7 @@ export class RefreshTokenGuard implements CanActivate {
 
         if (!token) {
             const error = new UnauthorizedException('Refresh token not found in cookies.');
-            this.logger.error(`No refreshToken inside cookie.`, error.stack ?? 'No Stack');
+            this.logger.error(`No refreshToken inside cookie.`, error.stack ?? 'No stack');
             throw error;
         }
 
@@ -31,8 +31,9 @@ export class RefreshTokenGuard implements CanActivate {
             return isValid;
         } catch (error) {
             if (error instanceof TokenExpiredError || error instanceof JsonWebTokenError) {
+                const trace = error.stack ?? 'No stack';
                 error = new UnauthorizedException(error.message);
-                this.logger.error(error.message, error.stack ?? 'No stack');
+                this.logger.error(error.message, trace);
                 throw error;
             } else {
                 error = new UnauthorizedException('No matching user found.');

--- a/backend/src/auth/oauth/google.service.ts
+++ b/backend/src/auth/oauth/google.service.ts
@@ -57,10 +57,9 @@ export class GoogleService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error(
-                    `Google: Failed to request token. ${JSON.stringify(error.response.data)}`,
-                    error.stack ?? 'No stack'
-                );
+                this.logger.error('Google: Failed to request token.', error.stack ?? 'No stack', {
+                    response: error.response.data,
+                });
                 error = new BadRequestException('Google: Failed to request token.');
             }
             throw error;
@@ -77,7 +76,7 @@ export class GoogleService implements OauthService {
                 })
             );
 
-            this.logger.log(`requestUserInfo:\n${JSON.stringify(data, null, 2)}`);
+            this.logger.log('requestUserInfo', { ...data });
 
             return {
                 oauthId: data.id,
@@ -87,10 +86,9 @@ export class GoogleService implements OauthService {
             };
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error(
-                    `Google: Failed to request userInfo. ${JSON.stringify(error.response.data)}`,
-                    error.stack ?? 'No stack'
-                );
+                this.logger.error('Google: Failed to request userInfo.', error.stack ?? 'No stack', {
+                    response: error.response.data,
+                });
                 error = new BadRequestException('Google: Failed to request userInfo.');
             }
             throw error;
@@ -115,10 +113,9 @@ export class GoogleService implements OauthService {
             );
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error(
-                    `Google: Failed to request token expiration. ${JSON.stringify(error.response.data)}`,
-                    error.stack ?? 'No stack'
-                );
+                this.logger.error('Google: Failed to request token expiration.', error.stack ?? 'No stack', {
+                    response: error.response.data,
+                });
                 error = new BadRequestException('Google: Failed to request token expiration.');
             }
             throw error;
@@ -139,10 +136,9 @@ export class GoogleService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error(
-                    `Google: Failed to request token refresh. ${JSON.stringify(error.response.data)}`,
-                    error.stack ?? 'No stack'
-                );
+                this.logger.error('Google: Failed to request token refresh.', error.stack ?? 'No stack', {
+                    response: error.response.data,
+                });
                 error = new BadRequestException('Google: Failed to request token refresh.');
             }
             throw error;

--- a/backend/src/auth/oauth/kakao.service.ts
+++ b/backend/src/auth/oauth/kakao.service.ts
@@ -73,10 +73,9 @@ export class KakaoService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error(
-                    `Kakao: Failed to request token. ${JSON.stringify(error.response.data)}`,
-                    error.stack ?? 'No stack'
-                );
+                this.logger.error(`Kakao: Failed to request token.`, error.stack ?? 'No stack', {
+                    response: error.response.data,
+                });
                 error = new BadRequestException('Kakao: Failed to request token.');
             }
             throw error;
@@ -93,7 +92,7 @@ export class KakaoService implements OauthService {
                 })
             );
 
-            this.logger.log(`requestUserInfo:\n${JSON.stringify(data, null, 2)}`);
+            this.logger.log('requestUserInfo', { ...data });
 
             return {
                 oauthId: data.id.toString(),
@@ -103,10 +102,9 @@ export class KakaoService implements OauthService {
             };
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error(
-                    `Kakao: Failed to request userInfo. ${JSON.stringify(error.response.data)}`,
-                    error.stack ?? 'No stack'
-                );
+                this.logger.error('Kakao: Failed to request userInfo.', error.stack ?? 'No stack', {
+                    response: error.response.data,
+                });
                 error = new BadRequestException('Kakao: Failed to request userInfo.');
             }
             throw error;
@@ -129,10 +127,9 @@ export class KakaoService implements OauthService {
             );
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error(
-                    `Kakao: Failed to request token expiration. ${JSON.stringify(error.response.data)}`,
-                    error.stack ?? 'No stack'
-                );
+                this.logger.error('Kakao: Failed to request token expiration.', error.stack ?? 'No stack', {
+                    response: error.response.data,
+                });
                 error = new BadRequestException('Kakao: Failed to request token expiration.');
             }
             throw error;
@@ -155,10 +152,9 @@ export class KakaoService implements OauthService {
             );
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error(
-                    `Kakao: Failed to request unlink. ${JSON.stringify(error.response.data)}`,
-                    error.stack ?? 'No stack'
-                );
+                this.logger.error('Kakao: Failed to request unlink.', error.stack ?? 'No stack', {
+                    response: error.response.data,
+                });
                 error = new BadRequestException('Kakao: Failed to request unlink.');
             }
             throw error;
@@ -187,10 +183,9 @@ export class KakaoService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error(
-                    `Kakao: Failed to request token refresh. ${JSON.stringify(error.response.data)}`,
-                    error.stack ?? 'No stack'
-                );
+                this.logger.error('Kakao: Failed to request token refresh.', error.stack ?? 'No stack', {
+                    response: error.response.data,
+                });
                 error = new BadRequestException('Kakao: Failed to request token refresh.');
             }
             throw error;

--- a/backend/src/auth/oauth/naver.service.ts
+++ b/backend/src/auth/oauth/naver.service.ts
@@ -60,10 +60,9 @@ export class NaverService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error(
-                    `Naver: Failed to request token. ${JSON.stringify(error.response.data)}`,
-                    error.stack ?? 'No stack'
-                );
+                this.logger.error('Naver: Failed to request token.', error.stack ?? 'No stack', {
+                    response: error.response.data,
+                });
                 error = new BadRequestException('Naver: Failed to request token.');
             }
             throw error;
@@ -80,7 +79,7 @@ export class NaverService implements OauthService {
                 })
             );
 
-            this.logger.log(`requestUserInfo:\n${JSON.stringify(data, null, 2)}`);
+            this.logger.log('requestUserInfo', { ...data });
 
             return {
                 oauthId: data.response.id,
@@ -90,10 +89,9 @@ export class NaverService implements OauthService {
             };
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error(
-                    `Naver: Failed to request userInfo. ${JSON.stringify(error.response.data)}`,
-                    error.stack ?? 'No stack'
-                );
+                this.logger.error('Naver: Failed to request userInfo.', error.stack ?? 'No stack', {
+                    response: error.response.data,
+                });
                 error = new BadRequestException('Naver: Failed to request userInfo.');
             }
             throw error;
@@ -115,10 +113,9 @@ export class NaverService implements OauthService {
             );
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error(
-                    `Naver: Failed to request token expiration. ${JSON.stringify(error.response.data)}`,
-                    error.stack ?? 'No stack'
-                );
+                this.logger.error('Naver: Failed to request token expiration.', error.stack ?? 'No stack', {
+                    response: error.response.data,
+                });
                 error = new BadRequestException('Naver: Failed to request token expiration.');
             }
             throw error;
@@ -141,10 +138,9 @@ export class NaverService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error(
-                    `Naver: Failed to request token refresh. ${JSON.stringify(error.response.data)}`,
-                    error.stack ?? 'No stack'
-                );
+                this.logger.error('Naver: Failed to request token refresh.', error.stack ?? 'No stack', {
+                    response: error.response.data,
+                });
                 error = new BadRequestException('Naver: Failed to request token refresh.');
             }
             throw error;

--- a/backend/src/common/interceptors/logging.interceptor.ts
+++ b/backend/src/common/interceptors/logging.interceptor.ts
@@ -50,7 +50,7 @@ export class LoggingInterceptor implements NestInterceptor {
                     `${color('RESPONSE', 'Magenta')} [ ${bold(method)} | ${bold(url)} | ${ip} | ${statusCode} | ${color(`+${responseTime}ms`, responseTimeColor)} ] ${color(requestId, 'Black')}`
                 );
 
-                this.logger.debug(`Response Object:\n${JSON.stringify(res, null, 2)}`);
+                this.logger.debug('Response body', { ...res });
             })
         );
     }

--- a/backend/src/common/logger/winstonLogger.service.ts
+++ b/backend/src/common/logger/winstonLogger.service.ts
@@ -16,14 +16,10 @@ export class WinstonLoggerService implements LoggerService {
             fs.mkdirSync(logDir, { recursive: true });
         }
 
-        const consoleLogFormat = winston.format.printf(({ timestamp, level, message }) => {
+        const consoleLogFormat = winston.format.printf(({ timestamp, level, message, ...meta }) => {
             const seoulTimestamp = new Date(timestamp).toLocaleString('ko-KR');
-            return `${seoulTimestamp} | ${level}| ${message}`;
-        });
-
-        const fileLogFormat = winston.format.printf(({ timestamp, level, message }) => {
-            const seoulTimestamp = new Date(timestamp).toLocaleString('ko-KR');
-            return `${seoulTimestamp} | ${level}| ${stripAnsi(message)}`;
+            const metaString = Object.keys(meta).length > 0 ? `\n${JSON.stringify(meta, null, 2)}` : '';
+            return `${seoulTimestamp} | ${level}| ${message}${metaString}`;
         });
 
         const consoleFormat = winston.format.combine(
@@ -42,9 +38,9 @@ export class WinstonLoggerService implements LoggerService {
             maxSize: '20m',
             maxFiles: '14d',
             format: winston.format.combine(
-                winston.format((info) => ({ ...info, level: info.level.toUpperCase().padEnd(7) }))(),
+                winston.format((info) => ({ ...info, message: stripAnsi(info.message) }))(),
                 winston.format.timestamp(),
-                fileLogFormat
+                winston.format.json()
             ),
         });
 
@@ -56,9 +52,9 @@ export class WinstonLoggerService implements LoggerService {
             maxFiles: '14d',
             level: 'error',
             format: winston.format.combine(
-                winston.format((info) => ({ ...info, level: info.level.toUpperCase().padEnd(7) }))(),
+                winston.format((info) => ({ ...info, message: stripAnsi(info.message) }))(),
                 winston.format.timestamp(),
-                fileLogFormat
+                winston.format.json()
             ),
         });
 
@@ -71,19 +67,19 @@ export class WinstonLoggerService implements LoggerService {
         });
     }
 
-    log(message: string) {
-        this.logger.info(message);
+    log(message: string, meta?: any) {
+        this.logger.info(message, meta);
     }
 
-    error(message: string, trace: string) {
-        this.logger.error(message, { trace });
+    error(message: string, trace: string, meta?: any) {
+        this.logger.error(message, { trace, ...meta });
     }
 
-    warn(message: string) {
-        this.logger.warn(message);
+    warn(message: string, meta?: any) {
+        this.logger.warn(message, meta);
     }
 
-    debug(message: string, ...meta: any[]) {
+    debug(message: string, meta?: any) {
         this.logger.debug(message, meta);
     }
 }


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- log format을 text에서 json으로 변환하여 Loki에서 log data를 json 형태로 다룰 수 있도록 했다.
- 각 level method에 `meta` parameter를 추가하여 원하는 field를 동적으로 log에 포함시킬 수 있도록 했다.
- console에서 meta parameter가 보기 좋게 출력되도록 consoleLogFormat 함수를 개선했다.
- 바뀐 log method에 맞게 존재하는 모든 log 업데이트

### Before
  ```log
  2024. 5. 31. 오후 9:46:17 | INFO   | AppController {/}:
  2024. 5. 31. 오후 9:46:17 | INFO   | Mapped {/, GET} route
  2024. 5. 31. 오후 9:46:17 | INFO   | HealthController {/health}:
  2024. 5. 31. 오후 9:46:17 | INFO   | Mapped {/health, GET} route
  ```
### After
  ```log
  {"level":"info","message":"AppController {/}:","timestamp":"2024-05-31T12:32:00.956Z"}
  {"level":"info","message":"Mapped {/, GET} route","timestamp":"2024-05-31T12:32:00.957Z"}
  {"level":"info","message":"HealthController {/health}:","timestamp":"2024-05-31T12:32:00.957Z"}
  {"level":"info","message":"Mapped {/health, GET} route","timestamp":"2024-05-31T12:32:00.958Z"}
  ```

## 링크 (Links)
https://www.notion.so/do0ori/WinstonLogger-log-json-log-8fffbf3191dc478c8aea97c653561915

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
