### PR TITLE
backend/DANG-942: S3Controller e2e test 코드 작성

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -128,9 +128,10 @@ export class AuthService {
     @Transactional()
     private async deleteUserData(userId: number) {
         const dogIds = await this.usersService.getOwnDogsList(userId);
-        dogIds.forEach(async (dogId) => {
+
+        for (const dogId of dogIds) {
             await this.dogsService.deleteDogFromUser(userId, dogId);
-        });
+        }
 
         await this.usersService.delete({ id: userId });
         await this.s3Service.deleteObjectFolder(userId);

--- a/backend/src/s3/__mocks__/s3.service.ts
+++ b/backend/src/s3/__mocks__/s3.service.ts
@@ -1,3 +1,4 @@
+import { ForbiddenException } from '@nestjs/common';
 import { generateUuid } from '../../utils/hash.util';
 import { PresignedUrlInfo } from '../types/presigned-url-info.type';
 
@@ -10,7 +11,13 @@ export const MockS3Service = {
         }));
     }),
 
-    deleteObjects: jest.fn(),
+    deleteObjects: jest.fn((userId: number, filenames: string[]) => {
+        for (const curFilename of filenames) {
+            if (parseInt(curFilename.split('/')[0]) !== userId) {
+                throw new ForbiddenException(`User ${userId} is not owner of the file ${curFilename}`);
+            }
+        }
+    }),
 
     deleteSingleObject: jest.fn(),
 

--- a/backend/src/s3/s3.controller.ts
+++ b/backend/src/s3/s3.controller.ts
@@ -1,5 +1,4 @@
-import { Body, Controller, Delete, ParseArrayPipe, Post } from '@nestjs/common';
-
+import { Body, Controller, Delete, HttpCode, ParseArrayPipe, Post } from '@nestjs/common';
 import { AccessTokenPayload } from '../auth/token/token.service';
 import { User } from '../users/decorators/user.decorator';
 
@@ -11,6 +10,7 @@ export class S3Controller {
     constructor(private readonly s3Service: S3Service) {}
 
     @Post('/upload')
+    @HttpCode(200)
     async upload(
         @User() user: AccessTokenPayload,
         @Body(new ParseArrayPipe({ items: String, separator: ',' })) type: string[],

--- a/backend/test/s3.e2e-spec.ts
+++ b/backend/test/s3.e2e-spec.ts
@@ -1,0 +1,70 @@
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { VALID_ACCESS_TOKEN_100_YEARS } from './constants';
+import { clearUsers, closeTestApp, insertMockUser, setupTestApp, testUnauthorizedAccess } from './test-utils';
+
+const context = describe;
+
+describe('S3Controller (e2e)', () => {
+    let app: INestApplication;
+
+    beforeAll(async () => {
+        ({ app } = await setupTestApp());
+        await insertMockUser();
+    });
+
+    afterAll(async () => {
+        await clearUsers();
+        await closeTestApp();
+    });
+
+    describe('/api/upload (POST)', () => {
+        context('사용자가 이미지 업로드를 위한 presignedUrl 요청을 보내면', () => {
+            it('200 상태 코드와 presignedUrl을 반환해야 한다.', async () => {
+                const response = await request(app.getHttpServer())
+                    .post('/api/upload')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send(['jpeg', 'png'])
+                    .expect(200);
+
+                expect(response.body.length).toBe(2);
+
+                expect(response.body[0]).toHaveProperty('filename');
+                expect(response.body[0]).toHaveProperty('url');
+                expect(response.body[0].filename).toMatch(new RegExp(`^1/[a-f0-9-]+\.jpeg$`));
+                expect(typeof response.body[0].url).toBe('string');
+
+                expect(response.body[1]).toHaveProperty('filename');
+                expect(response.body[1]).toHaveProperty('url');
+                expect(response.body[1].filename).toMatch(new RegExp(`^1/[a-f0-9-]+\.png$`));
+                expect(typeof response.body[1].url).toBe('string');
+            });
+        });
+
+        testUnauthorizedAccess('이미지 업로드를 위한 presignedUrl', 'post', '/api/upload');
+    });
+
+    describe('/api/delete (DELETE)', () => {
+        context('사용자가 자신이 소유한 이미지의 삭제 요청을 보내면', () => {
+            it('200 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .delete('/api/delete')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send(['1/dangdangwalk-1.jpeg', '1/dangdangwalk-2.png'])
+                    .expect(200);
+            });
+        });
+
+        context('사용자가 자신이 소유하지 않은 이미지의 삭제 요청을 보내면', () => {
+            it('403 상태 코드를 반환해야 한다.', () => {
+                return request(app.getHttpServer())
+                    .delete('/api/delete')
+                    .set('Authorization', `Bearer ${VALID_ACCESS_TOKEN_100_YEARS}`)
+                    .send(['1/dangdangwalk-1.jpeg', '2/dangdangwalk-2.png'])
+                    .expect(403);
+            });
+        });
+
+        testUnauthorizedAccess('이미지 삭제', 'delete', '/api/delete');
+    });
+});


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
```bash
$ npm run test:e2e -- --testPathPattern=test/s3.e2e-spec.ts

> nest-js-example@0.0.1 test:e2e
> cross-env NODE_ENV=test jest --config ./test/jest-e2e.json --maxWorkers=1 --testPathPattern=test/s3.e2e-spec.ts

 PASS  test/s3.e2e-spec.ts (11.833 s)
  S3Controller (e2e)
    /api/upload (POST)                                                                                                                                                                                             
      사용자가 이미지 업로드를 위한 presignedUrl 요청을 보내면                                                                                                                                                     
        √ 200 상태 코드와 presignedUrl을 반환해야 한다. (49 ms)                                                                                                                                                    
      Authorization header 없이 이미지 업로드를 위한 presignedUrl 요청을 보내면                                                                                                                                    
        √ 401 상태 코드를 반환해야 한다. (31 ms)                                                                                                                                                                   
      구조가 잘못된 access token을 Authorization header에 담아 이미지 업로드를 위한 presignedUrl 요청을 보내면                                                                                                     
        √ 401 상태 코드를 반환해야 한다. (8 ms)                                                                                                                                                                    
      만료된 access token을 Authorization header에 담아 이미지 업로드를 위한 presignedUrl 요청을 보내면                                                                                                            
        √ 401 상태 코드를 반환해야 한다. (10 ms)                                                                                                                                                                   
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 이미지 업로드를 위한 presignedUrl 요청을 보내면                                                                                       
        √ 401 상태 코드를 반환해야 한다. (10 ms)                                                                                                                                                                   
    /api/delete (DELETE)                                                                                                                                                                                           
      사용자가 자신이 소유한 이미지의 삭제 요청을 보내면                                                                                                                                                           
        √ 200 상태 코드를 반환해야 한다. (14 ms)                                                                                                                                                                   
      사용자가 자신이 소유하지 않은 이미지의 삭제 요청을 보내면                                                                                                                                                    
        √ 403 상태 코드를 반환해야 한다. (13 ms)                                                                                                                                                                   
      Authorization header 없이 이미지 삭제 요청을 보내면                                                                                                                                                          
        √ 401 상태 코드를 반환해야 한다. (8 ms)                                                                                                                                                                    
      구조가 잘못된 access token을 Authorization header에 담아 이미지 삭제 요청을 보내면                                                                                                                           
        √ 401 상태 코드를 반환해야 한다. (8 ms)                                                                                                                                                                    
      만료된 access token을 Authorization header에 담아 이미지 삭제 요청을 보내면                                                                                                                                  
        √ 401 상태 코드를 반환해야 한다. (9 ms)                                                                                                                                                                    
      존재하지 않는 userId를 가진 access token을 Authorization header에 담아 이미지 삭제 요청을 보내면                                                                                                             
        √ 401 상태 코드를 반환해야 한다. (13 ms)                                                                                                                                                                   
                                                                                                                                                                                                                   
Test Suites: 1 passed, 1 total                                                                                                                                                                                     
Tests:       11 passed, 11 total                                                                                                                                                                                   
Snapshots:   0 total
Time:        11.968 s
Ran all test suites matching /test\\s3.e2e-spec.ts/i.
```

## 링크 (Links)
https://www.notion.so/do0ori/S3Controller-e2e-test-0037dcd0942d450fb5a5e77760e7c987

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [x] CI 파이프라인이 통과가 되었나요?
