### PR TITLE
backend/DANG-944: UsersController e2e test 코드 작성

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -23,7 +23,7 @@ import { AccessTokenPayload, RefreshTokenPayload } from './token/token.service';
 
 @Controller('/auth')
 @UseInterceptors(CookieInterceptor)
-@UsePipes(new ValidationPipe({ validateCustomDecorators: true }))
+@UsePipes(new ValidationPipe({ validateCustomDecorators: true, whitelist: true }))
 export class AuthController {
     constructor(private readonly authService: AuthService) {}
 

--- a/backend/src/dogs/dogs.controller.ts
+++ b/backend/src/dogs/dogs.controller.ts
@@ -20,7 +20,7 @@ import { UpdateDogDto } from './dtos/update-dog.dto';
 import { AuthDogGuard } from './guards/auth-dog.guard';
 
 @Controller('/dogs')
-@UsePipes(new ValidationPipe({ validateCustomDecorators: true }))
+@UsePipes(new ValidationPipe({ validateCustomDecorators: true, whitelist: true }))
 export class DogsController {
     constructor(private readonly dogsService: DogsService) {}
 

--- a/backend/src/fixtures/users.fixture.ts
+++ b/backend/src/fixtures/users.fixture.ts
@@ -1,4 +1,4 @@
-import { VALID_REFRESH_TOKEN_100_YEARS } from '../../test/constants';
+import { VALID_PROVIDER_KAKAO, VALID_REFRESH_TOKEN_100_YEARS } from '../../test/constants';
 import { ROLE } from '../users/types/role.type';
 import { Users } from '../users/users.entity';
 
@@ -18,3 +18,11 @@ export const mockUser = new Users({
     refreshToken: VALID_REFRESH_TOKEN_100_YEARS,
     createdAt: new Date('2019-01-01'),
 });
+
+export const mockUserProfile = {
+    id: 1,
+    nickname: 'mock_oauth_nickname#12345',
+    email: 'mock_email@example.com',
+    profileImageUrl: 'mock_profile_image.jpg',
+    provider: VALID_PROVIDER_KAKAO,
+};

--- a/backend/src/journals/journals.controller.ts
+++ b/backend/src/journals/journals.controller.ts
@@ -22,7 +22,7 @@ import { JournalsService } from './journals.service';
 import { JournalInfoForList } from './types/journal-info.type';
 
 @Controller('/journals')
-@UsePipes(new ValidationPipe({ validateCustomDecorators: true }))
+@UsePipes(new ValidationPipe({ validateCustomDecorators: true, whitelist: true }))
 export class JournalsController {
     constructor(private readonly journalsService: JournalsService) {}
 

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Patch, UsePipes, ValidationPipe } from '@nestjs/common';
+import { Body, Controller, Get, HttpCode, Patch, UsePipes, ValidationPipe } from '@nestjs/common';
 import { AccessTokenPayload } from '../auth/token/token.service';
 import { User } from '../users/decorators/user.decorator';
 import { UpdateUserDto } from './dtos/update-user.dto';
@@ -15,6 +15,7 @@ export class UsersController {
     }
 
     @Patch('/me')
+    @HttpCode(204)
     async updateUserProfile(@User() { userId }: AccessTokenPayload, @Body() userInfo: UpdateUserDto) {
         return await this.usersService.updateUserProfile(userId, userInfo);
     }

--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -5,7 +5,7 @@ import { UpdateUserDto } from './dtos/update-user.dto';
 import { UsersService } from './users.service';
 
 @Controller('/users')
-@UsePipes(ValidationPipe)
+@UsePipes(new ValidationPipe({ whitelist: true }))
 export class UsersController {
     constructor(private readonly usersService: UsersService) {}
 

--- a/backend/src/walk/walk.controller.ts
+++ b/backend/src/walk/walk.controller.ts
@@ -8,7 +8,7 @@ import { WalkCommandDto } from './dtos/walk-command.dto';
 import { WalkService } from './walk.service';
 
 @Controller('/dogs/walks')
-@UsePipes(new ValidationPipe())
+@UsePipes(new ValidationPipe({ whitelist: true }))
 export class WalkController {
     constructor(
         private readonly walkService: WalkService,

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -1,0 +1,68 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { DataSource } from 'typeorm';
+import { mockUserProfile } from '../src/fixtures/users.fixture';
+import { Users } from '../src/users/users.entity';
+import { VALID_ACCESS_TOKEN_100_YEARS } from './constants';
+import { clearUsers, closeTestApp, insertMockUser, setupTestApp } from './test-utils';
+
+const context = describe;
+
+describe('UsersController (e2e)', () => {
+    let app: INestApplication;
+    let dataSource: DataSource;
+
+    beforeAll(async () => {
+        ({ app, dataSource } = await setupTestApp());
+    });
+
+    beforeEach(async () => {
+        await insertMockUser();
+    });
+
+    afterEach(async () => {
+        await clearUsers();
+    });
+
+    afterAll(async () => {
+        await closeTestApp();
+    });
+
+    describe('/users/me (GET)', () => {
+        context('사용자가 회원 정보 조회 요청을 보내면', () => {
+            const { id, ...mockUserInfo } = mockUserProfile;
+
+            it('200 상태 코드와 사용자 정보를 반환해야 한다.', async () => {
+                const response = await request(app.getHttpServer())
+                    .get('/users/me')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .expect(200);
+
+                expect(response.body).toEqual(mockUserInfo);
+            });
+        });
+    });
+
+    describe('/users/me (PATCH)', () => {
+        context('사용자가 회원 정보 수정 요청을 보내면', () => {
+            const { id, provider, ...mockUserInfo } = mockUserProfile;
+            const updateMockUser = {
+                nickname: 'new_mock_nickname',
+                profileImageUrl: 'new_mock_profile_image.jpg',
+            };
+
+            it('204 상태 코드를 반환해야 한다.', async () => {
+                await request(app.getHttpServer())
+                    .patch('/users/me')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send(updateMockUser)
+                    .expect(204);
+
+                const updatedUser = await dataSource.getRepository(Users).findOne({ where: { id: 1 } });
+                if (!updatedUser) throw new Error('User not found');
+                updatedUser.nickname = updatedUser.nickname.split('#')[0];
+                expect(updatedUser).toMatchObject({ ...mockUserInfo, ...updateMockUser });
+            });
+        });
+    });
+});


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
```bash
$ npm run test:e2e -- --testPathPattern=test/users.e2e-spec.ts

> nest-js-example@0.0.1 test:e2e
> cross-env NODE_ENV=test jest --config ./test/jest-e2e.json --maxWorkers=1 --testPathPattern=test/users.e2e-spec.ts

 PASS  test/users.e2e-spec.ts (8.779 s)
  UsersController (e2e)
    /users/me (GET)
      사용자가 회원 정보 조회 요청을 보내면
        √ 200 상태 코드와 사용자 정보를 반환해야 한다. (50 ms)
    /users/me (PATCH)
      사용자가 회원 정보 수정 요청을 보내면
        √ 204 상태 코드를 반환해야 한다. (37 ms)

Test Suites: 1 passed, 1 total
Tests:       2 passed, 2 total
Snapshots:   0 total
Time:        8.888 s, estimated 49 s
Ran all test suites matching /test\\users.e2e-spec.ts/i.
```

## 링크 (Links)
https://www.notion.so/do0ori/UsersController-e2e-test-7ab118e87ecb466ab92031a772b62223

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
