### PR TITLE
frontend/DANG-903: accessToken 설정을 custom axios interceptor에서 관리하기

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,8 +3,10 @@ import { useEffect } from 'react';
 import { Outlet } from 'react-router-dom';
 import { useSpinnerStore } from '@/store/spinnerStore';
 import Spinner from '@/components/common/Spinner';
+import { useAuth } from '@/hooks/useAuth';
 // var console;
 function App() {
+    useAuth();
     const { spinner } = useSpinnerStore();
     //TODO: 일시적인 배포시 console.log 제거 추가로 환경설정으로 빼줘야함ㄴ
     // if (process.env.NODE_ENV === 'production') {

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,18 +1,17 @@
 import { httpClient } from './http';
 import { getStorage } from '@/utils/storage';
-import { tokenKeys } from '@/constants';
-import { AxiosResponse } from 'axios';
+import { storageKeys } from '@/constants';
 
 export type ResponseToken = {
     accessToken: string;
 };
 
 const getAccessToken = async (): Promise<ResponseToken | undefined> => {
-    const isLoggedIn = getStorage(tokenKeys.AUTHORIZATION) ? true : false;
+    const isLoggedIn = getStorage(storageKeys.IS_LOGGED_IN) ? true : false;
     let data: ResponseToken | undefined;
 
     if (isLoggedIn) {
-        const response: AxiosResponse = await httpClient.get('/auth/token');
+        const response = await httpClient.get('/auth/token');
         data = response.data;
     }
 
@@ -48,10 +47,10 @@ export type ResponseProfile = {
     provider: string;
 };
 const requestProfile = async (): Promise<ResponseProfile | undefined> => {
-    const isLoggedIn = getStorage(tokenKeys.AUTHORIZATION) ? true : false;
+    const isLoggedIn = getStorage(storageKeys.IS_LOGGED_IN) ? true : false;
     let data: ResponseProfile | undefined;
     if (isLoggedIn) {
-        const response: AxiosResponse = await httpClient.get('/users/me');
+        const response = await httpClient.get('/users/me');
         data = response.data;
     }
     return data;

--- a/frontend/src/api/breed.ts
+++ b/frontend/src/api/breed.ts
@@ -1,6 +1,11 @@
 import { httpClient } from '@/api/http';
+import { storageKeys } from '@/constants';
+import { getStorage } from '@/utils/storage';
 
 export const fetchDogBreeds = async () => {
-    const { data } = await httpClient.get('/breeds');
-    return data;
+    const isLoggedIn = getStorage(storageKeys.IS_LOGGED_IN) ? true : false;
+    if (isLoggedIn) {
+        const { data } = await httpClient.get('/breeds');
+        return data;
+    }
 };

--- a/frontend/src/api/dogs.ts
+++ b/frontend/src/api/dogs.ts
@@ -2,7 +2,7 @@ import { httpClient } from '@/api/http';
 import { DogRegInfo } from '@/pages/Join';
 import { AvailableDog, Dog, DogStatistic } from '@/models/dog.model';
 import { getStorage } from '@/utils/storage';
-import { tokenKeys } from '@/constants';
+import { storageKeys } from '@/constants';
 export type period = 'week' | 'month';
 export const fetchDogStatistic = async (): Promise<DogStatistic[]> => {
     const { data } = await httpClient.get('/dogs/statistics');
@@ -34,7 +34,7 @@ export interface ResponseDogs {
     profilePhotoUrl: string | null;
 }
 export const fetchDogs = async (): Promise<ResponseDogs[] | undefined> => {
-    const isLoggedIn = getStorage(tokenKeys.AUTHORIZATION) ? true : false;
+    const isLoggedIn = getStorage(storageKeys.IS_LOGGED_IN) ? true : false;
     let data: ResponseDogs[] | undefined;
     if (isLoggedIn) {
         const response = await httpClient.get<ResponseDogs[]>('/dogs');

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -18,8 +18,8 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 const useLogin = (mutationOptions?: UseMutationCustomOptions) => {
-    const navigate = useNavigate();
     const { storeLogin } = useAuthStore();
+    const navigate = useNavigate();
     return useMutation({
         mutationFn: requestLogin,
         onSuccess: ({ accessToken }: ResponseToken) => {
@@ -55,11 +55,11 @@ const useSignup = (mutationOptions?: UseMutationCustomOptions) => {
 };
 
 const useGetRefreshToken = () => {
-    const { storeLogin, storeLogout } = useAuthStore();
-    const { isSuccess, isError, data } = useQuery({
+    const { storeLogin } = useAuthStore();
+    const { isSuccess, data } = useQuery({
         queryKey: [queryKeys.AUTH, queryKeys.GET_ACCESS_TOKEN],
         queryFn: getAccessToken,
-        gcTime: 1000 * 60 * 60 + 1000 * 60,
+        gcTime: 1000 * 60 * 60,
         staleTime: 1000 * 60 * 60 - 1000 * 60 * 10,
         refetchInterval: 1000 * 60 * 60 - 1000 * 60 * 10,
         refetchOnReconnect: true,
@@ -71,12 +71,7 @@ const useGetRefreshToken = () => {
         }
     }, [isSuccess, data]);
 
-    useEffect(() => {
-        if (isError) {
-            storeLogout();
-        }
-    }, [isError]);
-    return { isSuccess, isError };
+    return { isSuccess, data };
 };
 
 const useLogout = (mutationOptions?: UseMutationCustomOptions) => {
@@ -95,8 +90,8 @@ const useLogout = (mutationOptions?: UseMutationCustomOptions) => {
 };
 
 const useDeactivate = (mutationOptions?: UseMutationCustomOptions) => {
-    const navigate = useNavigate();
     const { storeLogout } = useAuthStore();
+    const navigate = useNavigate();
     return useMutation({
         mutationFn: requestDeactivate,
         onSuccess: () => {
@@ -113,6 +108,8 @@ const useGetProfile = (queryOptions?: UseQueryCustomOptions) => {
     return useQuery({
         queryKey: [queryKeys.AUTH, queryKeys.GET_PROFILE],
         queryFn: requestProfile,
+        gcTime: 1000 * 60 * 60 * 24,
+        staleTime: 1000 * 60 * 60 * 24 - 1000 * 60,
         ...queryOptions,
     });
 };
@@ -124,7 +121,6 @@ export const useAuth = () => {
     const getProfileQuery = useGetProfile();
     const deactivateMutation = useDeactivate();
     return {
-        isTokenInit: refreshTokenQuery.isSuccess,
         loginMutation,
         logoutMutation,
         signupMustation,

--- a/frontend/src/hooks/useBreed.ts
+++ b/frontend/src/hooks/useBreed.ts
@@ -5,6 +5,8 @@ export const useBreed = () => {
     const { data } = useQuery({
         queryKey: ['breeds'],
         queryFn: fetchDogBreeds,
+        gcTime: 1000 * 60 * 60 * 24,
+        staleTime: 1000 * 60 * 60 * 24 - 1000 * 60,
     });
     return { data };
 };

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,4 +1,4 @@
-import { tokenKeys } from '@/constants';
+import { storageKeys, tokenKeys } from '@/constants';
 import { removeHeader, setHeader } from '@/utils/header';
 import { getStorage, removeStorage, setStorage } from '@/utils/storage';
 import { create } from 'zustand';
@@ -8,15 +8,15 @@ interface AuthState {
     storeLogout: () => void;
 }
 export const useAuthStore = create<AuthState>((set) => ({
-    isLoggedIn: getStorage(tokenKeys.AUTHORIZATION) ? true : false,
+    isLoggedIn: getStorage(storageKeys.IS_LOGGED_IN) ? true : false,
     storeLogin: (token: string | undefined) => {
         set({ isLoggedIn: true });
         setHeader(tokenKeys.AUTHORIZATION, `Bearer ${token}`);
-        setStorage(tokenKeys.AUTHORIZATION, `Bearer ${token}`);
+        setStorage(storageKeys.IS_LOGGED_IN, 'true');
     },
     storeLogout: () => {
         set({ isLoggedIn: false });
+        removeStorage(storageKeys.IS_LOGGED_IN);
         removeHeader(tokenKeys.AUTHORIZATION);
-        removeStorage(tokenKeys.AUTHORIZATION);
     },
 }));


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
httpClient interceptor request에서 accessToken을 몇 가지 제외사항 나머지 우리 서버 관련 api request header에 넣어주고

비동기 이슈로 header에 token이 들어가지 않았을때 response에서 401에러가 났을때 캐싱된 accessToken을 fetch하여 header에 설정해주고 원래 호출하려던 api를 재호출 하는 방식으로 비동기 이슈 해결
## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
