### PR TITLE
backend/DANG-938: DogsController e2e test 코드 작성

### DIFF
--- a/backend/src/auth/auth.service.spec.ts
+++ b/backend/src/auth/auth.service.spec.ts
@@ -159,7 +159,7 @@ describe('AuthService', () => {
 
     describe('validateAccessToken', () => {
         context('userId에 해당하는 user가 존재하지 않으면', () => {
-            it('NotFoundException error를 던져야 한다.', async () => {
+            it('NotFoundException 예외를 던져야 한다.', async () => {
                 jest.spyOn(usersService, 'findOne').mockRejectedValue(new NotFoundException());
 
                 await expect(service.validateAccessToken(1)).rejects.toThrow(NotFoundException);
@@ -169,7 +169,7 @@ describe('AuthService', () => {
 
     describe('validateRefreshToken', () => {
         context('oauthId에 해당하는 user가 존재하지 않으면', () => {
-            it('NotFoundException error를 던져야 한다.', async () => {
+            it('NotFoundException 예외를 던져야 한다.', async () => {
                 jest.spyOn(usersService, 'findOne').mockRejectedValue(new NotFoundException());
 
                 await expect(service.validateRefreshToken(mockUser.oauthAccessToken, mockUser.oauthId)).rejects.toThrow(
@@ -179,7 +179,7 @@ describe('AuthService', () => {
         });
 
         context('oauthId에 해당하는 user의 refresh token과 현재 token이 일치하지 않으면', () => {
-            it('UnauthorizedException error를 던져야 한다.', async () => {
+            it('UnauthorizedException 예외를 던져야 한다.', async () => {
                 jest.spyOn(usersService, 'findOne').mockResolvedValue(mockUser);
 
                 await expect(service.validateRefreshToken(mockUser.oauthAccessToken, mockUser.oauthId)).rejects.toThrow(

--- a/backend/src/breed/breed.spec.ts
+++ b/backend/src/breed/breed.spec.ts
@@ -1,7 +1,7 @@
 import { Breed } from './breed.entity';
 
 describe('Breed', () => {
-    it('breed 정보가 주어지면 breed 정보를 리턴해야 한다.', () => {
+    it('breed 정보가 주어지면 breed 정보를 반환해야 한다.', () => {
         const breed = new Breed();
         breed.id = 1;
         breed.koreanName = '골드리트리버';
@@ -12,7 +12,7 @@ describe('Breed', () => {
         expect(breed.recommendedWalkAmount).toBe(1);
     });
 
-    it('breed 정보가 없으면 빈 객체를 리턴해야 한다.', () => {
+    it('breed 정보가 없으면 빈 객체를 반환해야 한다.', () => {
         const breed = new Breed();
 
         expect(breed).toEqual({});

--- a/backend/src/dog-walk-day/dog-walk-day.spec.ts
+++ b/backend/src/dog-walk-day/dog-walk-day.spec.ts
@@ -1,7 +1,7 @@
 import { DogWalkDay } from './dog-walk-day.entity';
 
 describe('DogWalkDay', () => {
-    it('DogWalkDay 정보가 주어지면 dogWalkDay 정보를 리턴해야 한다.', () => {
+    it('DogWalkDay 정보가 주어지면 dogWalkDay 정보를 반환해야 한다.', () => {
         const dogWalkDay = new DogWalkDay();
         dogWalkDay.mon = 2;
         dogWalkDay.tue = 3;
@@ -19,7 +19,7 @@ describe('DogWalkDay', () => {
         expect(dogWalkDay.sat).toBe(3);
         expect(dogWalkDay.sun).toBe(2);
     });
-    it('dogWalkDay 정보가 없으면 빈 객체를 리턴해야 한다.', () => {
+    it('dogWalkDay 정보가 없으면 빈 객체를 반환해야 한다.', () => {
         const dogWalkDay = new DogWalkDay();
 
         expect(dogWalkDay.tue).toBe(undefined);

--- a/backend/src/dogs/dogs.controller.ts
+++ b/backend/src/dogs/dogs.controller.ts
@@ -35,12 +35,10 @@ export class DogsController {
         return true;
     }
 
-    @Delete('/:id(\\d+)')
-    @HttpCode(204)
+    @Get('/:id(\\d+)')
     @UseGuards(AuthDogGuard)
-    async delete(@User() { userId }: AccessTokenPayload, @Param('id', ParseIntPipe) dogId: number) {
-        await this.dogsService.deleteDogFromUser(userId, dogId);
-        return true;
+    async getProfile(@Param('id', ParseIntPipe) dogId: number) {
+        return this.dogsService.getProfile(dogId);
     }
 
     @Patch('/:id(\\d+)')
@@ -55,9 +53,11 @@ export class DogsController {
         return true;
     }
 
-    @Get('/:id(\\d+)')
+    @Delete('/:id(\\d+)')
+    @HttpCode(204)
     @UseGuards(AuthDogGuard)
-    async getProfile(@Param('id', ParseIntPipe) dogId: number) {
-        return this.dogsService.getProfile(dogId);
+    async delete(@User() { userId }: AccessTokenPayload, @Param('id', ParseIntPipe) dogId: number) {
+        await this.dogsService.deleteDogFromUser(userId, dogId);
+        return true;
     }
 }

--- a/backend/src/dogs/dogs.service.ts
+++ b/backend/src/dogs/dogs.service.ts
@@ -118,7 +118,7 @@ export class DogsService {
     }
 
     private makeDogsSummaryList(dogs: Dogs[]): DogSummary[] {
-        //TODO: key를 리턴하는 함수 만들어 인자로 넣기
+        //TODO: key를 반환하는 함수 만들어 인자로 넣기
         return makeSubObjectsArray(dogs, ['id', 'name', 'profilePhotoUrl']);
     }
 

--- a/backend/src/dogs/dogs.spec.ts
+++ b/backend/src/dogs/dogs.spec.ts
@@ -1,15 +1,28 @@
+import { DogWalkDay } from '../dog-walk-day/dog-walk-day.entity';
+import { mockDog } from '../fixtures/dogs.fixture';
+import { TodayWalkTime } from '../today-walk-time/today-walk-time.entity';
 import { Dogs } from './dogs.entity';
+import { GENDER } from './types/gender.type';
 
 describe('Dogs', () => {
-    it('dogs 정보가 주어지면 dogs 정보를 리턴해야 한다.', () => {
-        const dogs = new Dogs({ id: 1, name: '덕지', gender: 'MALE' });
-
-        expect(dogs.id).toBe(1);
-        expect(dogs.name).toBe('덕지');
-        expect(dogs.gender).toBe('MALE');
+    it('dogs 정보가 주어지면 dogs 정보를 반환해야 한다.', () => {
+        expect(mockDog).toEqual({
+            id: 1,
+            walkDay: new DogWalkDay(),
+            todayWalkTime: new TodayWalkTime(),
+            name: '덕지',
+            breedId: 1,
+            gender: GENDER.Male,
+            birth: null,
+            isNeutered: true,
+            weight: 2,
+            profilePhotoUrl: 'mock_profile_photo.jpg',
+            isWalking: false,
+            updatedAt: expect.any(Date),
+        });
     });
 
-    it('dogs 정보가 없으면 빈 객체를 리턴해야 한다.', () => {
+    it('dogs 정보가 없으면 빈 객체를 반환해야 한다.', () => {
         const breed = new Dogs({});
 
         expect(breed).toEqual({});

--- a/backend/src/fixtures/dogs.fixture.ts
+++ b/backend/src/fixtures/dogs.fixture.ts
@@ -1,0 +1,56 @@
+import { DogWalkDay } from '../dog-walk-day/dog-walk-day.entity';
+import { Dogs } from '../dogs/dogs.entity';
+import { GENDER } from '../dogs/types/gender.type';
+import { TodayWalkTime } from '../today-walk-time/today-walk-time.entity';
+
+export const mockDog = new Dogs({
+    id: 1,
+    walkDay: new DogWalkDay(),
+    todayWalkTime: new TodayWalkTime(),
+    name: '덕지',
+    breedId: 1,
+    gender: GENDER.Male,
+    birth: null,
+    isNeutered: true,
+    weight: 2,
+    profilePhotoUrl: 'mock_profile_photo.jpg',
+    isWalking: false,
+    updatedAt: new Date('2019-01-01'),
+});
+
+export const mockDogProfile = {
+    id: 1,
+    name: '덕지',
+    breed: '아펜핀셔',
+    gender: 'MALE',
+    isNeutered: true,
+    birth: null,
+    weight: 2,
+    profilePhotoUrl: 'mock_profile_photo.jpg',
+};
+
+export const mockDog2 = new Dogs({
+    id: 2,
+    walkDay: new DogWalkDay(),
+    todayWalkTime: new TodayWalkTime(),
+    name: '루이',
+    breedId: 2,
+    gender: GENDER.Female,
+    birth: null,
+    isNeutered: false,
+    weight: 1,
+    profilePhotoUrl: 'mock_profile_photo2.jpg',
+    isWalking: false,
+    updatedAt: new Date('2019-01-01'),
+});
+
+export const mockDog2Profile = {
+    id: 2,
+    name: '루이',
+    breed: '아프간 하운드',
+    gender: 'FEMALE',
+    isNeutered: false,
+    birth: null,
+    weight: 1,
+    profilePhotoUrl: 'mock_profile_photo2.jpg',
+};

--- a/backend/src/fixtures/users.fixture.ts
+++ b/backend/src/fixtures/users.fixture.ts
@@ -1,4 +1,4 @@
-import { VALID_REFRESH_TOKEN_100_YEARS } from '../../test/test-utils';
+import { VALID_REFRESH_TOKEN_100_YEARS } from '../../test/constants';
 import { ROLE } from '../users/types/role.type';
 import { Users } from '../users/users.entity';
 

--- a/backend/src/journals/journals.spec.ts
+++ b/backend/src/journals/journals.spec.ts
@@ -1,7 +1,7 @@
 import { Journals } from './journals.entity';
 
 describe('Journals', () => {
-    it('journals가 주어지면 journals 정보를 리턴해야 한다. ', () => {
+    it('journals가 주어지면 journals 정보를 반환해야 한다. ', () => {
         const journals = new Journals({ id: 1, userId: 1, calories: 11 });
 
         expect(journals.id).toBe(1);
@@ -9,7 +9,7 @@ describe('Journals', () => {
         expect(journals.calories).toBe(11);
     });
 
-    it('journals 정보가 없으면 빈 객체를 리턴해야 한다.', () => {
+    it('journals 정보가 없으면 빈 객체를 반환해야 한다.', () => {
         const journals = new Journals({});
 
         expect(journals).toEqual({});

--- a/backend/src/users/users.service.spec.ts
+++ b/backend/src/users/users.service.spec.ts
@@ -59,7 +59,7 @@ describe('UsersService', () => {
                 jest.spyOn(userRepository, 'findOne').mockResolvedValue(mockUser);
             });
 
-            it('사용자 정보를 리턴해야 한다.', async () => {
+            it('사용자 정보를 반환해야 한다.', async () => {
                 const res = await service.findOne({ id: mockUser.id });
 
                 expect(res).toEqual(mockUser);
@@ -84,7 +84,7 @@ describe('UsersService', () => {
                 jest.spyOn(userRepository, 'update').mockResolvedValue({ affected: 1 } as UpdateResult);
             });
 
-            it('사용자 정보를 업데이트하고 사용자를 리턴해야 한다.', async () => {
+            it('사용자 정보를 업데이트하고 사용자를 반환해야 한다.', async () => {
                 const res = await service.updateAndFindOne(
                     { oauthId: mockUser.oauthId },
                     {

--- a/backend/src/users/users.spec.ts
+++ b/backend/src/users/users.spec.ts
@@ -1,10 +1,10 @@
-import { VALID_REFRESH_TOKEN_100_YEARS } from '../../test/test-utils';
+import { VALID_REFRESH_TOKEN_100_YEARS } from '../../test/constants';
 import { OAUTH_ACCESS_TOKEN, OAUTH_REFRESH_TOKEN, mockUser } from '../fixtures/users.fixture';
 import { ROLE } from './types/role.type';
 import { Users } from './users.entity';
 
 describe('User', () => {
-    it('user 정보가 주어지면 user 정보를 리턴해야 한다.', () => {
+    it('user 정보가 주어지면 user 정보를 반환해야 한다.', () => {
         expect(mockUser).toEqual({
             id: 1,
             nickname: 'mock_oauth_nickname#12345',
@@ -20,7 +20,7 @@ describe('User', () => {
         });
     });
 
-    it('user 정보가 없으면 빈 객체를 리턴해야 한다.', () => {
+    it('user 정보가 없으면 빈 객체를 반환해야 한다.', () => {
         const user = new Users({});
 
         expect(user).toEqual({});

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -1,8 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
-import { DataSource } from 'typeorm';
 import { mockUser } from '../src/fixtures/users.fixture';
-import { Users } from '../src/users/users.entity';
 import {
     EXPIRED_ACCESS_TOKEN,
     EXPIRED_REFRESH_TOKEN,
@@ -12,26 +10,20 @@ import {
     VALID_ACCESS_TOKEN_100_YEARS,
     VALID_PROVIDER_KAKAO,
     VALID_REFRESH_TOKEN_100_YEARS,
-    closeTestApp,
-    setupTestApp,
-} from './test-utils';
+} from './constants';
+import { clearUsers, closeTestApp, insertMockUser, setupTestApp } from './test-utils';
 
 const context = describe;
 
 describe('AuthController (e2e)', () => {
     let app: INestApplication;
-    let dataSource: DataSource;
 
     beforeAll(async () => {
-        ({ app, dataSource } = await setupTestApp());
+        ({ app } = await setupTestApp());
     });
 
     afterAll(async () => {
-        const userRepository = dataSource.getRepository(Users);
-        await userRepository.query('SET FOREIGN_KEY_CHECKS = 0;');
-        await userRepository.clear();
-        await userRepository.query('SET FOREIGN_KEY_CHECKS = 1;');
-
+        await clearUsers();
         await closeTestApp();
     });
 
@@ -53,15 +45,11 @@ describe('AuthController (e2e)', () => {
 
         context('회원이 로그인 요청을 보내면', () => {
             beforeEach(async () => {
-                const userRepository = dataSource.getRepository(Users);
-                await userRepository.save(mockUser);
+                await insertMockUser();
             });
 
             afterEach(async () => {
-                const userRepository = dataSource.getRepository(Users);
-                await userRepository.query('SET FOREIGN_KEY_CHECKS = 0;');
-                await userRepository.clear();
-                await userRepository.query('SET FOREIGN_KEY_CHECKS = 1;');
+                await clearUsers();
             });
 
             it('200 상태 코드와 body에는 access token, cookie에는 refresh token을 반환해야 한다.', async () => {
@@ -137,10 +125,7 @@ describe('AuthController (e2e)', () => {
 
         context('회원이 회원가입 요청을 보내면', () => {
             afterEach(async () => {
-                const userRepository = dataSource.getRepository(Users);
-                await userRepository.query('SET FOREIGN_KEY_CHECKS = 0;');
-                await userRepository.clear();
-                await userRepository.query('SET FOREIGN_KEY_CHECKS = 1;');
+                await clearUsers();
             });
 
             it('409 상태 코드를 반환해야 한다.', () => {
@@ -208,15 +193,11 @@ describe('AuthController (e2e)', () => {
     describe('/auth/logout (POST)', () => {
         context('회원이 유효한 access token을 Authorization header에 담아 로그아웃 요청을 보내면', () => {
             beforeEach(async () => {
-                const userRepository = dataSource.getRepository(Users);
-                await userRepository.save(mockUser);
+                await insertMockUser();
             });
 
             afterEach(async () => {
-                const userRepository = dataSource.getRepository(Users);
-                await userRepository.query('SET FOREIGN_KEY_CHECKS = 0;');
-                await userRepository.clear();
-                await userRepository.query('SET FOREIGN_KEY_CHECKS = 1;');
+                await clearUsers();
             });
 
             it('200 상태 코드를 반환하고 refresh token cookie를 삭제해야 한다.', async () => {
@@ -265,15 +246,11 @@ describe('AuthController (e2e)', () => {
     describe('/auth/token (GET)', () => {
         context('회원이 유효한 refresh token을 cookie에 가지고 token 재발급 요청을 보내면', () => {
             beforeEach(async () => {
-                const userRepository = dataSource.getRepository(Users);
-                await userRepository.save(mockUser);
+                await insertMockUser();
             });
 
             afterEach(async () => {
-                const userRepository = dataSource.getRepository(Users);
-                await userRepository.query('SET FOREIGN_KEY_CHECKS = 0;');
-                await userRepository.clear();
-                await userRepository.query('SET FOREIGN_KEY_CHECKS = 1;');
+                await clearUsers();
             });
 
             it('200 상태 코드와 body에는 access token, cookie에는 refresh token을 반환해야 한다.', async () => {
@@ -325,15 +302,11 @@ describe('AuthController (e2e)', () => {
     describe('/auth/deactivate (DELETE)', () => {
         context('회원이 유효한 access token을 Authorization header에 담아 회원탈퇴 요청을 보내면', () => {
             beforeEach(async () => {
-                const userRepository = dataSource.getRepository(Users);
-                await userRepository.save(mockUser);
+                await insertMockUser();
             });
 
             afterEach(async () => {
-                const userRepository = dataSource.getRepository(Users);
-                await userRepository.query('SET FOREIGN_KEY_CHECKS = 0;');
-                await userRepository.clear();
-                await userRepository.query('SET FOREIGN_KEY_CHECKS = 1;');
+                await clearUsers();
             });
 
             it('200 상태 코드를 반환하고 refresh token cookie를 삭제해야 한다.', async () => {

--- a/backend/test/constants.ts
+++ b/backend/test/constants.ts
@@ -1,0 +1,16 @@
+// Access token with maxAge = 100 years, userId = 1, provider = kakao
+export const VALID_ACCESS_TOKEN_100_YEARS =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsInByb3ZpZGVyIjoia2FrYW8iLCJpYXQiOjE3MTYxODc5NzAsImV4cCI6NDg3MTk0Nzk3MH0.QlL_1luAr4T-YdA5QfKl8_ivhAlE1_FFlRfSAq2u2Lc';
+export const EXPIRED_ACCESS_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsInByb3ZpZGVyIjoia2FrYW8iLCJpYXQiOjE3MTc1OTQ4NTYsImV4cCI6MTcxNzU5NDg2Nn0.KphkJf-oCeJoZTv3fw-XvI5Qo16058r_ak5lWCJrvmg';
+export const MALFORMED_ACCESS_TOKEN = 'malformed_access_token';
+
+// Refresh token with maxAge = 100 years, oauthId = 12345, provider = kakao
+export const VALID_REFRESH_TOKEN_100_YEARS =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvYXV0aElkIjoiMTIzNDUiLCJwcm92aWRlciI6Imtha2FvIiwiaWF0IjoxNzE3NjAwNzIzLCJleHAiOjQ4NzMzNjA3MjN9.4FVH0-mkQ_qf4J0lmdu9lBrTrOYNk13fy7TJSjyyPV4';
+export const EXPIRED_REFRESH_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvYXV0aElkIjoiMTIzNDUiLCJwcm92aWRlciI6Imtha2FvIiwiaWF0IjoxNzE3NjAwNzczLCJleHAiOjE3MTc2MDA3Nzh9.ESo_BdU8g2K5YayZkkRPw5v6AKPJwx-p6R7_RA1QUvg';
+export const MALFORMED_REFRESH_TOKEN = 'malformed_refresh_token';
+
+export const VALID_PROVIDER_KAKAO = 'kakao';
+export const INVALID_PROVIDER = 'invalid_provider';

--- a/backend/test/dogs.e2e-spec.ts
+++ b/backend/test/dogs.e2e-spec.ts
@@ -1,0 +1,53 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { mockDog2Profile, mockDogProfile } from '../src/fixtures/dogs.fixture';
+import { VALID_ACCESS_TOKEN_100_YEARS } from './constants';
+import { clearDogs, clearUsers, closeTestApp, insertMockDogs, insertMockUser, setupTestApp } from './test-utils';
+
+const context = describe;
+
+describe('DogsController (e2e)', () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+        ({ app } = await setupTestApp());
+        await insertMockUser();
+    });
+
+    afterAll(async () => {
+        await clearUsers();
+        await closeTestApp();
+    });
+
+    describe('/dogs (GET)', () => {
+        context('사용자가 소유한 강아지가 없을 때 소유한 강아지 목록 요청을 보내면', () => {
+            it('200 상태 코드와 빈 배열을 반환해야 한다.', async () => {
+                const response = await request(app.getHttpServer())
+                    .get('/dogs')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .expect(200);
+
+                expect(response.body).toEqual([]);
+            });
+        });
+
+        context('사용자가 소유한 강아지가 존재할 때 소유한 강아지 목록 요청을 보내면', () => {
+            beforeEach(async () => {
+                await insertMockDogs();
+            });
+
+            afterEach(async () => {
+                await clearDogs();
+            });
+
+            it('200 상태 코드와 강아지 프로필 목록을 반환해야 한다.', async () => {
+                const response = await request(app.getHttpServer())
+                    .get('/dogs')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .expect(200);
+
+                expect(response.body).toEqual([mockDogProfile, mockDog2Profile]);
+            });
+        });
+    });
+});

--- a/backend/test/dogs.e2e-spec.ts
+++ b/backend/test/dogs.e2e-spec.ts
@@ -1,5 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';
+import { DataSource } from 'typeorm';
+import { Dogs } from '../src/dogs/dogs.entity';
 import { mockDog2Profile, mockDogProfile } from '../src/fixtures/dogs.fixture';
 import { VALID_ACCESS_TOKEN_100_YEARS } from './constants';
 import { clearDogs, clearUsers, closeTestApp, insertMockDogs, insertMockUser, setupTestApp } from './test-utils';
@@ -8,9 +10,10 @@ const context = describe;
 
 describe('DogsController (e2e)', () => {
     let app: INestApplication;
+    let dataSource: DataSource;
 
     beforeAll(async () => {
-        ({ app } = await setupTestApp());
+        ({ app, dataSource } = await setupTestApp());
         await insertMockUser();
     });
 
@@ -47,6 +50,172 @@ describe('DogsController (e2e)', () => {
                     .expect(200);
 
                 expect(response.body).toEqual([mockDogProfile, mockDog2Profile]);
+            });
+        });
+    });
+
+    describe('/dogs (POST)', () => {
+        context('사용자가 강아지 등록 요청을 보내면', () => {
+            afterEach(async () => {
+                await clearDogs();
+            });
+
+            const { id, ...createMockDog } = mockDogProfile;
+
+            it('201 상태 코드를 반환해야 한다.', async () => {
+                await request(app.getHttpServer())
+                    .post('/dogs')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send(createMockDog)
+                    .expect(201);
+
+                expect(await dataSource.getRepository(Dogs).count()).toBe(1);
+            });
+        });
+
+        context('사용자가 존재하지 않는 견종으로 강아지 등록 요청을 보내면', () => {
+            beforeEach(async () => {
+                await insertMockDogs();
+            });
+
+            afterEach(async () => {
+                await clearDogs();
+            });
+
+            const { id, ...createMockDog } = mockDogProfile;
+            createMockDog.breed = '시고르자브종';
+
+            it('404 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .post('/dogs')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send(createMockDog)
+                    .expect(404);
+            });
+        });
+    });
+
+    describe('/dogs/:id (GET)', () => {
+        context('사용자가 자신이 소유한 강아지의 프로필 조회 요청을 보내면', () => {
+            beforeEach(async () => {
+                await insertMockDogs();
+            });
+
+            afterEach(async () => {
+                await clearDogs();
+            });
+
+            it('200 상태 코드와 강아지 프로필을 반환해야 한다.', async () => {
+                const response = await request(app.getHttpServer())
+                    .get('/dogs/1')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .expect(200);
+
+                expect(response.body).toEqual(mockDogProfile);
+            });
+        });
+
+        context('사용자가 자신이 소유하지 않은 강아지의 프로필 조회 요청을 보내면', () => {
+            beforeEach(async () => {
+                await insertMockDogs();
+            });
+
+            afterEach(async () => {
+                await clearDogs();
+            });
+
+            it('403 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .get('/dogs/3')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .expect(403);
+            });
+        });
+    });
+
+    describe('/dogs/:id (PATCH)', () => {
+        context('사용자가 자신이 소유한 강아지의 정보 수정 요청을 보내면', () => {
+            beforeEach(async () => {
+                await insertMockDogs();
+            });
+
+            afterEach(async () => {
+                await clearDogs();
+            });
+
+            const { id, ...updateMockDog } = mockDog2Profile;
+
+            it('204 상태 코드를 반환해야 한다.', async () => {
+                await request(app.getHttpServer())
+                    .patch('/dogs/1')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send(updateMockDog)
+                    .expect(204);
+
+                const updatedDog = await dataSource.getRepository(Dogs).findOne({ where: { id: 1 } });
+                if (!updatedDog) throw new Error('Dog not found');
+                updatedDog.breed = (updatedDog.breed as any).koreanName;
+                expect(updatedDog).toMatchObject(updateMockDog);
+            });
+        });
+
+        context('사용자가 자신이 소유하지 않은 강아지의 정보 수정 요청을 보내면', () => {
+            it('403 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .patch('/dogs/3')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .expect(403);
+            });
+        });
+
+        context('사용자가 존재하지 않는 견종으로 강아지의 정보 수정 요청을 보내면', () => {
+            beforeEach(async () => {
+                await insertMockDogs();
+            });
+
+            afterEach(async () => {
+                await clearDogs();
+            });
+
+            const { id, ...updateMockDog } = mockDog2Profile;
+            updateMockDog.breed = '시고르자브종';
+
+            it('404 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .patch('/dogs/1')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send(updateMockDog)
+                    .expect(404);
+            });
+        });
+    });
+
+    describe('/dogs/:id (DELETE)', () => {
+        context('사용자가 자신이 소유한 강아지의 삭제 요청을 보내면', () => {
+            beforeEach(async () => {
+                await insertMockDogs();
+            });
+
+            afterEach(async () => {
+                await clearDogs();
+            });
+
+            it('204 상태 코드를 반환해야 한다.', async () => {
+                await request(app.getHttpServer())
+                    .delete('/dogs/1')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .expect(204);
+
+                expect(await dataSource.getRepository(Dogs).count()).toBe(1);
+            });
+        });
+
+        context('사용자가 자신이 소유하지 않은 강아지의 삭제 요청을 보내면', () => {
+            it('403 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .delete('/dogs/3')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .expect(403);
             });
         });
     });

--- a/backend/test/test-utils.ts
+++ b/backend/test/test-utils.ts
@@ -8,8 +8,15 @@ import { MockOauthService } from '../src/auth/oauth/__mocks__/oauth.service';
 import { GoogleService } from '../src/auth/oauth/google.service';
 import { KakaoService } from '../src/auth/oauth/kakao.service';
 import { NaverService } from '../src/auth/oauth/naver.service';
+import { DogWalkDay } from '../src/dog-walk-day/dog-walk-day.entity';
+import { Dogs } from '../src/dogs/dogs.entity';
+import { mockDog, mockDog2 } from '../src/fixtures/dogs.fixture';
+import { mockUser } from '../src/fixtures/users.fixture';
 import { MockS3Service } from '../src/s3/__mocks__/s3.service';
 import { S3Service } from '../src/s3/s3.service';
+import { TodayWalkTime } from '../src/today-walk-time/today-walk-time.entity';
+import { UsersDogs } from '../src/users-dogs/users-dogs.entity';
+import { Users } from '../src/users/users.entity';
 import { AppModule } from './../src/app.module';
 
 let app: INestApplication;
@@ -47,19 +54,33 @@ export const closeTestApp = async () => {
     await app.close();
 };
 
-// Access token with maxAge = 100 years, userId = 1, provider = kakao
-export const VALID_ACCESS_TOKEN_100_YEARS =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsInByb3ZpZGVyIjoia2FrYW8iLCJpYXQiOjE3MTYxODc5NzAsImV4cCI6NDg3MTk0Nzk3MH0.QlL_1luAr4T-YdA5QfKl8_ivhAlE1_FFlRfSAq2u2Lc';
-export const EXPIRED_ACCESS_TOKEN =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsInByb3ZpZGVyIjoia2FrYW8iLCJpYXQiOjE3MTc1OTQ4NTYsImV4cCI6MTcxNzU5NDg2Nn0.KphkJf-oCeJoZTv3fw-XvI5Qo16058r_ak5lWCJrvmg';
-export const MALFORMED_ACCESS_TOKEN = 'malformed_access_token';
+export const insertMockUser = async () => {
+    const usersRepository = dataSource.getRepository(Users);
+    await usersRepository.save(mockUser);
+};
 
-// Refresh token with maxAge = 100 years, oauthId = 12345, provider = kakao
-export const VALID_REFRESH_TOKEN_100_YEARS =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvYXV0aElkIjoiMTIzNDUiLCJwcm92aWRlciI6Imtha2FvIiwiaWF0IjoxNzE3NjAwNzIzLCJleHAiOjQ4NzMzNjA3MjN9.4FVH0-mkQ_qf4J0lmdu9lBrTrOYNk13fy7TJSjyyPV4';
-export const EXPIRED_REFRESH_TOKEN =
-    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvYXV0aElkIjoiMTIzNDUiLCJwcm92aWRlciI6Imtha2FvIiwiaWF0IjoxNzE3NjAwNzczLCJleHAiOjE3MTc2MDA3Nzh9.ESo_BdU8g2K5YayZkkRPw5v6AKPJwx-p6R7_RA1QUvg';
-export const MALFORMED_REFRESH_TOKEN = 'malformed_refresh_token';
+export const clearUsers = async () => {
+    const usersRepository = dataSource.getRepository(Users);
+    await usersRepository.query('SET FOREIGN_KEY_CHECKS = 0;');
+    await usersRepository.clear();
+    await usersRepository.query('SET FOREIGN_KEY_CHECKS = 1;');
+};
 
-export const VALID_PROVIDER_KAKAO = 'kakao';
-export const INVALID_PROVIDER = 'invalid_provider';
+export const insertMockDogs = async () => {
+    const dogsRepository = dataSource.getRepository(Dogs);
+    const usersDogsRepository = dataSource.getRepository(UsersDogs);
+    await dogsRepository.save(mockDog);
+    await usersDogsRepository.save({ userId: 1, dogId: mockDog.id });
+    await dogsRepository.save(mockDog2);
+    await usersDogsRepository.save({ userId: 1, dogId: mockDog2.id });
+};
+
+export const clearDogs = async () => {
+    const dogsRepository = dataSource.getRepository(Dogs);
+    await dogsRepository.query('SET FOREIGN_KEY_CHECKS = 0;');
+    await dataSource.getRepository(DogWalkDay).clear();
+    await dataSource.getRepository(TodayWalkTime).clear();
+    await dogsRepository.clear();
+    await dataSource.getRepository(UsersDogs).clear();
+    await dogsRepository.query('SET FOREIGN_KEY_CHECKS = 1;');
+};

--- a/docs/api/upload.yaml
+++ b/docs/api/upload.yaml
@@ -1,7 +1,7 @@
 post:
   tags:
     - 이미지
-  summary: 이미지 업로드용 presignedUrl 리턴
+  summary: 이미지 업로드용 presignedUrl 반환
   description: S3에 이미지를 업로드 할 수 있는 presignedUrl을 요청합니다.
   parameters:
     - in: cookie
@@ -21,7 +21,7 @@ post:
             example: "jpg"
   responses:
     "200":
-      description: presignedUrl 성공적으로 리턴
+      description: presignedUrl 성공적으로 반환
       content:
         application/json:
           schema:

--- a/docs/dogs/id-statistics.yaml
+++ b/docs/dogs/id-statistics.yaml
@@ -29,7 +29,7 @@ get:
               - week
   responses:
     "200":
-      description: 한달/일주일 산책 횟수 리턴
+      description: 한달/일주일 산책 횟수 반환
       content:
         application/json:
           schema:

--- a/docs/journals/id.yaml
+++ b/docs/journals/id.yaml
@@ -43,7 +43,7 @@ patch:
 delete:
   tags:
     - 산책 일지
-  summary: 산책 일지 삭제 
+  summary: 산책 일지 삭제
   description: 산책 일지를 삭제한다
   parameters:
     - in: cookie
@@ -71,7 +71,7 @@ get:
   tags:
     - 산책 일지
   summary: 산책 일지 상세
-  description: 산책 일지의 상세 정보를 리턴한다
+  description: 산책 일지의 상세 정보를 반환한다
   parameters:
     - in: cookie
       name: Authorization

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -33,7 +33,7 @@ paths:
       security: []
       responses:
         "200":
-          description: 견종 목록 리턴
+          description: 견종 목록 반환
           content:
             application/json:
               schema:


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
```bash
$ npm run test:e2e -- --testPathPattern=test/dogs.e2e-spec.ts

> nest-js-example@0.0.1 test:e2e
> cross-env NODE_ENV=test jest --config ./test/jest-e2e.json --maxWorkers=1 --testPathPattern=test/dogs.e2e-spec.ts

 PASS  test/dogs.e2e-spec.ts (7.199 s)
  DogsController (e2e)
    /dogs (GET)
      사용자가 소유한 강아지가 없을 때 소유한 강아지 목록 요청을 보내면
        √ 200 상태 코드와 빈 배열을 반환해야 한다. (31 ms)
      사용자가 소유한 강아지가 존재할 때 소유한 강아지 목록 요청을 보내면
        √ 200 상태 코드와 강아지 프로필 목록을 반환해야 한다. (50 ms)
    /dogs (POST)
      사용자가 강아지 등록 요청을 보내면
        √ 201 상태 코드를 반환해야 한다. (59 ms)
      사용자가 존재하지 않는 견종으로 강아지 등록 요청을 보내면
        √ 404 상태 코드를 반환해야 한다. (73 ms)
    /dogs/:id (GET)
      사용자가 자신이 소유한 강아지의 프로필 조회 요청을 보내면
        √ 200 상태 코드와 강아지 프로필을 반환해야 한다. (106 ms)
      사용자가 자신이 소유하지 않은 강아지의 프로필 조회 요청을 보내면
        √ 403 상태 코드를 반환해야 한다. (52 ms)
    /dogs/:id (PATCH)
      사용자가 자신이 소유한 강아지의 정보 수정 요청을 보내면
        √ 204 상태 코드를 반환해야 한다. (61 ms)
      사용자가 자신이 소유하지 않은 강아지의 정보 수정 요청을 보내면
        √ 403 상태 코드를 반환해야 한다. (10 ms)
      사용자가 존재하지 않는 견종으로 강아지의 정보 수정 요청을 보내면
        √ 404 상태 코드를 반환해야 한다. (50 ms)
    /dogs/:id (DELETE)
      사용자가 자신이 소유한 강아지의 삭제 요청을 보내면
        √ 204 상태 코드를 반환해야 한다. (56 ms)
      사용자가 자신이 소유하지 않은 강아지의 삭제 요청을 보내면
        √ 403 상태 코드를 반환해야 한다. (9 ms)

Test Suites: 1 passed, 1 total                                                                            
Tests:       11 passed, 11 total                                                                          
Snapshots:   0 total
Time:        7.291 s, estimated 8 s
Ran all test suites matching /test\\dogs.e2e-spec.ts/i.
```

## 링크 (Links)
https://www.notion.so/do0ori/DogsController-e2e-test-c3a426f0e045428f952586b5c632d367

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
