### PR TITLE
backend/DANG-1283: 강아지 프로필·품종 조회 캐시 도입 및 통계 캐시 정비

### DIFF
--- a/backend/server/jest.config.cjs
+++ b/backend/server/jest.config.cjs
@@ -3,6 +3,7 @@ module.exports = {
     testEnvironment: 'node',
     moduleFileExtensions: ['js', 'json', 'ts'],
     setupFiles: ['jest-plugin-context/setup'],
+    modulePaths: ['<rootDir>/src'],
     moduleNameMapper: {
         '^src/(.*)$': '<rootDir>/src/$1',
     },

--- a/backend/server/src/applications/breed/breed.service.spec.ts
+++ b/backend/server/src/applications/breed/breed.service.spec.ts
@@ -1,40 +1,58 @@
+jest.mock('shared/database', () => ({
+    TypeORMRepository: class {},
+}));
+
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
 import { NotFoundException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 
-import { getRepositoryToken } from '@nestjs/typeorm';
+import { Cache } from 'cache-manager';
 
-import { mockBreed } from '_tests_/breed.fixture';
-import { EntityManager, Repository } from 'typeorm';
-
-import { Breed } from './breed.entity';
 import { BreedRepository } from './breed.repository';
 import { BreedService } from './breed.service';
 
+const mockBreed = { id: 1, englishName: 'Poodle', koreanName: '푸들', recommendedWalkAmount: 60 };
+
+const mockCacheManager: Partial<Cache> = {
+    get: jest.fn().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue(undefined),
+    del: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockBreedRepository = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+};
+
 describe('BreedService', () => {
     let service: BreedService;
-    let breedRepository: Repository<Breed>;
+    let cacheManager: Cache;
 
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
                 BreedService,
-                BreedRepository,
-                EntityManager,
                 {
-                    provide: getRepositoryToken(Breed),
-                    useClass: Repository,
+                    provide: BreedRepository,
+                    useValue: mockBreedRepository,
+                },
+                {
+                    provide: CACHE_MANAGER,
+                    useValue: mockCacheManager,
                 },
             ],
         }).compile();
 
         service = module.get<BreedService>(BreedService);
-        breedRepository = module.get<Repository<Breed>>(getRepositoryToken(Breed));
+        cacheManager = module.get(CACHE_MANAGER);
+
+        jest.clearAllMocks();
     });
 
     describe('findOne', () => {
         context('견종 조회 할 때', () => {
             beforeEach(() => {
-                jest.spyOn(breedRepository, 'findOne').mockResolvedValue(mockBreed);
+                mockBreedRepository.findOne.mockResolvedValue(mockBreed);
             });
 
             it('견종 정보를 반환해야 한다.', async () => {
@@ -51,24 +69,24 @@ describe('BreedService', () => {
     });
 
     describe('getKoreanNames', () => {
-        context('견종의 한국어 이름을 조회할 때', () => {
-            const mockBreedList = [
-                {
-                    englishName: 'Poodle',
-                    id: 1,
-                    koreanName: '푸들',
-                    recommendedWalkAmount: 60,
-                },
-                {
-                    englishName: 'Airedale Terrier',
-                    id: 2,
-                    koreanName: '에어데일 테리어',
-                    recommendedWalkAmount: 1800,
-                },
-            ];
+        const mockBreedList = [
+            {
+                englishName: 'Poodle',
+                id: 1,
+                koreanName: '푸들',
+                recommendedWalkAmount: 60,
+            },
+            {
+                englishName: 'Airedale Terrier',
+                id: 2,
+                koreanName: '에어데일 테리어',
+                recommendedWalkAmount: 1800,
+            },
+        ];
 
+        context('견종의 한국어 이름을 조회할 때', () => {
             beforeEach(() => {
-                jest.spyOn(breedRepository, 'find').mockResolvedValue(mockBreedList);
+                mockBreedRepository.find.mockResolvedValue(mockBreedList);
             });
 
             it('견종의 한국어 이름 리스트를 반환한다.', async () => {
@@ -76,11 +94,35 @@ describe('BreedService', () => {
 
                 expect(breed).toEqual(['푸들', '에어데일 테리어']);
             });
+
+            it('결과를 캐시에 저장해야 한다.', async () => {
+                await service.getKoreanNames();
+
+                expect(cacheManager.set).toHaveBeenCalledWith(
+                    'breeds:koreanNames',
+                    ['푸들', '에어데일 테리어'],
+                    expect.any(Number),
+                );
+            });
+        });
+
+        context('캐시에 데이터가 있으면', () => {
+            beforeEach(() => {
+                (cacheManager.get as jest.Mock).mockResolvedValue(['푸들', '에어데일 테리어']);
+            });
+
+            it('DB를 조회하지 않고 캐시된 값을 반환해야 한다.', async () => {
+                const result = await service.getKoreanNames();
+
+                expect(result).toEqual(['푸들', '에어데일 테리어']);
+                expect(mockBreedRepository.find).not.toHaveBeenCalled();
+            });
         });
 
         context('견종 목록이 존재하지 않으면', () => {
             beforeEach(() => {
-                jest.spyOn(breedRepository, 'find').mockResolvedValue([]);
+                (cacheManager.get as jest.Mock).mockResolvedValue(null);
+                mockBreedRepository.find.mockResolvedValue([]);
             });
 
             it('NotFoundException 예외를 던져야 한다.', async () => {
@@ -111,7 +153,7 @@ describe('BreedService', () => {
         const not_exist_BreedIds = [999, 1000];
 
         beforeEach(() => {
-            jest.spyOn(breedRepository, 'find').mockResolvedValue(mockBreedList);
+            mockBreedRepository.find.mockResolvedValue(mockBreedList);
         });
 
         context('견종 id가 주어지면', () => {
@@ -132,7 +174,7 @@ describe('BreedService', () => {
 
         context('견종 목록이 빈 값이면', () => {
             beforeEach(() => {
-                jest.spyOn(breedRepository, 'find').mockResolvedValue([]);
+                mockBreedRepository.find.mockResolvedValue([]);
             });
             it('NotFoundException 예외를 던져야 한다.', async () => {
                 await expect(service.getRecommendedWalkAmountList(not_exist_BreedIds)).rejects.toThrow(

--- a/backend/server/src/applications/breed/breed.service.ts
+++ b/backend/server/src/applications/breed/breed.service.ts
@@ -1,25 +1,43 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Cache } from 'cache-manager';
 import { FindOneOptions, In } from 'typeorm';
 
 import { Breed } from './breed.entity';
 import { BreedRepository } from './breed.repository';
 
+import { CACHE_TTL } from '../../shared/utils/etc';
+
 @Injectable()
 export class BreedService {
-    constructor(private readonly breedRepository: BreedRepository) {}
+    private static readonly BREED_NAMES_CACHE_KEY = 'breeds:koreanNames';
+
+    constructor(
+        private readonly breedRepository: BreedRepository,
+        @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
+    ) {}
 
     async findOne(where: FindOneOptions<Breed>): Promise<Breed> {
         return this.breedRepository.findOne(where);
     }
 
     async getKoreanNames(): Promise<string[]> {
+        const cached = await this.cacheManager.get<string[]>(BreedService.BREED_NAMES_CACHE_KEY);
+
+        if (cached) {
+            return cached;
+        }
+
         const breeds = await this.breedRepository.find({ select: ['koreanName'] });
 
         if (!breeds.length) {
             throw new NotFoundException(`견종 목록을 찾을 수 없습니다.`);
         }
 
-        return breeds.map((breed) => breed.koreanName);
+        const names = breeds.map((breed) => breed.koreanName);
+        await this.cacheManager.set(BreedService.BREED_NAMES_CACHE_KEY, names, CACHE_TTL.BREED_NAMES);
+
+        return names;
     }
 
     async getRecommendedWalkAmountList(breedIds: number[]): Promise<number[]> {

--- a/backend/server/src/applications/dogs/dogs.service.ts
+++ b/backend/server/src/applications/dogs/dogs.service.ts
@@ -1,5 +1,6 @@
-import { ConflictException, Injectable } from '@nestjs/common';
-import { EventEmitter2 } from '@nestjs/event-emitter';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { ConflictException, Inject, Injectable } from '@nestjs/common';
+import { EventEmitter2, OnEvent } from '@nestjs/event-emitter';
 import { BreedService } from 'applications/breed';
 import { DogWalkDay } from 'applications/dog-walk-day/dog-walk-day.entity';
 import { DogWalkDayService } from 'applications/dog-walk-day/dog-walk-day.service';
@@ -7,6 +8,7 @@ import { TodayWalkTime } from 'applications/today-walk-time/today-walk-time.enti
 import { TodayWalkTimeService } from 'applications/today-walk-time/today-walk-time.service';
 import { UsersDogs } from 'applications/users-dogs/users-dogs.entity';
 import { UsersDogsService } from 'applications/users-dogs/users-dogs.service';
+import { Cache } from 'cache-manager';
 import { EntityManager, FindManyOptions, FindOneOptions, FindOptionsWhere, In } from 'typeorm';
 import { Transactional } from 'typeorm-transactional';
 
@@ -16,7 +18,7 @@ import { DogsRepository } from './dogs.repository';
 import { CreateDogRequest, DogProfileResponse, DogSummaryResponse, UpdateDogRequest } from './types/dogs.type';
 
 import { S3Service } from '../../infrastructure/aws/s3/s3.service';
-import { EVENTS } from '../../shared/utils/etc';
+import { CACHE_TTL, EVENTS } from '../../shared/utils/etc';
 import { makeSubObject, makeSubObjectsArray } from '../../shared/utils/manipulate.util';
 import { UsersService } from '../users/users.service';
 
@@ -32,6 +34,7 @@ export class DogsService {
         private readonly todayWalkTimeService: TodayWalkTimeService,
         private readonly s3Service: S3Service,
         private readonly entityManager: EntityManager,
+        @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
     ) {}
 
     @Transactional()
@@ -89,6 +92,7 @@ export class DogsService {
             this.todayWalkTimeService.delete({ id: In(todayWalkTimeIds) }),
             profilePhotoUrls.length ? this.s3Service.deleteObjects(userId, profilePhotoUrls) : Promise.resolve(),
         ]);
+        this.eventEmitter.emit(EVENTS.DOG_DELETED, { userId });
     }
 
     async find(where: FindManyOptions<Dogs>): Promise<Dogs[]> {
@@ -159,6 +163,13 @@ export class DogsService {
     }
 
     async getProfileList(userId: number): Promise<DogProfileResponse[]> {
+        const cacheKey = this.generateProfilesCacheKey(userId);
+        const cached = await this.cacheManager.get<DogProfileResponse[]>(cacheKey);
+
+        if (cached) {
+            return cached;
+        }
+
         const dogInfos = await this.entityManager
             .createQueryBuilder(Dogs, 'dogs')
             .innerJoin(UsersDogs, 'users_dogs', 'users_dogs.dogId = dogs.id')
@@ -166,7 +177,22 @@ export class DogsService {
             .where('users_dogs.userId = :userId', { userId })
             .getMany();
 
-        return dogInfos.map((dogInfo) => this.makeProfile(dogInfo));
+        const profiles = dogInfos.map((dogInfo) => this.makeProfile(dogInfo));
+        await this.cacheManager.set(cacheKey, profiles, CACHE_TTL.DOG_PROFILES);
+
+        return profiles;
+    }
+
+    @OnEvent(EVENTS.DOG_CREATED)
+    @OnEvent(EVENTS.DOG_DELETED)
+    @OnEvent(EVENTS.DOG_UPDATED)
+    async invalidateProfilesCache(payload: { userId: number }) {
+        const cacheKey = this.generateProfilesCacheKey(payload.userId);
+        await this.cacheManager.del(cacheKey);
+    }
+
+    private generateProfilesCacheKey(userId: number) {
+        return `dogs:profiles:${userId}`;
     }
 
     async getRelatedTableIdList(

--- a/backend/server/src/applications/statistics/statistics.module.ts
+++ b/backend/server/src/applications/statistics/statistics.module.ts
@@ -1,4 +1,3 @@
-import { CacheModule } from '@nestjs/cache-manager';
 import { Module } from '@nestjs/common';
 
 import { StatisticsController } from './statistics.controller';
@@ -7,7 +6,7 @@ import { StatisticsService } from './statistics.service';
 import { JournalsModule } from '../journals/journals.module';
 
 @Module({
-    imports: [JournalsModule, CacheModule.register()],
+    imports: [JournalsModule],
     controllers: [StatisticsController],
     providers: [StatisticsService],
 })

--- a/backend/server/src/applications/statistics/statistics.service.ts
+++ b/backend/server/src/applications/statistics/statistics.service.ts
@@ -97,7 +97,7 @@ export class StatisticsService {
         if (!overviewData) {
             this.logger.log(`유저 ${userId}의 일주일 산책 통계 데이터에 대한 캐시 미스 발생, 데이터를 조회합니다`);
             overviewData = await this.getDogsWeeklyWalkingOverviewData(userId);
-            await this.cacheManager.set(cacheKey, overviewData, CACHE_TTL);
+            await this.cacheManager.set(cacheKey, overviewData, CACHE_TTL.STATISTICS);
         }
         return overviewData;
     }

--- a/backend/server/src/applications/statistics/statistics.service.ts
+++ b/backend/server/src/applications/statistics/statistics.service.ts
@@ -72,13 +72,21 @@ export class StatisticsService {
                 todayWalkTime: true,
             },
         });
+
         return await Promise.all(
-            ownDogInfos.map(async (ownDogInfo) => ({
-                ...makeSubObject(ownDogInfo, ['id', 'name', 'profilePhotoUrl']),
-                recommendedWalkAmount: ownDogInfo.breed.recommendedWalkAmount,
-                todayWalkAmount: await this.todayWalkTimeService.updateIfStaleAndGetDuration(ownDogInfo.todayWalkTime),
-                weeklyWalks: await this.dogWalkDayService.updateIfStaleAndGetWeeklyWalks(ownDogInfo.walkDay),
-            })),
+            ownDogInfos.map(async (ownDogInfo) => {
+                const [todayWalkAmount, weeklyWalks] = await Promise.all([
+                    this.todayWalkTimeService.updateIfStaleAndGetDuration(ownDogInfo.todayWalkTime),
+                    this.dogWalkDayService.updateIfStaleAndGetWeeklyWalks(ownDogInfo.walkDay),
+                ]);
+
+                return {
+                    ...makeSubObject(ownDogInfo, ['id', 'name', 'profilePhotoUrl']),
+                    recommendedWalkAmount: ownDogInfo.breed.recommendedWalkAmount,
+                    todayWalkAmount,
+                    weeklyWalks,
+                };
+            }),
         );
     }
 

--- a/backend/server/src/modules/cache.module.ts
+++ b/backend/server/src/modules/cache.module.ts
@@ -2,6 +2,6 @@ import { CacheModule as NestCacheModule } from '@nestjs/cache-manager';
 import { Module } from '@nestjs/common';
 
 @Module({
-    imports: [NestCacheModule.register()],
+    imports: [NestCacheModule.register({ isGlobal: true })],
 })
 export class CacheModule {}

--- a/backend/server/src/shared/utils/etc.ts
+++ b/backend/server/src/shared/utils/etc.ts
@@ -14,4 +14,8 @@ export const EVENTS = {
     DOG_DELETED: 'dog.deleted',
 } as const;
 
-export const CACHE_TTL = 1000 * 60 * 60;
+export const CACHE_TTL = {
+    STATISTICS: 1000 * 60 * 60,
+    DOG_PROFILES: 1000 * 60 * 30,
+    BREED_NAMES: 1000 * 60 * 60 * 24,
+} as const;


### PR DESCRIPTION
## 작업 내용 (Content)

홈 화면의 주간 산책 개요는 이미 캐시되어 있으나, 앱 진입 시 자주 호출되는 강아지 프로필 목록과 품종 목록 API는 매 요청마다 DB를 조회하고 있었다. 인메모리 캐시를 도입하여 DB 부하를 줄였다.

### 성능 개선
- `getDogsWeeklyWalkingOverviewData`에서 `todayWalkAmount`와 `weeklyWalks` 조회를 `Promise.all`로 병렬 실행
- `getProfileList`에 `dogs:profiles:{userId}` 캐시 도입 (TTL 30분, 이벤트 기반 무효화)
- `getKoreanNames`에 `breeds:koreanNames` 캐시 도입 (TTL 24시간, 자연 만료)

### 버그 수정
- `deleteOwnDogs`에서 누락되어 있던 `DOG_DELETED` 이벤트 emit 보완

### 리팩터링
- `CACHE_TTL`을 `EVENTS`와 동일한 const 객체 패턴으로 통합
- `CacheModule`에 `isGlobal: true` 적용, 모듈별 중복 `register()` 제거

### 테스트
- `jest.config.cjs`에 `modulePaths` 추가 (tsconfig `baseUrl` Jest 호환)
- `breed.service.spec` 순환 참조 해결 및 캐시 테스트 추가 (8/8 통과)

## 링크 (Links)
https://www.notion.so/do0ori/3328ad35868480c2ab9ff1ab9e25000b

## 기타 사항 (Etc)
- 캐시는 기존과 동일한 NestJS 인메모리 스토어 사용 (Redis 전환은 스케일아웃 시 별도 검토)

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 올리기 전 **rebase** 동기화를 하셨나요?
- [x] 마지막 줄에 공백 처리를 하셨나요?
- [x] 커밋 단위를 의미 단위로 나눴나요?
    - 예시
        - 코드 가독성을 위해 메서드를 추출하라
        - if-else 문을 if 문으로 분리하라
        - 불필요한 메서드를 인라인화하라
- [x] 커밋 본문을 작성하셨나요?
    - 예시
        - 함수는 한 가지 일을 해야 한다는 원칙에 따라 메서드를 추출합니다.
        - if-else는 컴파일 시 처리가 되어 재컴파일 없이 수정 할 수 없습니다.  
          이에 따라 코드가 실행되는 순간에 실행이 결정되는 if 문으로 수정합니다.
- [x] 리뷰 요청 전 Self-Review로 의문점을 해결 하셨나요?
- [x] PR 리뷰 가능한 크기를 유지하셨나요?
- [ ] CI 파이프라인이 통과가 되었나요?