### PR TITLE
backend/DANG-915: 산책일지 목록에서 journalId를 리턴하지 않는 버그 수정

### DIFF
--- a/backend/src/utils/manipulate.util.ts
+++ b/backend/src/utils/manipulate.util.ts
@@ -31,27 +31,12 @@ export function checkIfExistsInArr<T>(targetArr: T[], toFind: T | T[]): boolean 
  * @param {(string|string[])} srcAttributes - 소스 배열의 각 요소에서 속성을 추출할 속성 이름입니다.
  * 단일 문자열 또는 속성 이름의 배열을 받을 수 있습니다.
  * @returns {any[]} 결과 객체들의 배열입니다.
- *
- * @example
- * const data = [
- *     { id: 1, name: 'Alice', age: 30 },
- *     { id: 2, name: 'Bob', age: 25 }
- * ];
- * const targetAttrs = ['name'];
- * const srcAttrs = ['age'];
- * const result = makeSubObjectsArray(data, targetAttrs, srcAttrs);
- * console.log(result);
- * // 출력:
- * // [
- * //     { name: 30 },
- * //     { name: 25 }
- * // ]
- */
+ **/
 
 export function makeSubObjectsArray(
     targetArr: any[],
     srcAttributes: string | string[],
-    newAttributes?: string | string[]
+    newAttributes?: string | string[],
 ): any[] {
     const resArr: any[] = [];
     newAttributes = newAttributes ?? srcAttributes;

--- a/backend/src/utils/manipulate.util.ts
+++ b/backend/src/utils/manipulate.util.ts
@@ -26,7 +26,7 @@ export function checkIfExistsInArr<T>(targetArr: T[], toFind: T | T[]): boolean 
  * 생성된 객체들은 최종 결과 배열에 추가됩니다.
  *
  * @param {any[]} targetArr - 속성을 추출할 소스 배열입니다.
- * @param {(string|string[])} targetAttributes - 결과 객체의 키로 사용할 속성 이름입니다.
+ * @param {(string|string[])} newAttributes - 결과 객체의 키로 사용할 속성 이름입니다.
  * 단일 문자열 또는 속성 이름의 배열을 받을 수 있습니다.
  * @param {(string|string[])} srcAttributes - 소스 배열의 각 요소에서 속성을 추출할 속성 이름입니다.
  * 단일 문자열 또는 속성 이름의 배열을 받을 수 있습니다.
@@ -51,19 +51,20 @@ export function checkIfExistsInArr<T>(targetArr: T[], toFind: T | T[]): boolean 
 export function makeSubObjectsArray(
     targetArr: any[],
     srcAttributes: string | string[],
-    targetAttributes?: string | string[],
+    newAttributes?: string | string[]
 ): any[] {
     const resArr: any[] = [];
-    targetAttributes = targetAttributes ?? srcAttributes;
+    newAttributes = newAttributes ?? srcAttributes;
     Array.isArray(srcAttributes) ? srcAttributes : [srcAttributes];
-    Array.isArray(targetAttributes) ? targetAttributes : [targetAttributes];
-    if (srcAttributes.length != targetAttributes.length) {
+    Array.isArray(newAttributes) ? newAttributes : [newAttributes];
+
+    if (srcAttributes.length != newAttributes.length) {
         throw new Error('srcAttributes and targetAttributes must have same length');
     }
     targetArr.map((cur) => {
         const obj: { [key: string]: any } = {};
         for (let i = 0; i < srcAttributes.length; i++) {
-            obj[`${targetAttributes[i]}`] = cur[`${srcAttributes[i]}`];
+            obj[`${srcAttributes[i]}`] = cur[`${newAttributes[i]}`];
         }
         resArr.push(obj);
     });


### PR DESCRIPTION
## 작업 내용 (Content)
makeSubObjectsArray 함수에서 할당시 src와 target의 위치가 바뀌어 생긴 문제
변수명이 헷갈리는것같아 원래 객체의 속성 : srcAttributes, 새로 만들 객체의 속성 : newAttributes로 수정함

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [ ] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [ ] 마지막 줄에 공백 처리를 하셨나요?
- [ ] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [ ] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
