### PR TITLE
frontend/DANG-975: 로그아웃, 회원탈퇴  후 isSignedIn bfcache 문제 해결

### DIFF
--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -86,20 +86,24 @@ const useSignOut = (mutationOptions?: UseMutationCustomOptions) => {
             queryClient.resetQueries({ queryKey: [queryKeys.AUTH] });
             queryClient.refetchQueries({ queryKey: [queryKeys.DOGS] });
         },
+        onSettled: () => {
+            window.location.href = '/';
+        },
         ...mutationOptions,
     });
 };
 
 const useDeactivate = (mutationOptions?: UseMutationCustomOptions) => {
     const { storeSignOut } = useAuthStore();
-    const navigate = useNavigate();
     return useMutation({
         mutationFn: requestDeactivate,
         onSuccess: () => {
             storeSignOut();
             queryClient.resetQueries({ queryKey: [queryKeys.AUTH] });
             queryClient.refetchQueries({ queryKey: [queryKeys.DOGS] });
-            navigate('/');
+        },
+        onSettled: () => {
+            window.location.href = '/';
         },
         ...mutationOptions,
     });


### PR DESCRIPTION
## 작업 내용 (Content)
<!--해당 PR에 대한 설명 혹은 이미지, 링크 등을 넣어주세요. -->
as-is : 
1. 회원탈퇴 후 useNavigate 사용해서 '/' 루트로 리다이렉트했더니 re-render 에러 발생
2. 로그아웃 후 홈으로 갔다가 마이페이지로 이동하면 isSignedIn 스토리지가 bfcache되는 문제 발생

to-be: 
1. window.location.href = '/'으로 리다이렉트로 해결
2.window.location.href = '/'으로 리다이렉트해서 새로고침됨으로써 bfcache 캐싱 해결 
## 링크 (Links)

## 기타 사항 (Etc)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [ ] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [ ] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?
