### PR TITLE
backend/DANG-969: e2e test Authorization header 인가 test 공통 함수로 분리하여 적용하기

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
         "test:cov": "cross-env NODE_ENV=test jest --coverage",
         "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
         "test:e2e": "cross-env NODE_ENV=test jest --config ./test/jest-e2e.json --maxWorkers=1",
+        "test:e2e-watch": "cross-env NODE_ENV=test jest --watch --config ./test/jest-e2e.json --maxWorkers=1",
         "test:only-changed": "cross-env NODE_ENV=test jest --onlyChanged",
         "prepare": "cd .. && husky backend/.husky"
     },

--- a/backend/test/auth.e2e-spec.ts
+++ b/backend/test/auth.e2e-spec.ts
@@ -4,16 +4,14 @@ import { DataSource } from 'typeorm';
 import { mockUser } from '../src/fixtures/users.fixture';
 import { Users } from '../src/users/users.entity';
 import {
-    EXPIRED_ACCESS_TOKEN,
     EXPIRED_REFRESH_TOKEN,
     INVALID_PROVIDER,
-    MALFORMED_ACCESS_TOKEN,
     MALFORMED_REFRESH_TOKEN,
     VALID_ACCESS_TOKEN_100_YEARS,
     VALID_PROVIDER_KAKAO,
     VALID_REFRESH_TOKEN_100_YEARS,
 } from './constants';
-import { clearUsers, closeTestApp, insertMockUser, setupTestApp } from './test-utils';
+import { clearUsers, closeTestApp, insertMockUser, setupTestApp, testUnauthorizedAccess } from './test-utils';
 
 const context = describe;
 
@@ -222,38 +220,7 @@ describe('AuthController (e2e)', () => {
             });
         });
 
-        context('Authorization header 없이 로그아웃 요청을 보내면', () => {
-            it('401 상태 코드를 반환해야 한다.', async () => {
-                return request(app.getHttpServer()).post('/auth/logout').expect(401);
-            });
-        });
-
-        context('구조가 잘못된 access token을 Authorization header에 담아 로그아웃 요청을 보내면', () => {
-            it('401 상태 코드를 반환해야 한다.', async () => {
-                return request(app.getHttpServer())
-                    .post('/auth/logout')
-                    .set('Authorization', `Bearer ${MALFORMED_ACCESS_TOKEN}`)
-                    .expect(401);
-            });
-        });
-
-        context('만료된 access token을 Authorization header에 담아 로그아웃 요청을 보내면', () => {
-            it('401 상태 코드를 반환해야 한다.', async () => {
-                return request(app.getHttpServer())
-                    .post('/auth/logout')
-                    .set('Authorization', `Bearer ${EXPIRED_ACCESS_TOKEN}`)
-                    .expect(401);
-            });
-        });
-
-        context('존재하지 않는 userId를 가진 access token을 Authorization header에 담아 로그아웃 요청을 보내면', () => {
-            it('401 상태 코드를 반환해야 한다.', async () => {
-                return request(app.getHttpServer())
-                    .post('/auth/logout')
-                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
-                    .expect(401);
-            });
-        });
+        testUnauthorizedAccess('로그아웃', 'post', '/auth/logout');
     });
 
     describe('/auth/token (GET)', () => {
@@ -333,37 +300,6 @@ describe('AuthController (e2e)', () => {
             });
         });
 
-        context('Authorization header 없이 회원탈퇴 요청을 보내면', () => {
-            it('401 상태 코드를 반환해야 한다.', async () => {
-                return request(app.getHttpServer()).delete('/auth/deactivate').expect(401);
-            });
-        });
-
-        context('구조가 잘못된 access token을 Authorization header에 담아 회원탈퇴 요청을 보내면', () => {
-            it('401 상태 코드를 반환해야 한다.', async () => {
-                return request(app.getHttpServer())
-                    .delete('/auth/deactivate')
-                    .set('Authorization', `Bearer ${MALFORMED_ACCESS_TOKEN}`)
-                    .expect(401);
-            });
-        });
-
-        context('만료된 access token을 Authorization header에 담아 회원탈퇴 요청을 보내면', () => {
-            it('401 상태 코드를 반환해야 한다.', async () => {
-                return request(app.getHttpServer())
-                    .delete('/auth/deactivate')
-                    .set('Authorization', `Bearer ${EXPIRED_ACCESS_TOKEN}`)
-                    .expect(401);
-            });
-        });
-
-        context('존재하지 않는 userId를 가진 access token을 Authorization header에 담아 회원탈퇴 요청을 보내면', () => {
-            it('401 상태 코드를 반환해야 한다.', async () => {
-                return request(app.getHttpServer())
-                    .delete('/auth/deactivate')
-                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
-                    .expect(401);
-            });
-        });
+        testUnauthorizedAccess('회원탈퇴', 'delete', '/auth/deactivate');
     });
 });

--- a/backend/test/constants.ts
+++ b/backend/test/constants.ts
@@ -1,6 +1,9 @@
 // Access token with maxAge = 100 years, userId = 1, provider = kakao
 export const VALID_ACCESS_TOKEN_100_YEARS =
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsInByb3ZpZGVyIjoia2FrYW8iLCJpYXQiOjE3MTYxODc5NzAsImV4cCI6NDg3MTk0Nzk3MH0.QlL_1luAr4T-YdA5QfKl8_ivhAlE1_FFlRfSAq2u2Lc';
+// Access token with maxAge = 100 years, userId = 100, provider = kakao
+export const INVALID_USER_ID_ACCESS_TOKEN =
+    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEwMCwicHJvdmlkZXIiOiJrYWthbyIsImlhdCI6MTcxNzkzMTM5OCwiZXhwIjoxNzE3OTM0OTk4fQ.oLl9-M7qkDZNbMmcrCNhyMcQ2Eyxxy751Xo3pBjww_4';
 export const EXPIRED_ACCESS_TOKEN =
     'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsInByb3ZpZGVyIjoia2FrYW8iLCJpYXQiOjE3MTc1OTQ4NTYsImV4cCI6MTcxNzU5NDg2Nn0.KphkJf-oCeJoZTv3fw-XvI5Qo16058r_ak5lWCJrvmg';
 export const MALFORMED_ACCESS_TOKEN = 'malformed_access_token';

--- a/backend/test/dogs.e2e-spec.ts
+++ b/backend/test/dogs.e2e-spec.ts
@@ -4,7 +4,15 @@ import { DataSource } from 'typeorm';
 import { Dogs } from '../src/dogs/dogs.entity';
 import { mockDog2Profile, mockDogProfile } from '../src/fixtures/dogs.fixture';
 import { VALID_ACCESS_TOKEN_100_YEARS } from './constants';
-import { clearDogs, clearUsers, closeTestApp, insertMockDogs, insertMockUser, setupTestApp } from './test-utils';
+import {
+    clearDogs,
+    clearUsers,
+    closeTestApp,
+    insertMockDogs,
+    insertMockUser,
+    setupTestApp,
+    testUnauthorizedAccess,
+} from './test-utils';
 
 const context = describe;
 
@@ -52,6 +60,8 @@ describe('DogsController (e2e)', () => {
                 expect(response.body).toEqual([mockDogProfile, mockDog2Profile]);
             });
         });
+
+        testUnauthorizedAccess('강아지 목록', 'get', '/dogs');
     });
 
     describe('/dogs (POST)', () => {
@@ -93,6 +103,8 @@ describe('DogsController (e2e)', () => {
                     .expect(404);
             });
         });
+
+        testUnauthorizedAccess('강아지 등록', 'post', '/dogs');
     });
 
     describe('/dogs/:id (GET)', () => {
@@ -131,6 +143,8 @@ describe('DogsController (e2e)', () => {
                     .expect(403);
             });
         });
+
+        testUnauthorizedAccess('강아지의 프로필 조회', 'get', '/dogs/1');
     });
 
     describe('/dogs/:id (PATCH)', () => {
@@ -188,6 +202,8 @@ describe('DogsController (e2e)', () => {
                     .expect(404);
             });
         });
+
+        testUnauthorizedAccess('강아지의 정보 수정', 'patch', '/dogs/1');
     });
 
     describe('/dogs/:id (DELETE)', () => {
@@ -218,5 +234,7 @@ describe('DogsController (e2e)', () => {
                     .expect(403);
             });
         });
+
+        testUnauthorizedAccess('강아지의 삭제', 'delete', '/dogs/1');
     });
 });

--- a/backend/test/statistics.e2e-spec.ts
+++ b/backend/test/statistics.e2e-spec.ts
@@ -14,6 +14,7 @@ import {
     insertMockUser,
     setFakeDate,
     setupTestApp,
+    testUnauthorizedAccess,
 } from './test-utils';
 
 const context = describe;
@@ -92,6 +93,8 @@ describe('StatisticsController (e2e)', () => {
                     .expect(400);
             });
         });
+
+        testUnauthorizedAccess('강아지의 최근 한달 간 산책 통계 조회', 'get', '/dogs/1/statistics/recent?period=month');
     });
 
     describe('/dogs/:id/statistics (GET)', () => {
@@ -210,6 +213,8 @@ describe('StatisticsController (e2e)', () => {
                     .expect(400);
             });
         });
+
+        testUnauthorizedAccess('강아지의 산책 횟수 조회', 'get', '/dogs/1/statistics?date=2024-05-08&period=month');
     });
 
     describe('/dogs/statistics (GET)', () => {
@@ -240,5 +245,7 @@ describe('StatisticsController (e2e)', () => {
                 ]);
             });
         });
+
+        testUnauthorizedAccess('강아지들의 일주일 산책 현황 조회', 'get', '/dogs/statistics');
     });
 });

--- a/backend/test/users.e2e-spec.ts
+++ b/backend/test/users.e2e-spec.ts
@@ -4,7 +4,7 @@ import { DataSource } from 'typeorm';
 import { mockUserProfile } from '../src/fixtures/users.fixture';
 import { Users } from '../src/users/users.entity';
 import { VALID_ACCESS_TOKEN_100_YEARS } from './constants';
-import { clearUsers, closeTestApp, insertMockUser, setupTestApp } from './test-utils';
+import { clearUsers, closeTestApp, insertMockUser, setupTestApp, testUnauthorizedAccess } from './test-utils';
 
 const context = describe;
 
@@ -41,6 +41,8 @@ describe('UsersController (e2e)', () => {
                 expect(response.body).toEqual(mockUserInfo);
             });
         });
+
+        testUnauthorizedAccess('회원 정보 조회', 'get', '/users/me');
     });
 
     describe('/users/me (PATCH)', () => {
@@ -64,5 +66,7 @@ describe('UsersController (e2e)', () => {
                 expect(updatedUser).toMatchObject({ ...mockUserInfo, ...updateMockUser });
             });
         });
+
+        testUnauthorizedAccess('회원 정보 수정', 'patch', '/users/me');
     });
 });


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
```bash
$ npm run test:e2e

> nest-js-example@0.0.1 test:e2e
> cross-env NODE_ENV=test jest --config ./test/jest-e2e.json --maxWorkers=1

 PASS  test/dogs.e2e-spec.ts (9.747 s)
  DogsController (e2e)
    /dogs (GET)
      사용자가 소유한 강아지가 없을 때 소유한 강아지 목록 요청을 보내면
        √ 200 상태 코드와 빈 배열을 반환해야 한다. (39 ms)
      사용자가 소유한 강아지가 존재할 때 소유한 강아지 목록 요청을 보내면
        √ 200 상태 코드와 강아지 프로필 목록을 반환해야 한다. (58 ms)
      Authorization header 없이 강아지 목록 요청을 보내면
        √ 401 상태 코드를 반환해야 한다. (12 ms)
      구조가 잘못된 access token을 Authorization header에 담아 강아지 목록 요청을 보내면
        √ 401 상태 코드를 반환해야 한다. (7 ms)
      만료된 access token을 Authorization header에 담아 강아지 목록 요청을 보내면
        √ 401 상태 코드를 반환해야 한다. (6 ms)
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 강아지 목록 요청을 보내면  
        √ 401 상태 코드를 반환해야 한다. (9 ms)
    /dogs (POST)
      사용자가 강아지 등록 요청을 보내면
        √ 201 상태 코드를 반환해야 한다. (62 ms)
      사용자가 존재하지 않는 견종으로 강아지 등록 요청을 보내면
        √ 404 상태 코드를 반환해야 한다. (60 ms)
      Authorization header 없이 강아지 등록 요청을 보내면
        √ 401 상태 코드를 반환해야 한다. (7 ms)
      구조가 잘못된 access token을 Authorization header에 담아 강아지 등록 요청을 보내면
        √ 401 상태 코드를 반환해야 한다. (6 ms)
      만료된 access token을 Authorization header에 담아 강아지 등록 요청을 보내면
        √ 401 상태 코드를 반환해야 한다. (7 ms)
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 강아지 등록 요청을 보내면  
        √ 401 상태 코드를 반환해야 한다. (8 ms)
    /dogs/:id (GET)
      사용자가 자신이 소유한 강아지의 프로필 조회 요청을 보내면
        √ 200 상태 코드와 강아지 프로필을 반환해야 한다. (73 ms)
      사용자가 자신이 소유하지 않은 강아지의 프로필 조회 요청을 보내면
        √ 403 상태 코드를 반환해야 한다. (62 ms)
      Authorization header 없이 강아지의 프로필 조회 요청을 보내면
        √ 401 상태 코드를 반환해야 한다. (7 ms)
      구조가 잘못된 access token을 Authorization header에 담아 강아지의 프로필 조회 요청을 보내면       
        √ 401 상태 코드를 반환해야 한다. (6 ms)
      만료된 access token을 Authorization header에 담아 강아지의 프로필 조회 요청을 보내면
        √ 401 상태 코드를 반환해야 한다. (8 ms)
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 강아지의 프로필 조회 요청을 보내면
        √ 401 상태 코드를 반환해야 한다. (11 ms)
    /dogs/:id (PATCH)
      사용자가 자신이 소유한 강아지의 정보 수정 요청을 보내면
        √ 204 상태 코드를 반환해야 한다. (67 ms)
      사용자가 자신이 소유하지 않은 강아지의 정보 수정 요청을 보내면
        √ 403 상태 코드를 반환해야 한다. (12 ms)
      사용자가 존재하지 않는 견종으로 강아지의 정보 수정 요청을 보내면                                  
        √ 404 상태 코드를 반환해야 한다. (63 ms)                                                        
      Authorization header 없이 강아지의 정보 수정 요청을 보내면                                        
        √ 401 상태 코드를 반환해야 한다. (5 ms)                                                         
      구조가 잘못된 access token을 Authorization header에 담아 강아지의 정보 수정 요청을 보내면         
        √ 401 상태 코드를 반환해야 한다. (8 ms)                                                         
      만료된 access token을 Authorization header에 담아 강아지의 정보 수정 요청을 보내면                
        √ 401 상태 코드를 반환해야 한다. (7 ms)                                                         
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 강아지의 정보 수정 요청을  
보내면                                                                                                  
        √ 401 상태 코드를 반환해야 한다. (11 ms)
    /dogs/:id (DELETE)                                                                                  
      사용자가 자신이 소유한 강아지의 삭제 요청을 보내면                                                
        √ 204 상태 코드를 반환해야 한다. (70 ms)                                                        
      사용자가 자신이 소유하지 않은 강아지의 삭제 요청을 보내면                                         
        √ 403 상태 코드를 반환해야 한다. (8 ms)                                                         
      Authorization header 없이 강아지의 삭제 요청을 보내면                                             
        √ 401 상태 코드를 반환해야 한다. (7 ms)                                                         
      구조가 잘못된 access token을 Authorization header에 담아 강아지의 삭제 요청을 보내면              
        √ 401 상태 코드를 반환해야 한다. (5 ms)                                                         
      만료된 access token을 Authorization header에 담아 강아지의 삭제 요청을 보내면                     
        √ 401 상태 코드를 반환해야 한다. (12 ms)                                                        
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 강아지의 삭제 요청을 보내면
        √ 401 상태 코드를 반환해야 한다. (11 ms)                                                        
                                                                                                        
 PASS  test/users.e2e-spec.ts                                                                           
  UsersController (e2e)
    /users/me (GET)                                                                                     
      사용자가 회원 정보 조회 요청을 보내면                                                             
        √ 200 상태 코드와 사용자 정보를 반환해야 한다. (36 ms)                                          
      Authorization header 없이 회원 정보 조회 요청을 보내면                                            
        √ 401 상태 코드를 반환해야 한다. (23 ms)                                                        
      구조가 잘못된 access token을 Authorization header에 담아 회원 정보 조회 요청을 보내면             
        √ 401 상태 코드를 반환해야 한다. (17 ms)                                                        
      만료된 access token을 Authorization header에 담아 회원 정보 조회 요청을 보내면                    
        √ 401 상태 코드를 반환해야 한다. (19 ms)                                                        
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 회원 정보 조회 요청을 보내 
면                                                                                                      
        √ 401 상태 코드를 반환해야 한다. (20 ms)
    /users/me (PATCH)                                                                                   
      사용자가 회원 정보 수정 요청을 보내면                                                             
        √ 204 상태 코드를 반환해야 한다. (40 ms)                                                        
      Authorization header 없이 회원 정보 수정 요청을 보내면                                            
        √ 401 상태 코드를 반환해야 한다. (21 ms)                                                        
      구조가 잘못된 access token을 Authorization header에 담아 회원 정보 수정 요청을 보내면             
        √ 401 상태 코드를 반환해야 한다. (20 ms)                                                        
      만료된 access token을 Authorization header에 담아 회원 정보 수정 요청을 보내면                    
        √ 401 상태 코드를 반환해야 한다. (20 ms)                                                        
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 회원 정보 수정 요청을 보내 
면                                                                                                      
        √ 401 상태 코드를 반환해야 한다. (22 ms)
                                                                                                        
 PASS  test/statistics.e2e-spec.ts                                                                      
  StatisticsController (e2e)
    /dogs/:id/statistics/recent (GET)
      사용자가 소유한 강아지의 최근 한달 간 산책 통계 조회 요청을 보내면                                
        √ 200 상태 코드와 산책 통계를 반환해야 한다. (142 ms)                                           
      사용자가 소유하지 않은 강아지의 최근 한달 간 산책 통계 조회 요청을 보내면                         
        √ 403 상태 코드를 반환해야 한다. (102 ms)                                                       
      period query 없이 강아지의 최근 한달 간 산책 통계 조회 요청을 보내면                              
        √ 400 상태 코드를 반환해야 한다. (128 ms)                                                       
      유효하지 않은 period query로 강아지의 최근 한달 간 산책 통계 조회 요청을 보내면                   
        √ 400 상태 코드를 반환해야 한다. (136 ms)                                                       
      Authorization header 없이 강아지의 최근 한달 간 산책 통계 조회 요청을 보내면                      
        √ 401 상태 코드를 반환해야 한다. (119 ms)                                                       
      구조가 잘못된 access token을 Authorization header에 담아 강아지의 최근 한달 간 산책 통계 조회 요청을 보내면                                                                                               
        √ 401 상태 코드를 반환해야 한다. (80 ms)
      만료된 access token을 Authorization header에 담아 강아지의 최근 한달 간 산책 통계 조회 요청을 보내면                                                                                                      
        √ 401 상태 코드를 반환해야 한다. (86 ms)
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 강아지의 최근 한달 간 산책 통계 조회 요청을 보내면                                                                                 
        √ 401 상태 코드를 반환해야 한다. (85 ms)
    /dogs/:id/statistics (GET)                                                                          
      사용자가 소유한 강아지의 한달 산책 횟수 조회 요청을 보내면                                        
        √ 200 상태 코드와 한달 산책 횟수를 반환해야 한다. (81 ms)                                       
      사용자가 소유한 강아지의 일주일 산책 횟수 조회 요청을 보내면                                      
        √ 200 상태 코드와 일주일 산책 횟수를 반환해야 한다. (87 ms)                                     
      사용자가 소유하지 않은 강아지의 한달 산책 횟수 조회 요청을 보내면                                 
        √ 403 상태 코드를 반환해야 한다. (90 ms)                                                        
      사용자가 소유하지 않은 강아지의 일주일 산책 횟수 조회 요청을 보내면                               
        √ 403 상태 코드를 반환해야 한다. (82 ms)                                                        
      date query 없이 강아지의 산책 횟수 조회 요청을 보내면                                             
        √ 400 상태 코드를 반환해야 한다. (86 ms)                                                        
      YYYY-MM-DD 형식이 아닌 date query로 강아지의 산책 횟수 조회 요청을 보내면                         
        √ 400 상태 코드를 반환해야 한다. (82 ms)                                                        
      period query 없이 강아지의 산책 횟수 조회 요청을 보내면                                           
        √ 400 상태 코드를 반환해야 한다. (86 ms)                                                        
      유효하지 않은 period query로 강아지의 산책 횟수 조회 요청을 보내면                                
        √ 400 상태 코드를 반환해야 한다. (85 ms)                                                        
      Authorization header 없이 강아지의 산책 횟수 조회 요청을 보내면                                   
        √ 401 상태 코드를 반환해야 한다. (74 ms)                                                        
      구조가 잘못된 access token을 Authorization header에 담아 강아지의 산책 횟수 조회 요청을 보내면    
        √ 401 상태 코드를 반환해야 한다. (72 ms)                                                        
      만료된 access token을 Authorization header에 담아 강아지의 산책 횟수 조회 요청을 보내면           
        √ 401 상태 코드를 반환해야 한다. (74 ms)                                                        
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 강아지의 산책 횟수 조회 요 
청을 보내면                                                                                             
        √ 401 상태 코드를 반환해야 한다. (92 ms)
    /dogs/statistics (GET)                                                                              
      사용자가 소유한 강아지들의 일주일 산책 현황 조회 요청을 보내면                                    
        √ 200 상태 코드와 일주일 산책 현황을 반환해야 한다. (125 ms)                                    
      Authorization header 없이 강아지들의 일주일 산책 현황 조회 요청을 보내면                          
        √ 401 상태 코드를 반환해야 한다. (107 ms)                                                       
      구조가 잘못된 access token을 Authorization header에 담아 강아지들의 일주일 산책 현황 조회 요청을  
보내면                                                                                                  
        √ 401 상태 코드를 반환해야 한다. (144 ms)
      만료된 access token을 Authorization header에 담아 강아지들의 일주일 산책 현황 조회 요청을 보내면  
        √ 401 상태 코드를 반환해야 한다. (170 ms)                                                       
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 강아지들의 일주일 산책 현황 조회 요청을 보내면                                                                                     
        √ 401 상태 코드를 반환해야 한다. (163 ms)
                                                                                                        
 PASS  test/auth.e2e-spec.ts
  AuthController (e2e)
    /auth/login (POST)                                                                                  
      비회원이 로그인 요청을 보내면                                                                     
        √ 404 상태 코드와 Oauth data cookie를 반환해야 한다. (86 ms)                                    
      회원이 로그인 요청을 보내면                                                                       
        √ 200 상태 코드와 body에는 access token, cookie에는 refresh token을 반환해야 한다. (42 ms)      
      요청 body에 authorizeCode field가 빠진 경우                                                       
        √ 400 상태 코드를 반환해야 한다. (14 ms)                                                        
      요청 body에 provider field가 빠진 경우                                                            
        √ 400 상태 코드를 반환해야 한다. (19 ms)                                                        
      요청 body의 provider field 값이 google, kakao, naver 중 하나가 아닌 경우                          
        √ 400 상태 코드를 반환해야 한다. (7 ms)                                                         
    /auth/signup (POST)                                                                                 
      비회원이 회원가입 요청을 보내면                                                                   
        √ 201 상태 코드와 body에는 access token, cookie에는 refresh token을 반환하고 Oauth data cookie를 삭제해야 한다. (46 ms)                                                                                 
      회원이 회원가입 요청을 보내면
        √ 409 상태 코드를 반환해야 한다. (32 ms)                                                        
      요청 cookie에 oauthRefreshToken field가 빠진 경우                                                 
        √ 401 상태 코드를 반환해야 한다. (12 ms)                                                        
      요청 cookie에 oauthAccessToken field가 없는 경우                                                  
        √ 401 상태 코드를 반환해야 한다. (10 ms)                                                        
      요청 cookie에 provider field가 없는 경우                                                          
        √ 401 상태 코드를 반환해야 한다. (9 ms)                                                         
      요청 cookie의 provider field 값이 google, kakao, naver 중 하나가 아닌 경우                        
        √ 400 상태 코드를 반환해야 한다. (7 ms)                                                         
    /auth/logout (POST)                                                                                 
      회원이 유효한 access token을 Authorization header에 담아 로그아웃 요청을 보내면                   
        √ 200 상태 코드를 반환하고 refresh token cookie를 삭제해야 한다. (31 ms)                        
      Authorization header 없이 로그아웃 요청을 보내면                                                  
        √ 401 상태 코드를 반환해야 한다. (15 ms)                                                        
      구조가 잘못된 access token을 Authorization header에 담아 로그아웃 요청을 보내면                   
        √ 401 상태 코드를 반환해야 한다. (12 ms)                                                        
      만료된 access token을 Authorization header에 담아 로그아웃 요청을 보내면                          
        √ 401 상태 코드를 반환해야 한다. (12 ms)                                                        
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 로그아웃 요청을 보내면     
        √ 401 상태 코드를 반환해야 한다. (18 ms)                                                        
    /auth/token (GET)                                                                                   
      회원이 유효한 refresh token을 cookie에 가지고 token 재발급 요청을 보내면                          
        √ 200 상태 코드와 body에는 access token, cookie에는 refresh token을 반환해야 한다. (44 ms)      
      요청 cookie에 refreshToken field가 없는 경우                                                      
        √ 401 상태 코드를 반환해야 한다. (9 ms)                                                         
      구조가 잘못된 refresh token을 cookie에 담아 token 재발급 요청을 보내면                            
        √ 401 상태 코드를 반환해야 한다. (13 ms)                                                        
      만료된 refresh token을 cookie에 담아 token 재발급 요청을 보내면                                   
        √ 401 상태 코드를 반환해야 한다. (15 ms)                                                        
      존재하지 않는 oauthId를 가진 refresh token을 cookie에 담아 token 재발급 요청을 보내면             
        √ 401 상태 코드를 반환해야 한다. (14 ms)                                                        
    /auth/deactivate (DELETE)                                                                           
      회원이 유효한 access token을 Authorization header에 담아 회원탈퇴 요청을 보내면                   
        √ 200 상태 코드를 반환하고 refresh token cookie를 삭제해야 한다. (39 ms)                        
      Authorization header 없이 회원탈퇴 요청을 보내면                                                  
        √ 401 상태 코드를 반환해야 한다. (7 ms)                                                         
      구조가 잘못된 access token을 Authorization header에 담아 회원탈퇴 요청을 보내면                   
        √ 401 상태 코드를 반환해야 한다. (6 ms)                                                         
      만료된 access token을 Authorization header에 담아 회원탈퇴 요청을 보내면                          
        √ 401 상태 코드를 반환해야 한다. (6 ms)                                                         
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 회원탈퇴 요청을 보내면     
        √ 401 상태 코드를 반환해야 한다. (12 ms)                                                        
                                                                                                        
 PASS  test/breed.e2e-spec.ts                                                                           
  BreedController (e2e)
    /breeds (GET)                                                                                       
      견종 목록 가져오기 요청을 보내면                                                                  
        √ 200 상태 코드와 견종 목록을 반환해야 한다. (25 ms)                                            
                                                                                                        
 PASS  test/app.e2e-spec.ts                                                                             
  AppController (e2e)
    √ / (GET) (14 ms)                                                                                   
                                                                                                        
Test Suites: 6 passed, 6 total                                                                          
Tests:       94 passed, 94 total                                                                        
Snapshots:   0 total
Time:        23.749 s, estimated 25 s
Ran all test suites.
```

## 링크 (Links)
https://www.notion.so/do0ori/e2e-test-Authorization-header-test-29995d0d9e704ac08291de1c0921a8e9

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
