### PR TITLE
frontend/DANG-905: useDogsStatistic: getRefreshToken 의존성 (enabled) 삭제

### DIFF
--- a/frontend/src/hooks/useDogsStatistic.ts
+++ b/frontend/src/hooks/useDogsStatistic.ts
@@ -1,5 +1,6 @@
 import { fetchDogStatistic } from '@/api/dogs';
 import { DogStatistic } from '@/models/dog.model';
+import { useAuthStore } from '@/store/authStore';
 import { UseQueryCustomOptions } from '@/types/common';
 import { useQuery } from '@tanstack/react-query';
 const { REACT_APP_BASE_IMAGE_URL = '' } = window._ENV ?? process.env;
@@ -23,7 +24,8 @@ const defaultDpgs: DogStatistic[] = [
     },
 ];
 
-const useDogsStatistic = (isLoggedIn: boolean, queryOptions?: UseQueryCustomOptions) => {
+const useDogsStatistic = (queryOptions?: UseQueryCustomOptions) => {
+    const { isLoggedIn } = useAuthStore();
     const { data, isPending } = useQuery({
         queryKey: ['dog-statistic'],
         queryFn: async () => {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -11,10 +11,8 @@ import useDogsStatistic from '@/hooks/useDogsStatistic';
 import { useNavigate } from 'react-router-dom';
 import useWalkAvailabeDog from '@/hooks/useWalkAvailabeDog';
 import Spinner from '@/components/common/Spinner';
-import { useAuth } from '@/hooks/useAuth';
 import RegisterCard from '@/components/home/RegisterCard';
 import { queryStringKeys } from '@/constants';
-import { useAuthStore } from '@/store/authStore';
 
 function Home() {
     const [isDogBottomsheetOpen, setIsDogBottomsheetOpen] = useState<boolean>(false);

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -25,11 +25,7 @@ function Home() {
         toggleCheck: handleToggle,
         changeCheckAll: handleCheckAll,
     } = useWalkAvailabeDog();
-    const { refreshTokenQuery } = useAuth();
-    const { isLoggedIn } = useAuthStore();
-    const { dogs, isDogsPending } = useDogsStatistic(isLoggedIn, {
-        enabled: refreshTokenQuery.isSuccess,
-    });
+    const { dogs, isDogsPending } = useDogsStatistic();
     const navigate = useNavigate();
     const handleBottomSheet = () => {
         if (!isDogBottomsheetOpen) {


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
accesstoken 비동기 이슈로 인해 useDogsStatistic에 enabled 옵션으로 getRefreshToken와의 의존성 삭제
## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
