### PR TITLE
backend/DANG-925: e2e test 실행 시 발생하는 EntityMetadataNotFoundError 해결하기

### DIFF
--- a/backend/src/common/database/database.module.ts
+++ b/backend/src/common/database/database.module.ts
@@ -5,6 +5,7 @@ import { EntityClassOrSchema } from '@nestjs/typeorm/dist/interfaces/entity-clas
 import { DataSource } from 'typeorm';
 import { runSeeders } from 'typeorm-extension';
 import { addTransactionalDataSource, getDataSourceByName } from 'typeorm-transactional';
+import { Breed } from '../../breed/breed.entity';
 import { color } from '../../utils/ansi.util';
 import { WinstonLoggerService } from '../logger/winstonLogger.service';
 import BreedSeeder from './seeds/breed.seeder';
@@ -21,7 +22,7 @@ import BreedSeeder from './seeds/breed.seeder';
                     username: config.get<string>('MYSQL_ROOT_USER'),
                     password: config.get<string>('MYSQL_ROOT_PASSWORD'),
                     database: config.get<string>('MYSQL_DATABASE'),
-                    entities: ['dist/**/*.entity{.ts,.js}'],
+                    entities: ['dist/**/*.entity{.ts,.js}', Breed],
                     synchronize: true,
                     timezone: 'Z',
                     legacySpatialSupport: false,

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -1,18 +1,26 @@
+import { INestApplication } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
+import { initializeTransactionalContext } from 'typeorm-transactional';
 import { AppModule } from './../src/app.module';
-import { INestApplication } from '@nestjs/common';
 
 describe('AppController (e2e)', () => {
     let app: INestApplication;
 
-    beforeEach(async () => {
+    beforeAll(async () => {
+        initializeTransactionalContext();
+
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [AppModule],
         }).compile();
 
         app = moduleFixture.createNestApplication();
+
         await app.init();
+    });
+
+    afterAll(async () => {
+        await app.close();
     });
 
     it('/ (GET)', () => {


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
database module에서 data source option 중 entities에 경로를 명시하고 있지만 e2e test 시 seeding 작업에서 사용하는 Breed를 찾지 못하고 있어 해당 entity class를 직접 추가해주어 해결했다.

## 링크 (Links)
https://www.notion.so/do0ori/e2e-test-EntityMetadataNotFoundError-No-metadata-for-Breed-was-found-c311e486a503409db89e37b64c29d164

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
