### PR TITLE
backend/DANG-859: auth e2e test 코드 작성

### DIFF
--- a/backend/src/auth/guards/auth.guard.ts
+++ b/backend/src/auth/guards/auth.guard.ts
@@ -42,19 +42,19 @@ export class AuthGuard implements CanActivate {
             const payload = this.tokenService.verify(token) as AccessTokenPayload;
             this.logger.log('Payload', payload);
 
-            const isValid = await this.authService.validateAccessToken(payload.userId);
+            await this.authService.validateAccessToken(payload.userId);
 
             request.user = payload;
 
-            return isValid;
+            return true;
         } catch (error) {
             if (error instanceof TokenExpiredError || error instanceof JsonWebTokenError) {
                 error = new UnauthorizedException(error.message);
                 this.logger.error(error.message, { trace: error.stack ?? 'No stack' });
                 throw error;
             } else {
-                error = new UnauthorizedException('No matching user found.');
-                this.logger.error(`No matching user found`, { trace: error.stack ?? 'No stack' });
+                error = new UnauthorizedException();
+                this.logger.error(error.message, { trace: error.stack ?? 'No stack' });
                 throw error;
             }
         }

--- a/backend/src/auth/guards/refresh-token.guard.ts
+++ b/backend/src/auth/guards/refresh-token.guard.ts
@@ -24,11 +24,13 @@ export class RefreshTokenGuard implements CanActivate {
 
         try {
             const payload = this.tokenService.verify(token) as RefreshTokenPayload;
-            const isValid = await this.authService.validateRefreshToken(token, payload.oauthId);
+            this.logger.log('Payload', payload);
+
+            await this.authService.validateRefreshToken(token, payload.oauthId);
 
             request.user = payload;
 
-            return isValid;
+            return true;
         } catch (error) {
             if (error instanceof TokenExpiredError || error instanceof JsonWebTokenError) {
                 const trace = { trace: error.stack ?? 'No stack' };
@@ -36,8 +38,8 @@ export class RefreshTokenGuard implements CanActivate {
                 this.logger.error(error.message, trace);
                 throw error;
             } else {
-                error = new UnauthorizedException('No matching user found.');
-                this.logger.error(`No matching user found`, { trace: error.stack ?? 'No stack' });
+                error = new UnauthorizedException();
+                this.logger.error(error.message, { trace: error.stack ?? 'No stack' });
                 throw error;
             }
         }

--- a/backend/src/common/logger/winstonLogger.service.ts
+++ b/backend/src/common/logger/winstonLogger.service.ts
@@ -11,6 +11,8 @@ export class WinstonLoggerService implements LoggerService {
 
     constructor() {
         const isDevelopment = process.env.NODE_ENV != 'prod';
+        const isTest = process.env.NODE_ENV == 'test';
+
         const logDir = path.join(process.cwd(), 'log');
         if (!fs.existsSync(logDir)) {
             fs.mkdirSync(logDir, { recursive: true });
@@ -61,9 +63,10 @@ export class WinstonLoggerService implements LoggerService {
         this.logger = winston.createLogger({
             level: 'debug',
             format: winston.format.json(),
-            transports: isDevelopment
-                ? [consoleTransport, fileTransport, errorFileTransport]
-                : [fileTransport, errorFileTransport],
+            transports:
+                isDevelopment && !isTest
+                    ? [consoleTransport, fileTransport, errorFileTransport]
+                    : [fileTransport, errorFileTransport],
         });
     }
 

--- a/backend/src/fixtures/users.fixture.ts
+++ b/backend/src/fixtures/users.fixture.ts
@@ -10,10 +10,12 @@ const OAUTH_REFRESH_TOKEN =
 
 export const mockUser = new Users({
     id: 1,
-    nickname: '오징어1234',
+    nickname: 'mock_oauth_nickname#12345',
+    email: 'mock_email@example.com',
+    profileImageUrl: 'mock_profile_image.jpg',
     role: ROLE.User,
-    mainDogId: 1,
-    oauthId: '1',
+    mainDogId: null,
+    oauthId: '12345',
     oauthAccessToken: OAUTH_ACCESS_TOKEN,
     oauthRefreshToken: OAUTH_REFRESH_TOKEN,
     refreshToken: REFRESH_TOKEN,

--- a/backend/src/fixtures/users.fixture.ts
+++ b/backend/src/fixtures/users.fixture.ts
@@ -1,12 +1,9 @@
+import { VALID_REFRESH_TOKEN_100_YEARS } from '../../test/test-utils';
 import { ROLE } from '../users/types/role.type';
 import { Users } from '../users/users.entity';
 
-const REFRESH_TOKEN =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM';
-const OAUTH_ACCESS_TOKEN =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTY2ODc1NzUzNCwiZXhwIjoxNjY4ODQzOTM0fQ.fwjmKJZ7enTKt7tPfNx-ZG_rczvhkz2ktMV5pDNbxkw';
-const OAUTH_REFRESH_TOKEN =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM';
+export const OAUTH_ACCESS_TOKEN = 'oauth_access_token';
+export const OAUTH_REFRESH_TOKEN = 'oauth_refresh_token';
 
 export const mockUser = new Users({
     id: 1,
@@ -18,6 +15,6 @@ export const mockUser = new Users({
     oauthId: '12345',
     oauthAccessToken: OAUTH_ACCESS_TOKEN,
     oauthRefreshToken: OAUTH_REFRESH_TOKEN,
-    refreshToken: REFRESH_TOKEN,
+    refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
     createdAt: new Date('2019-01-01'),
 });

--- a/backend/src/users/users.spec.ts
+++ b/backend/src/users/users.spec.ts
@@ -1,4 +1,6 @@
-import { mockUser } from '../fixtures/users.fixture';
+import { VALID_REFRESH_TOKEN_100_YEARS } from '../../test/test-utils';
+import { OAUTH_ACCESS_TOKEN, OAUTH_REFRESH_TOKEN, mockUser } from '../fixtures/users.fixture';
+import { ROLE } from './types/role.type';
 import { Users } from './users.entity';
 
 describe('User', () => {
@@ -8,15 +10,12 @@ describe('User', () => {
             nickname: 'mock_oauth_nickname#12345',
             email: 'mock_email@example.com',
             profileImageUrl: 'mock_profile_image.jpg',
-            role: 'USER',
+            role: ROLE.User,
             mainDogId: null,
             oauthId: '12345',
-            oauthAccessToken:
-                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTY2ODc1NzUzNCwiZXhwIjoxNjY4ODQzOTM0fQ.fwjmKJZ7enTKt7tPfNx-ZG_rczvhkz2ktMV5pDNbxkw',
-            oauthRefreshToken:
-                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM',
-            refreshToken:
-                'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM',
+            oauthAccessToken: OAUTH_ACCESS_TOKEN,
+            oauthRefreshToken: OAUTH_REFRESH_TOKEN,
+            refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
             createdAt: expect.any(Date),
         });
     });

--- a/backend/src/users/users.spec.ts
+++ b/backend/src/users/users.spec.ts
@@ -10,7 +10,7 @@ describe('User', () => {
             profileImageUrl: 'mock_profile_image.jpg',
             role: 'USER',
             mainDogId: null,
-            oauthId: '1',
+            oauthId: '12345',
             oauthAccessToken:
                 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTY2ODc1NzUzNCwiZXhwIjoxNjY4ODQzOTM0fQ.fwjmKJZ7enTKt7tPfNx-ZG_rczvhkz2ktMV5pDNbxkw',
             oauthRefreshToken:

--- a/backend/src/users/users.spec.ts
+++ b/backend/src/users/users.spec.ts
@@ -5,8 +5,11 @@ describe('User', () => {
     it('user 정보가 주어지면 user 정보를 리턴해야 한다.', () => {
         expect(mockUser).toEqual({
             id: 1,
-            mainDogId: 1,
-            nickname: '오징어1234',
+            nickname: 'mock_oauth_nickname#12345',
+            email: 'mock_email@example.com',
+            profileImageUrl: 'mock_profile_image.jpg',
+            role: 'USER',
+            mainDogId: null,
             oauthId: '1',
             oauthAccessToken:
                 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTY2ODc1NzUzNCwiZXhwIjoxNjY4ODQzOTM0fQ.fwjmKJZ7enTKt7tPfNx-ZG_rczvhkz2ktMV5pDNbxkw',
@@ -14,7 +17,6 @@ describe('User', () => {
                 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM',
             refreshToken:
                 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiaWF0IjoxNjY5OTU2MjQxLCJleHAiOjE2NzE3NTYyNDF9.8Nzxs_ev8bhq9bkrAc-nBV9YBTDIxajK3pwwPY5LMRM',
-            role: 'USER',
             createdAt: expect.any(Date),
         });
     });

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -1,26 +1,16 @@
 import { INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
 import * as request from 'supertest';
-import { initializeTransactionalContext } from 'typeorm-transactional';
-import { AppModule } from './../src/app.module';
+import { closeTestApp, setupTestApp } from './test-utils';
 
 describe('AppController (e2e)', () => {
     let app: INestApplication;
 
     beforeAll(async () => {
-        initializeTransactionalContext();
-
-        const moduleFixture: TestingModule = await Test.createTestingModule({
-            imports: [AppModule],
-        }).compile();
-
-        app = moduleFixture.createNestApplication();
-
-        await app.init();
+        ({ app } = await setupTestApp());
     });
 
     afterAll(async () => {
-        await app.close();
+        await closeTestApp();
     });
 
     it('/ (GET)', () => {

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -3,7 +3,15 @@ import * as request from 'supertest';
 import { DataSource } from 'typeorm';
 import { mockUser } from '../src/fixtures/users.fixture';
 import { Users } from '../src/users/users.entity';
-import { TEST_INVALID_PROVIDER, TEST_VALID_PROVIDER, closeTestApp, setupTestApp } from './test-utils';
+import {
+    EXPIRED_ACCESS_TOKEN,
+    INVALID_PROVIDER,
+    MALFORMED_ACCESS_TOKEN,
+    VALID_ACCESS_TOKEN_100_YEARS,
+    VALID_PROVIDER_KAKAO,
+    closeTestApp,
+    setupTestApp,
+} from './test-utils';
 
 const context = describe;
 
@@ -31,7 +39,7 @@ describe('AuthController (e2e)', () => {
                     .post('/auth/login')
                     .send({
                         authorizeCode: 'authorizeCode',
-                        provider: TEST_VALID_PROVIDER,
+                        provider: VALID_PROVIDER_KAKAO,
                     })
                     .expect(404)
                     .expect('set-cookie', /oauthRefreshToken=.+/)
@@ -58,7 +66,7 @@ describe('AuthController (e2e)', () => {
                     .post('/auth/login')
                     .send({
                         authorizeCode: 'authorizeCode',
-                        provider: TEST_VALID_PROVIDER,
+                        provider: VALID_PROVIDER_KAKAO,
                     })
                     .expect(200)
                     .expect('set-cookie', /refreshToken=.+;/);
@@ -73,7 +81,7 @@ describe('AuthController (e2e)', () => {
                 return request(app.getHttpServer())
                     .post('/auth/login')
                     .send({
-                        provider: TEST_VALID_PROVIDER,
+                        provider: VALID_PROVIDER_KAKAO,
                     })
                     .expect(400);
             });
@@ -96,7 +104,7 @@ describe('AuthController (e2e)', () => {
                     .post('/auth/login')
                     .send({
                         authorizeCode: 'authorizeCode',
-                        provider: TEST_INVALID_PROVIDER,
+                        provider: INVALID_PROVIDER,
                     })
                     .expect(400);
             });
@@ -111,7 +119,7 @@ describe('AuthController (e2e)', () => {
                     .set('Cookie', [
                         `oauthRefreshToken=${mockUser.oauthRefreshToken}`,
                         `oauthAccessToken=${mockUser.oauthAccessToken}`,
-                        `provider=${TEST_VALID_PROVIDER}`,
+                        `provider=${VALID_PROVIDER_KAKAO}`,
                     ])
                     .expect(201)
                     .expect('set-cookie', /refreshToken=.+;/);
@@ -135,7 +143,7 @@ describe('AuthController (e2e)', () => {
                     .set('Cookie', [
                         `oauthRefreshToken=${mockUser.oauthRefreshToken}`,
                         `oauthAccessToken=${mockUser.oauthAccessToken}`,
-                        `provider=${TEST_VALID_PROVIDER}`,
+                        `provider=${VALID_PROVIDER_KAKAO}`,
                     ])
                     .expect(409);
             });
@@ -145,7 +153,10 @@ describe('AuthController (e2e)', () => {
             it('401 상태 코드를 반환해야 한다.', () => {
                 return request(app.getHttpServer())
                     .post('/auth/signup')
-                    .set('Cookie', [`oauthAccessToken=${mockUser.oauthAccessToken}`, `provider=${TEST_VALID_PROVIDER}`])
+                    .set('Cookie', [
+                        `oauthAccessToken=${mockUser.oauthAccessToken}`,
+                        `provider=${VALID_PROVIDER_KAKAO}`,
+                    ])
                     .expect(401);
             });
         });
@@ -156,7 +167,7 @@ describe('AuthController (e2e)', () => {
                     .post('/auth/signup')
                     .set('Cookie', [
                         `oauthRefreshToken=${mockUser.oauthRefreshToken}`,
-                        `provider=${TEST_VALID_PROVIDER}`,
+                        `provider=${VALID_PROVIDER_KAKAO}`,
                     ])
                     .expect(401);
             });
@@ -181,9 +192,65 @@ describe('AuthController (e2e)', () => {
                     .set('Cookie', [
                         `oauthRefreshToken=${mockUser.oauthRefreshToken}`,
                         `oauthAccessToken=${mockUser.oauthAccessToken}`,
-                        `provider=${TEST_INVALID_PROVIDER}`,
+                        `provider=${INVALID_PROVIDER}`,
                     ])
                     .expect(400);
+            });
+        });
+    });
+
+    describe('/auth/logout (POST)', () => {
+        context('회원이 유효한 access token을 Authorization header에 담아 로그아웃 요청을 보내면', () => {
+            beforeEach(async () => {
+                const userRepository = dataSource.getRepository(Users);
+                await userRepository.save(mockUser);
+            });
+
+            afterEach(async () => {
+                const userRepository = dataSource.getRepository(Users);
+                await userRepository.query('SET FOREIGN_KEY_CHECKS = 0;');
+                await userRepository.clear();
+                await userRepository.query('SET FOREIGN_KEY_CHECKS = 1;');
+            });
+
+            it('200 상태 코드를 반환해야 한다.', async () => {
+                return request(app.getHttpServer())
+                    .post('/auth/logout')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .expect(200);
+            });
+        });
+
+        context('Authorization header 없이 로그아웃 요청을 보내면', () => {
+            it('401 상태 코드를 반환해야 한다.', async () => {
+                return request(app.getHttpServer()).post('/auth/logout').expect(401);
+            });
+        });
+
+        context('구조가 잘못된 access token을 Authorization header에 담아 로그아웃 요청을 보내면', () => {
+            it('401 상태 코드를 반환해야 한다.', async () => {
+                return request(app.getHttpServer())
+                    .post('/auth/logout')
+                    .set('Authorization', `Bearer ${MALFORMED_ACCESS_TOKEN}`)
+                    .expect(401);
+            });
+        });
+
+        context('만료된 access token을 Authorization header에 담아 로그아웃 요청을 보내면', () => {
+            it('401 상태 코드를 반환해야 한다.', async () => {
+                return request(app.getHttpServer())
+                    .post('/auth/logout')
+                    .set('Authorization', `Bearer ${EXPIRED_ACCESS_TOKEN}`)
+                    .expect(401);
+            });
+        });
+
+        context('존재하지 않는 userId를 가진 access token을 Authorization header에 담아 로그아웃 요청을 보내면', () => {
+            it('401 상태 코드를 반환해야 한다.', async () => {
+                return request(app.getHttpServer())
+                    .post('/auth/logout')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .expect(401);
             });
         });
     });

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -1,0 +1,105 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { DataSource } from 'typeorm';
+import { mockUser } from '../src/fixtures/users.fixture';
+import { Users } from '../src/users/users.entity';
+import { TEST_PROVIDER, closeTestApp, setupTestApp } from './test-utils';
+
+const context = describe;
+
+describe('AuthController (e2e)', () => {
+    let app: INestApplication;
+    let dataSource: DataSource;
+
+    beforeAll(async () => {
+        ({ app, dataSource } = await setupTestApp());
+    });
+
+    afterAll(async () => {
+        const userRepository = dataSource.getRepository(Users);
+        await userRepository.query('SET FOREIGN_KEY_CHECKS = 0;');
+        await userRepository.clear();
+        await userRepository.query('SET FOREIGN_KEY_CHECKS = 1;');
+
+        await closeTestApp();
+    });
+
+    describe('/auth/login (POST)', () => {
+        context('비회원이 로그인 요청을 보내면', () => {
+            it('404 상태 코드와 Oauth data cookie를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .post('/auth/login')
+                    .send({
+                        authorizeCode: 'authorizeCode',
+                        provider: TEST_PROVIDER,
+                    })
+                    .expect(404)
+                    .expect('set-cookie', /oauthRefreshToken=.+/)
+                    .expect('set-cookie', /oauthAccessToken=.+/)
+                    .expect('set-cookie', /provider=kakao;/);
+            });
+        });
+
+        context('회원이 로그인 요청을 보내면', () => {
+            beforeEach(async () => {
+                const userRepository = dataSource.getRepository(Users);
+                await userRepository.save(mockUser);
+            });
+
+            afterEach(async () => {
+                const userRepository = dataSource.getRepository(Users);
+                await userRepository.query('SET FOREIGN_KEY_CHECKS = 0;');
+                await userRepository.clear();
+                await userRepository.query('SET FOREIGN_KEY_CHECKS = 1;');
+            });
+
+            it('200 상태 코드와 body에는 access token, cookie에는 refresh token을 반환해야 한다.', async () => {
+                const response = await request(app.getHttpServer())
+                    .post('/auth/login')
+                    .send({
+                        authorizeCode: 'authorizeCode',
+                        provider: TEST_PROVIDER,
+                    })
+                    .expect(200)
+                    .expect('set-cookie', /refreshToken=.+;/);
+
+                expect(response.body).toHaveProperty('accessToken');
+                expect(typeof response.body.accessToken).toBe('string');
+            });
+        });
+
+        context('요청 body에 authorizeCode field가 빠진 경우', () => {
+            it('400 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .post('/auth/login')
+                    .send({
+                        provider: TEST_PROVIDER,
+                    })
+                    .expect(400);
+            });
+        });
+
+        context('요청 body에 provider field가 빠진 경우', () => {
+            it('400 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .post('/auth/login')
+                    .send({
+                        authorizeCode: 'authorizeCode',
+                    })
+                    .expect(400);
+            });
+        });
+
+        context('요청 body의 provider field 값이 google, kakao, naver 중 하나가 아닌 경우', () => {
+            it('400 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .post('/auth/login')
+                    .send({
+                        authorizeCode: 'authorizeCode',
+                        provider: 'invalid_provider',
+                    })
+                    .expect(400);
+            });
+        });
+    });
+});

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -5,10 +5,13 @@ import { mockUser } from '../src/fixtures/users.fixture';
 import { Users } from '../src/users/users.entity';
 import {
     EXPIRED_ACCESS_TOKEN,
+    EXPIRED_REFRESH_TOKEN,
     INVALID_PROVIDER,
     MALFORMED_ACCESS_TOKEN,
+    MALFORMED_REFRESH_TOKEN,
     VALID_ACCESS_TOKEN_100_YEARS,
     VALID_PROVIDER_KAKAO,
+    VALID_REFRESH_TOKEN_100_YEARS,
     closeTestApp,
     setupTestApp,
 } from './test-utils';
@@ -250,6 +253,66 @@ describe('AuthController (e2e)', () => {
                 return request(app.getHttpServer())
                     .post('/auth/logout')
                     .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .expect(401);
+            });
+        });
+    });
+
+    describe('/auth/token (GET)', () => {
+        context('회원이 유효한 refresh token을 cookie에 가지고 token 재발급 요청을 보내면', () => {
+            beforeEach(async () => {
+                const userRepository = dataSource.getRepository(Users);
+                await userRepository.save(mockUser);
+            });
+
+            afterEach(async () => {
+                const userRepository = dataSource.getRepository(Users);
+                await userRepository.query('SET FOREIGN_KEY_CHECKS = 0;');
+                await userRepository.clear();
+                await userRepository.query('SET FOREIGN_KEY_CHECKS = 1;');
+            });
+
+            it('200 상태 코드와 body에는 access token, cookie에는 refresh token을 반환해야 한다.', async () => {
+                const response = await request(app.getHttpServer())
+                    .get('/auth/token')
+                    .set('Cookie', [`refreshToken=${VALID_REFRESH_TOKEN_100_YEARS}`])
+                    .expect(200)
+                    .expect('set-cookie', /refreshToken=.+;/);
+
+                expect(response.body).toHaveProperty('accessToken');
+                expect(typeof response.body.accessToken).toBe('string');
+            });
+        });
+
+        context('요청 cookie에 refreshToken field가 없는 경우', () => {
+            it('401 상태 코드를 반환해야 한다.', async () => {
+                return request(app.getHttpServer()).get('/auth/token').expect(401);
+            });
+        });
+
+        context('구조가 잘못된 refresh token을 cookie에 담아 token 재발급 요청을 보내면', () => {
+            it('401 상태 코드를 반환해야 한다.', async () => {
+                return request(app.getHttpServer())
+                    .get('/auth/token')
+                    .set('Cookie', [`refreshToken=${MALFORMED_REFRESH_TOKEN}`])
+                    .expect(401);
+            });
+        });
+
+        context('만료된 refresh token을 cookie에 담아 token 재발급 요청을 보내면', () => {
+            it('401 상태 코드를 반환해야 한다.', async () => {
+                return request(app.getHttpServer())
+                    .get('/auth/token')
+                    .set('Cookie', [`refreshToken=${EXPIRED_REFRESH_TOKEN}`])
+                    .expect(401);
+            });
+        });
+
+        context('존재하지 않는 oauthId를 가진 refresh token을 cookie에 담아 token 재발급 요청을 보내면', () => {
+            it('401 상태 코드를 반환해야 한다.', async () => {
+                return request(app.getHttpServer())
+                    .get('/auth/token')
+                    .set('Cookie', [`refreshToken=${VALID_REFRESH_TOKEN_100_YEARS}`])
                     .expect(401);
             });
         });

--- a/backend/test/jest-e2e.json
+++ b/backend/test/jest-e2e.json
@@ -5,5 +5,6 @@
     "testRegex": ".e2e-spec.ts$",
     "transform": {
         "^.+\\.(t|j)s$": "ts-jest"
-    }
+    },
+    "verbose": true
 }

--- a/backend/test/test-utils.ts
+++ b/backend/test/test-utils.ts
@@ -42,3 +42,20 @@ export const closeTestApp = async () => {
     await dataSource.destroy();
     await app.close();
 };
+
+// Access token with maxAge = 100 years, userId = 1, provider = kakao
+export const VALID_ACCESS_TOKEN_100_YEARS =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsInByb3ZpZGVyIjoia2FrYW8iLCJpYXQiOjE3MTYxODc5NzAsImV4cCI6NDg3MTk0Nzk3MH0.QlL_1luAr4T-YdA5QfKl8_ivhAlE1_FFlRfSAq2u2Lc';
+export const EXPIRED_ACCESS_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsInByb3ZpZGVyIjoia2FrYW8iLCJpYXQiOjE3MTc1OTQ4NTYsImV4cCI6MTcxNzU5NDg2Nn0.KphkJf-oCeJoZTv3fw-XvI5Qo16058r_ak5lWCJrvmg';
+export const MALFORMED_ACCESS_TOKEN = 'malformed_access_token';
+
+// Refresh token with maxAge = 100 years, oauthId = 12345, provider = kakao
+export const VALID_REFRESH_TOKEN_100_YEARS =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvYXV0aElkIjoiMTIzNDUiLCJwcm92aWRlciI6Imtha2FvIiwiaWF0IjoxNzE3NjAwNzIzLCJleHAiOjQ4NzMzNjA3MjN9.4FVH0-mkQ_qf4J0lmdu9lBrTrOYNk13fy7TJSjyyPV4';
+export const EXPIRED_REFRESH_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvYXV0aElkIjoiMTIzNDUiLCJwcm92aWRlciI6Imtha2FvIiwiaWF0IjoxNzE3NjAwNzczLCJleHAiOjE3MTc2MDA3Nzh9.ESo_BdU8g2K5YayZkkRPw5v6AKPJwx-p6R7_RA1QUvg';
+export const MALFORMED_REFRESH_TOKEN = 'malformed_refresh_token';
+
+export const VALID_PROVIDER_KAKAO = 'kakao';
+export const INVALID_PROVIDER = 'invalid_provider';

--- a/backend/test/test-utils.ts
+++ b/backend/test/test-utils.ts
@@ -1,0 +1,44 @@
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getDataSourceToken } from '@nestjs/typeorm';
+import * as cookieParser from 'cookie-parser';
+import { DataSource } from 'typeorm';
+import { initializeTransactionalContext } from 'typeorm-transactional';
+import { MockOauthService } from '../src/auth/oauth/__mocks__/oauth.service';
+import { GoogleService } from '../src/auth/oauth/google.service';
+import { KakaoService } from '../src/auth/oauth/kakao.service';
+import { NaverService } from '../src/auth/oauth/naver.service';
+import { AppModule } from './../src/app.module';
+
+let app: INestApplication;
+let dataSource: DataSource;
+
+export const setupTestApp = async () => {
+    initializeTransactionalContext();
+
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+        imports: [AppModule],
+    })
+        .overrideProvider(GoogleService)
+        .useValue(MockOauthService)
+        .overrideProvider(KakaoService)
+        .useValue(MockOauthService)
+        .overrideProvider(NaverService)
+        .useValue(MockOauthService)
+        .compile();
+
+    app = moduleFixture.createNestApplication();
+
+    app.use(cookieParser());
+
+    await app.init();
+
+    dataSource = app.get(getDataSourceToken());
+
+    return { app, dataSource };
+};
+
+export const closeTestApp = async () => {
+    await dataSource.destroy();
+    await app.close();
+};


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
```bash
$ npm run test:e2e

> nest-js-example@0.0.1 test:e2e
> cross-env NODE_ENV=test jest --config ./test/jest-e2e.json --maxWorkers=1

 PASS  test/auth.e2e-spec.ts (7.925 s)
  AuthController (e2e)
    /auth/login (POST)
      비회원이 로그인 요청을 보내면
        √ 404 상태 코드와 Oauth data cookie를 반환해야 한다. (54 ms)
      회원이 로그인 요청을 보내면
        √ 200 상태 코드와 body에는 access token, cookie에는 refresh token을 반환해야 한다. (48 ms)
      요청 body에 authorizeCode field가 빠진 경우
        √ 400 상태 코드를 반환해야 한다. (8 ms)
      요청 body에 provider field가 빠진 경우
        √ 400 상태 코드를 반환해야 한다. (10 ms)
      요청 body의 provider field 값이 google, kakao, naver 중 하나가 아닌 경우                                                                                                                                                          
        √ 400 상태 코드를 반환해야 한다. (6 ms)                                                                                                                                                                                         
    /auth/signup (POST)                                                                                                                                                                                                                 
      비회원이 회원가입 요청을 보내면                                                                                                                                                                                                   
        √ 201 상태 코드와 body에는 access token, cookie에는 refresh token을 반환하고 Oauth data cookie를 삭제해야 한다. (26 ms)                                                                                                         
      회원이 회원가입 요청을 보내면                                                                                                                                                                                                     
        √ 409 상태 코드를 반환해야 한다. (20 ms)                                                                                                                                                                                        
      요청 cookie에 oauthRefreshToken field가 빠진 경우                                                                                                                                                                                 
        √ 401 상태 코드를 반환해야 한다. (8 ms)                                                                                                                                                                                         
      요청 cookie에 oauthAccessToken field가 없는 경우                                                                                                                                                                                  
        √ 401 상태 코드를 반환해야 한다. (7 ms)                                                                                                                                                                                         
      요청 cookie에 provider field가 없는 경우                                                                                                                                                                                          
        √ 401 상태 코드를 반환해야 한다. (8 ms)                                                                                                                                                                                         
      요청 cookie의 provider field 값이 google, kakao, naver 중 하나가 아닌 경우                                                                                                                                                        
        √ 400 상태 코드를 반환해야 한다. (6 ms)                                                                                                                                                                                         
    /auth/logout (POST)                                                                                                                                                                                                                 
      회원이 유효한 access token을 Authorization header에 담아 로그아웃 요청을 보내면                                                                                                                                                   
        √ 200 상태 코드를 반환하고 refresh token cookie를 삭제해야 한다. (28 ms)                                                                                                                                                        
      Authorization header 없이 로그아웃 요청을 보내면
        √ 401 상태 코드를 반환해야 한다. (7 ms)                                                                                                                                                                                         
      구조가 잘못된 access token을 Authorization header에 담아 로그아웃 요청을 보내면                                                                                                                                                   
        √ 401 상태 코드를 반환해야 한다. (5 ms)                                                                                                                                                                                         
      만료된 access token을 Authorization header에 담아 로그아웃 요청을 보내면                                                                                                                                                          
        √ 401 상태 코드를 반환해야 한다. (6 ms)                                                                                                                                                                                         
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 로그아웃 요청을 보내면                                                                                                                                     
        √ 401 상태 코드를 반환해야 한다. (8 ms)                                                                                                                                                                                         
    /auth/token (GET)                                                                                                                                                                                                                   
      회원이 유효한 refresh token을 cookie에 가지고 token 재발급 요청을 보내면                                                                                                                                                          
        √ 200 상태 코드와 body에는 access token, cookie에는 refresh token을 반환해야 한다. (31 ms)                                                                                                                                      
      요청 cookie에 refreshToken field가 없는 경우                                                                                                                                                                                      
        √ 401 상태 코드를 반환해야 한다. (8 ms)                                                                                                                                                                                         
      구조가 잘못된 refresh token을 cookie에 담아 token 재발급 요청을 보내면                                                                                                                                                            
        √ 401 상태 코드를 반환해야 한다. (10 ms)                                                                                                                                                                                        
      만료된 refresh token을 cookie에 담아 token 재발급 요청을 보내면                                                                                                                                                                   
        √ 401 상태 코드를 반환해야 한다. (6 ms)                                                                                                                                                                                         
      존재하지 않는 oauthId를 가진 refresh token을 cookie에 담아 token 재발급 요청을 보내면                                                                                                                                             
        √ 401 상태 코드를 반환해야 한다. (9 ms)                                                                                                                                                                                         
    /auth/deactivate (DELETE)                                                                                                                                                                                                           
      회원이 유효한 access token을 Authorization header에 담아 회원탈퇴 요청을 보내면                                                                                                                                                   
        √ 200 상태 코드를 반환하고 refresh token cookie를 삭제해야 한다. (153 ms)                                                                                                                                                       
      Authorization header 없이 회원탈퇴 요청을 보내면                                                                                                                                                                                  
        √ 401 상태 코드를 반환해야 한다. (7 ms)                                                                                                                                                                                         
      구조가 잘못된 access token을 Authorization header에 담아 회원탈퇴 요청을 보내면                                                                                                                                                   
        √ 401 상태 코드를 반환해야 한다. (5 ms)                                                                                                                                                                                         
      만료된 access token을 Authorization header에 담아 회원탈퇴 요청을 보내면                                                                                                                                                          
        √ 401 상태 코드를 반환해야 한다. (6 ms)                                                                                                                                                                                         
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 회원탈퇴 요청을 보내면                                                                                                                                     
        √ 401 상태 코드를 반환해야 한다. (8 ms)                                                                                                                                                                                         
                                                                                                                                                                                                                                        
 PASS  test/app.e2e-spec.ts                                                                                                                                                                                                             
  AppController (e2e)
    √ / (GET) (11 ms)                                                                                                                                                                                                                   
                                                                                                                                                                                                                                        
Test Suites: 2 passed, 2 total                                                                                                                                                                                                          
Tests:       27 passed, 27 total                                                                                                                                                                                                        
Snapshots:   0 total
Time:        9.71 s, estimated 11 s
Ran all test suites.
```

## 링크 (Links)
https://www.notion.so/do0ori/auth-e2e-test-f6a6346ce715478f857ab006077ebe1a

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
