### PR TITLE
frontend/DANG-904: 비로그인상태에서 getRefreshToken api 호출하지 않기

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,11 +1,21 @@
 import { httpClient } from './http';
+import { getStorage } from '@/utils/storage';
+import { tokenKeys } from '@/constants';
+import { AxiosResponse } from 'axios';
 
 export type ResponseToken = {
     accessToken: string;
 };
 
-const getAccessToken = async (): Promise<ResponseToken> => {
-    const { data } = await httpClient.get('/auth/token');
+const getAccessToken = async (): Promise<ResponseToken | undefined> => {
+    const isLoggedIn = getStorage(tokenKeys.AUTHORIZATION) ? true : false;
+    let data: ResponseToken | undefined;
+
+    if (isLoggedIn) {
+        const response: AxiosResponse = await httpClient.get('/auth/token');
+        data = response.data;
+    }
+
     return data;
 };
 

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -67,7 +67,7 @@ const useGetRefreshToken = () => {
     });
     useEffect(() => {
         if (isSuccess) {
-            storeLogin(data.accessToken);
+            storeLogin(data?.accessToken);
         }
     }, [isSuccess, data]);
 

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -4,12 +4,12 @@ import { getStorage, removeStorage, setStorage } from '@/utils/storage';
 import { create } from 'zustand';
 interface AuthState {
     isLoggedIn: boolean;
-    storeLogin: (token: string) => void;
+    storeLogin: (token: string | undefined) => void;
     storeLogout: () => void;
 }
 export const useAuthStore = create<AuthState>((set) => ({
     isLoggedIn: getStorage(tokenKeys.AUTHORIZATION) ? true : false,
-    storeLogin: (token: string) => {
+    storeLogin: (token: string | undefined) => {
         set({ isLoggedIn: true });
         setHeader(tokenKeys.AUTHORIZATION, `Bearer ${token}`);
         setStorage(tokenKeys.AUTHORIZATION, `Bearer ${token}`);


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
비로그인상태에서 getRefreshToken api 호출되는 문제 
로그인 상태로 조건부로 api 호출하기
## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
