### PR TITLE
backend/DANG-949: BreedService의 findOne 메서드 테스트 케이스 추가

### DIFF
--- a/backend/src/breed/breed.service.spec.ts
+++ b/backend/src/breed/breed.service.spec.ts
@@ -1,0 +1,51 @@
+import { BreedService } from './breed.service';
+import { Test, TestingModule } from '@nestjs/testing';
+import { BreedRepository } from './breed.repository';
+import { Breed } from './breed.entity';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { EntityManager, Repository } from 'typeorm';
+import { mockBreed } from '../fixtures/breed.fixture';
+
+const context = describe;
+
+describe('BreedService', () => {
+    let service: BreedService;
+    let breedRepository: Repository<Breed>;
+    let repository: BreedRepository;
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                BreedService,
+                BreedRepository,
+                EntityManager,
+                {
+                    provide: getRepositoryToken(Breed),
+                    useClass: Repository,
+                },
+            ],
+        }).compile();
+
+        service = module.get<BreedService>(BreedService);
+        breedRepository = module.get<Repository<Breed>>(getRepositoryToken(Breed));
+    });
+
+    describe('findOne', () => {
+        context('견종 조회 할 때', () => {
+            beforeEach(() => {
+                jest.spyOn(breedRepository, 'findOne').mockResolvedValue(mockBreed);
+            });
+
+            it('견종 정보를 반환해야 한다.', async () => {
+                const breed = await service.findOne({ id: 1 });
+
+                expect(breed).toEqual({
+                    id: 1,
+                    englishName: 'Poodle',
+                    koreanName: '푸들',
+                    recommendedWalkAmount: 60,
+                });
+            });
+        });
+    });
+});

--- a/backend/src/fixtures/breed.fixture.ts
+++ b/backend/src/fixtures/breed.fixture.ts
@@ -1,0 +1,6 @@
+export const mockBreed = {
+    englishName: 'Poodle',
+    id: 1,
+    koreanName: '푸들',
+    recommendedWalkAmount: 60,
+};


### PR DESCRIPTION
## 작업 내용 (Content)
- BreedService의 findOne 메서드가 특정 ID의 견종 정보를 성공적으로 조회하는지 테스트
- 견종 정보 조회 성공 시, 올바른 견종 데이터를 반환하는지 검증
- Fixture 데이터를 활용하여 테스트 환경 구성

## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
