### PR TITLE
backend/DANG-868: journlas validation 추가

### DIFF
--- a/backend/src/excrements/excrements.service.ts
+++ b/backend/src/excrements/excrements.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@nestjs/common';
-import { Location } from 'src/journals/types/create-journal-data.type';
+import { Location } from 'src/journals/dtos/create-journal.dto';
 import { DeleteResult, FindManyOptions, FindOptionsWhere, UpdateResult } from 'typeorm';
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { Excrements } from './excrements.entity';

--- a/backend/src/journals/dtos/create-journal.dto.ts
+++ b/backend/src/journals/dtos/create-journal.dto.ts
@@ -1,21 +1,21 @@
 import { Type } from 'class-transformer';
-import {
-    IsArray,
-    IsDefined,
-    IsNotEmpty,
-    IsNotEmptyObject,
-    IsNumber,
-    IsOptional,
-    IsString,
-    ValidateNested,
-} from 'class-validator';
-// TODO: 문자열이면서 숫자 범위를 넘지 않는지 확인하는 custom Validator 만들기..?
+import { IsArray, IsDefined, IsNotEmpty, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsWGS84 } from '../validator/WGS84.validator';
 export class Location {
-    @IsNumber()
+    @IsWGS84({ message: 'The provided point is not in WGS84 format' })
     lat: string;
 
-    @IsNumber()
+    @IsWGS84({ message: 'The provided point is not in WGS84 format' })
     lng: string;
+}
+
+//TODO: GeoJSON으로 넘어가기 전 임시로 사용
+export class journalLocation {
+    @IsNumber()
+    lat: number;
+
+    @IsNumber()
+    lng: number;
 }
 
 export class ExcrementsInfoForCreate {
@@ -49,8 +49,8 @@ export class JournalInfoForCreate {
 
     @IsArray()
     @ValidateNested()
-    @Type(() => Location)
-    routes: Location[];
+    @Type(() => journalLocation)
+    routes: journalLocation[];
 
     @IsOptional()
     memo: string;
@@ -61,18 +61,15 @@ export class JournalInfoForCreate {
 }
 
 export class CreateJournalDto {
-    @IsNotEmpty()
+    @IsDefined()
     dogs: number[];
 
     @IsDefined()
-    @IsNotEmptyObject()
-    @IsNotEmpty()
     @ValidateNested()
     @Type(() => JournalInfoForCreate)
     journalInfo: JournalInfoForCreate;
 
     @IsOptional()
-    @IsDefined()
     @ValidateNested()
     @Type(() => ExcrementsInfoForCreate)
     excrements: ExcrementsInfoForCreate[];

--- a/backend/src/journals/dtos/create-journal.dto.ts
+++ b/backend/src/journals/dtos/create-journal.dto.ts
@@ -1,11 +1,24 @@
 import { Type } from 'class-transformer';
-import { IsArray, IsDefined, IsNotEmpty, IsNumber, IsOptional, IsString, ValidateNested } from 'class-validator';
+import {
+    IsArray,
+    IsDateString,
+    IsNotEmpty,
+    IsNumber,
+    IsOptional,
+    IsString,
+    Max,
+    Min,
+    ValidateNested,
+} from 'class-validator';
 import { IsWGS84 } from '../validator/WGS84.validator';
+
 export class Location {
     @IsWGS84({ message: 'The provided point is not in WGS84 format' })
+    @IsString()
     lat: string;
 
     @IsWGS84({ message: 'The provided point is not in WGS84 format' })
+    @IsString()
     lng: string;
 }
 
@@ -35,17 +48,24 @@ export class ExcrementsInfoForCreate {
 
 export class JournalInfoForCreate {
     @IsNotEmpty()
+    @Max(100000) //TODO: 합의 필요
+    @Min(0)
     distance: number;
 
     @IsNotEmpty()
+    @Max(10800) //TODO: 합의 필요
+    @Min(0)
     calories: number;
 
     @IsNotEmpty()
+    @IsDateString()
     startedAt: Date;
 
-    //TODO: validation 완성되면 number로 변경
     @IsNotEmpty()
-    duration: string;
+    @IsNumber()
+    @Max(10800) //TODO: 합의 필요
+    @Min(0)
+    duration: number;
 
     @IsArray()
     @ValidateNested()
@@ -53,23 +73,28 @@ export class JournalInfoForCreate {
     routes: journalLocation[];
 
     @IsOptional()
+    @IsString()
     memo: string;
 
     @IsOptional()
+    @IsArray()
     @IsString({ each: true })
     photoUrls: string[];
 }
 
 export class CreateJournalDto {
-    @IsDefined()
+    @IsNotEmpty()
+    @IsArray()
+    @IsNumber({}, { each: true })
     dogs: number[];
 
-    @IsDefined()
+    @IsNotEmpty()
     @ValidateNested()
     @Type(() => JournalInfoForCreate)
     journalInfo: JournalInfoForCreate;
 
     @IsOptional()
+    @IsArray()
     @ValidateNested()
     @Type(() => ExcrementsInfoForCreate)
     excrements: ExcrementsInfoForCreate[];

--- a/backend/src/journals/dtos/update-journal.dto.ts
+++ b/backend/src/journals/dtos/update-journal.dto.ts
@@ -1,11 +1,12 @@
-import { IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsArray, IsOptional, IsString } from 'class-validator';
 
 export class UpdateJournalDto {
     @IsOptional()
+    @IsString()
     memo: string;
 
     @IsOptional()
-    @ValidateNested()
+    @IsArray()
     @IsString({ each: true })
     photoUrls: string[];
 }

--- a/backend/src/journals/journals.controller.ts
+++ b/backend/src/journals/journals.controller.ts
@@ -1,4 +1,17 @@
-import { Body, Controller, Delete, Get, Param, ParseIntPipe, Patch, Post, Query, UseGuards } from '@nestjs/common';
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    Param,
+    ParseIntPipe,
+    Patch,
+    Post,
+    Query,
+    UseGuards,
+    UsePipes,
+    ValidationPipe,
+} from '@nestjs/common';
 import { AccessTokenPayload } from 'src/auth/token/token.service';
 import { DateValidationPipe } from 'src/statistics/pipes/date-validation.pipe';
 import { User } from 'src/users/decorators/user.decorator';
@@ -9,6 +22,7 @@ import { JournalsService } from './journals.service';
 import { JournalInfoForList } from './types/journal-info.type';
 
 @Controller('/journals')
+@UsePipes(new ValidationPipe({ validateCustomDecorators: true }))
 export class JournalsController {
     constructor(private readonly journalsService: JournalsService) {}
 

--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -207,7 +207,7 @@ export class JournalsService {
         await this.updateDogWalkDay(dogIds, (current: number) => (current += 1));
         await this.updateTodayWalkTime(
             dogIds,
-            parseInt(createJournalData.journalInfo.duration),
+            createJournalData.journalInfo.duration,
             (current: number, value: number) => current + value
         );
     }

--- a/backend/src/journals/journals.service.ts
+++ b/backend/src/journals/journals.service.ts
@@ -198,9 +198,11 @@ export class JournalsService {
         const photoUrls = this.checkPhotoUrlExist(createJournalData.journalInfo.photoUrls);
         await this.journalPhotosService.createNewPhotoUrls(createJournalResult.id, photoUrls);
 
-        const excrements: CreateExcrementsInfo[] = createJournalData.excrements;
-        if (excrements.length) {
-            await this.excrementsLoop(createJournalResult.id, excrements);
+        if (createJournalData.excrements) {
+            const excrements: CreateExcrementsInfo[] = createJournalData.excrements;
+            if (excrements.length) {
+                await this.excrementsLoop(createJournalResult.id, excrements);
+            }
         }
         await this.updateDogWalkDay(dogIds, (current: number) => (current += 1));
         await this.updateTodayWalkTime(

--- a/backend/src/journals/types/create-journal-data.type.ts
+++ b/backend/src/journals/types/create-journal-data.type.ts
@@ -10,7 +10,7 @@ export class CreateJournalInfo {
     distance: number;
     calories: number;
     startedAt: Date;
-    duration: string; //TODO: validation 완성되면 number로 변경
+    duration: number;
     routes: journalLocation[];
     memo: string;
     photoUrls: string[];

--- a/backend/src/journals/types/create-journal-data.type.ts
+++ b/backend/src/journals/types/create-journal-data.type.ts
@@ -1,7 +1,4 @@
-export interface Location {
-    lat: string;
-    lng: string;
-}
+import { Location, journalLocation } from '../dtos/create-journal.dto';
 
 export interface CreateExcrementsInfo {
     dogId: number;
@@ -14,7 +11,7 @@ export class CreateJournalInfo {
     calories: number;
     startedAt: Date;
     duration: string; //TODO: validation 완성되면 number로 변경
-    routes: Location[];
+    routes: journalLocation[];
     memo: string;
     photoUrls: string[];
 

--- a/backend/src/journals/validator/WGS84.validator.ts
+++ b/backend/src/journals/validator/WGS84.validator.ts
@@ -1,0 +1,27 @@
+import {
+    ValidationArguments,
+    ValidationOptions,
+    ValidatorConstraint,
+    ValidatorConstraintInterface,
+    registerDecorator,
+} from 'class-validator';
+
+@ValidatorConstraint({ async: false })
+export class IsWGS84Constraint implements ValidatorConstraintInterface {
+    private regexWgs84 = /^-?\d+\.*\d*/;
+    validate(point: string, validationArguments?: ValidationArguments | undefined): boolean {
+        return this.regexWgs84.test(point);
+    }
+}
+
+export function IsWGS84(validationOptions?: ValidationOptions) {
+    return function (object: object, propertyName: string) {
+        registerDecorator({
+            target: object.constructor,
+            propertyName: propertyName,
+            options: validationOptions,
+            constraints: [],
+            validator: IsWGS84Constraint,
+        });
+    };
+}


### PR DESCRIPTION
## 작업 내용 (Content)
- journals에 validation pipe 적용, 부족한 데코레이터 보완
- WGS84 좌표계 확인하는 custom validator 추가
    - class-validator에도 위도, 경도를 확인하는 @IsLatitude, @IsLatitude()  데코레이터가 있지만 
        GPS에서 사용하는 WGS84 좌표계가 아닌 DM, DMS 형식을 기반으로 해서 맞지 않음
        간단하게 앞에마이너스 부호와, 중간에 소숫점을 허용하도록 하는 정규표현식을 사용해 구현함
- 일지 생성시 excrements가 없는 경우에 대한 분기 처리가 안되어있어 추가

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
