### PR TITLE
backend/DANG-913: ERROR 로그에서 원치 않는 메타 데이터 찍히는 버그 해결하기

### DIFF
--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -1,6 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AppController } from './app.controller';
-import { AppService } from './app.service';
 
 describe('AppController', () => {
     let appController: AppController;
@@ -8,7 +7,6 @@ describe('AppController', () => {
     beforeEach(async () => {
         const app: TestingModule = await Test.createTestingModule({
             controllers: [AppController],
-            providers: [AppService],
         }).compile();
 
         appController = app.get<AppController>(AppController);

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -54,7 +54,7 @@ export class AuthService {
             if (error instanceof NotFoundException) {
                 return { oauthAccessToken, oauthRefreshToken, provider };
             }
-            this.logger.error(`Login error`, error.stack ?? 'No stack');
+            this.logger.error(`Login error`, { trace: error.stack ?? 'No stack' });
             throw error;
         }
     }

--- a/backend/src/auth/guards/auth.guard.ts
+++ b/backend/src/auth/guards/auth.guard.ts
@@ -34,7 +34,7 @@ export class AuthGuard implements CanActivate {
         const token = this.extractTokenFromHeader(request);
         if (!token) {
             const error = new UnauthorizedException('Token does not exist in Authorization header.');
-            this.logger.error(`Authorization header is missing or empty.`, error.stack ?? 'No stack');
+            this.logger.error(`Authorization header is missing or empty.`, { trace: error.stack ?? 'No stack' });
             throw error;
         }
 
@@ -50,11 +50,11 @@ export class AuthGuard implements CanActivate {
         } catch (error) {
             if (error instanceof TokenExpiredError || error instanceof JsonWebTokenError) {
                 error = new UnauthorizedException(error.message);
-                this.logger.error(error.message, error.stack ?? 'No stack');
+                this.logger.error(error.message, { trace: error.stack ?? 'No stack' });
                 throw error;
             } else {
                 error = new UnauthorizedException('No matching user found.');
-                this.logger.error(`No matching user found`, error.stack ?? 'No stack');
+                this.logger.error(`No matching user found`, { trace: error.stack ?? 'No stack' });
                 throw error;
             }
         }

--- a/backend/src/auth/guards/oauth-data.guard.ts
+++ b/backend/src/auth/guards/oauth-data.guard.ts
@@ -20,7 +20,7 @@ export class OauthDataGuard implements CanActivate {
                 .join(', ');
 
             const error = new UnauthorizedException(`OAuth data missing in cookies: ${missingFields}.`);
-            this.logger.error(`OAuthDataGuard failed: missing ${missingFields}.`, error.stack ?? 'No stack');
+            this.logger.error(`OAuthDataGuard failed: missing ${missingFields}.`, { trace: error.stack ?? 'No stack' });
             throw error;
         }
         request.oauthData = { oauthAccessToken, oauthRefreshToken, provider };

--- a/backend/src/auth/guards/refresh-token.guard.ts
+++ b/backend/src/auth/guards/refresh-token.guard.ts
@@ -18,7 +18,7 @@ export class RefreshTokenGuard implements CanActivate {
 
         if (!token) {
             const error = new UnauthorizedException('Refresh token not found in cookies.');
-            this.logger.error(`No refreshToken inside cookie.`, error.stack ?? 'No stack');
+            this.logger.error(`No refreshToken inside cookie.`, { trace: error.stack ?? 'No stack' });
             throw error;
         }
 
@@ -31,13 +31,13 @@ export class RefreshTokenGuard implements CanActivate {
             return isValid;
         } catch (error) {
             if (error instanceof TokenExpiredError || error instanceof JsonWebTokenError) {
-                const trace = error.stack ?? 'No stack';
+                const trace = { trace: error.stack ?? 'No stack' };
                 error = new UnauthorizedException(error.message);
                 this.logger.error(error.message, trace);
                 throw error;
             } else {
                 error = new UnauthorizedException('No matching user found.');
-                this.logger.error(`No matching user found`, error.stack ?? 'No stack');
+                this.logger.error(`No matching user found`, { trace: error.stack ?? 'No stack' });
                 throw error;
             }
         }

--- a/backend/src/auth/oauth/google.service.ts
+++ b/backend/src/auth/oauth/google.service.ts
@@ -57,7 +57,8 @@ export class GoogleService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Google: Failed to request token.', error.stack ?? 'No stack', {
+                this.logger.error('Google: Failed to request token.', {
+                    trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
                 error = new BadRequestException('Google: Failed to request token.');
@@ -86,7 +87,8 @@ export class GoogleService implements OauthService {
             };
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Google: Failed to request userInfo.', error.stack ?? 'No stack', {
+                this.logger.error('Google: Failed to request userInfo.', {
+                    trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
                 error = new BadRequestException('Google: Failed to request userInfo.');
@@ -113,7 +115,8 @@ export class GoogleService implements OauthService {
             );
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Google: Failed to request token expiration.', error.stack ?? 'No stack', {
+                this.logger.error('Google: Failed to request token expiration.', {
+                    trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
                 error = new BadRequestException('Google: Failed to request token expiration.');
@@ -136,7 +139,8 @@ export class GoogleService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Google: Failed to request token refresh.', error.stack ?? 'No stack', {
+                this.logger.error('Google: Failed to request token refresh.', {
+                    trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
                 error = new BadRequestException('Google: Failed to request token refresh.');

--- a/backend/src/auth/oauth/kakao.service.ts
+++ b/backend/src/auth/oauth/kakao.service.ts
@@ -73,7 +73,8 @@ export class KakaoService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error(`Kakao: Failed to request token.`, error.stack ?? 'No stack', {
+                this.logger.error(`Kakao: Failed to request token.`, {
+                    trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
                 error = new BadRequestException('Kakao: Failed to request token.');
@@ -102,7 +103,8 @@ export class KakaoService implements OauthService {
             };
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Kakao: Failed to request userInfo.', error.stack ?? 'No stack', {
+                this.logger.error('Kakao: Failed to request userInfo.', {
+                    trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
                 error = new BadRequestException('Kakao: Failed to request userInfo.');
@@ -127,7 +129,8 @@ export class KakaoService implements OauthService {
             );
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Kakao: Failed to request token expiration.', error.stack ?? 'No stack', {
+                this.logger.error('Kakao: Failed to request token expiration.', {
+                    trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
                 error = new BadRequestException('Kakao: Failed to request token expiration.');
@@ -152,7 +155,8 @@ export class KakaoService implements OauthService {
             );
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Kakao: Failed to request unlink.', error.stack ?? 'No stack', {
+                this.logger.error('Kakao: Failed to request unlink.', {
+                    trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
                 error = new BadRequestException('Kakao: Failed to request unlink.');
@@ -183,7 +187,8 @@ export class KakaoService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Kakao: Failed to request token refresh.', error.stack ?? 'No stack', {
+                this.logger.error('Kakao: Failed to request token refresh.', {
+                    trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
                 error = new BadRequestException('Kakao: Failed to request token refresh.');

--- a/backend/src/auth/oauth/naver.service.ts
+++ b/backend/src/auth/oauth/naver.service.ts
@@ -60,7 +60,8 @@ export class NaverService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Naver: Failed to request token.', error.stack ?? 'No stack', {
+                this.logger.error('Naver: Failed to request token.', {
+                    trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
                 error = new BadRequestException('Naver: Failed to request token.');
@@ -89,7 +90,8 @@ export class NaverService implements OauthService {
             };
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Naver: Failed to request userInfo.', error.stack ?? 'No stack', {
+                this.logger.error('Naver: Failed to request userInfo.', {
+                    trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
                 error = new BadRequestException('Naver: Failed to request userInfo.');
@@ -113,7 +115,8 @@ export class NaverService implements OauthService {
             );
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Naver: Failed to request token expiration.', error.stack ?? 'No stack', {
+                this.logger.error('Naver: Failed to request token expiration.', {
+                    trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
                 error = new BadRequestException('Naver: Failed to request token expiration.');
@@ -138,7 +141,8 @@ export class NaverService implements OauthService {
             return data;
         } catch (error) {
             if (axios.isAxiosError(error) && error.response) {
-                this.logger.error('Naver: Failed to request token refresh.', error.stack ?? 'No stack', {
+                this.logger.error('Naver: Failed to request token refresh.', {
+                    trace: error.stack ?? 'No stack',
                     response: error.response.data,
                 });
                 error = new BadRequestException('Naver: Failed to request token refresh.');

--- a/backend/src/common/logger/winstonLogger.service.ts
+++ b/backend/src/common/logger/winstonLogger.service.ts
@@ -71,8 +71,8 @@ export class WinstonLoggerService implements LoggerService {
         this.logger.info(message, meta);
     }
 
-    error(message: string, trace: string, meta?: any) {
-        this.logger.error(message, { trace, ...meta });
+    error(message: string, meta: any) {
+        this.logger.error(message, meta);
     }
 
     warn(message: string, meta?: any) {

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -49,7 +49,7 @@ export class DogsService {
 
             return this.usersDogsService.create({ userId, dogId: dog.id });
         } catch (error) {
-            this.logger.error(`Unknown breed.`, error.stack ?? 'No stack');
+            this.logger.error(`Unknown breed.`, { trace: error.stack ?? 'No stack' });
             throw error;
         }
     }

--- a/backend/src/dogs/guards/auth-dog.guard.ts
+++ b/backend/src/dogs/guards/auth-dog.guard.ts
@@ -18,7 +18,7 @@ export class AuthDogGuard implements CanActivate {
 
         if (!owned) {
             const error = new ForbiddenException(`User ${userId} does not own the dog ${dogId}.`);
-            this.logger.error(`User ${userId} does not own the dog ${dogId}.`, error.stack ?? 'No stack');
+            this.logger.error(`User ${userId} does not own the dog ${dogId}.`, { trace: error.stack ?? 'No stack' });
             throw error;
         }
 

--- a/backend/src/journals/guards/auth-journal.guard.ts
+++ b/backend/src/journals/guards/auth-journal.guard.ts
@@ -18,7 +18,9 @@ export class AuthJournalGuard implements CanActivate {
 
         if (!owned) {
             const error = new ForbiddenException(`User ${userId} does not have access to journal ${journalId}`);
-            this.logger.error(`User ${userId} does not have access to journal ${journalId}`, error.stack ?? 'No stack');
+            this.logger.error(`User ${userId} does not have access to journal ${journalId}`, {
+                trace: error.stack ?? 'No stack',
+            });
             throw error;
         }
 

--- a/backend/src/statistics/statistics.service.ts
+++ b/backend/src/statistics/statistics.service.ts
@@ -90,7 +90,7 @@ export class StatisticsService {
             const error = new NotFoundException(`Data missing or mismatched for dogId: ${ownDogIds}.`);
             this.logger.error(
                 `Data missing or mismatched for dogId: ${ownDogIds}. Expected length: ${length}. Mismatched data: ${mismatchedLengths.join(', ')}`,
-                error.stack ?? 'No stack',
+                { trace: error.stack ?? 'No stack' },
             );
             throw error;
         }

--- a/backend/src/today-walk-time/today-walk-time.service.ts
+++ b/backend/src/today-walk-time/today-walk-time.service.ts
@@ -39,7 +39,9 @@ export class TodayWalkTimeService {
         const walkTimeListBeforeCheck = await this.todayWalkTimeRepository.find({ where: { id: In(walkTimeIds) } });
         if (!walkTimeListBeforeCheck.length) {
             const error = new NotFoundException(`No walkTime found for the provided IDs: ${walkTimeIds}.`);
-            this.logger.error(`No walkTime found for the provided IDs: ${walkTimeIds}.`, error.stack ?? 'No stack');
+            this.logger.error(`No walkTime found for the provided IDs: ${walkTimeIds}.`, {
+                trace: error.stack ?? 'No stack',
+            });
             throw error;
         }
 


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
- meta parameter가 string일 때 `…meta`를 하게 되면 (index: 문자) 형태로 spread되어 버리는 것이 원인이었다.
- trace까지 포함해서 meta parameter로 받도록 한다.
- `this.logger.error('error message', { trace: 'trace' })`와 같이 사용하면 된다.

## 링크 (Links)
https://www.notion.so/do0ori/ERROR-79a0a23df9814ba28e5627b6cfecf659

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
